### PR TITLE
n8vem-mark4: Optimise SD SPI routines to be faster, smaller

### DIFF
--- a/Kernel/dev/devsd.h
+++ b/Kernel/dev/devsd.h
@@ -26,8 +26,8 @@ void sd_spi_raise_cs(uint8_t drive);
 void sd_spi_lower_cs(uint8_t drive);
 void sd_spi_transmit_byte(uint8_t drive, uint8_t byte);
 uint8_t sd_spi_receive_byte(uint8_t drive);
-bool sd_spi_receive_to_memory(uint8_t drive, uint8_t *ptr, unsigned int length);
-bool sd_spi_transmit_from_memory(uint8_t drive, uint8_t *ptr, unsigned int length);
+bool sd_spi_receive_block(uint8_t drive, uint8_t *ptr, unsigned int length);
+bool sd_spi_transmit_block(uint8_t drive, uint8_t *ptr, unsigned int length);
 
 /* Definitions for MMC/SDC command */
 #define CMD0    (0x40+0)    /* GO_IDLE_STATE */


### PR DESCRIPTION
Alan

I've dropped the large precomputed table used to reverse bits in a byte from the n8vem-mark4 SD SPI routines, replaced with a function in assembler. I've also rewritten the block send/receive routines in assembler to optimise the performance by doing all the loop housekeeping when we'd otherwise have to wait for the hardware. I've measured the timing using my oscilloscope and the new routines are about three times faster for receive and twice as fast for transmit. The fuzix kernel binary has shrunk by 264 bytes.

Will
