### PR TITLE
Minor improvements to prompting for boot device number

### DIFF
--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -15,10 +15,6 @@ From UZI by Doug Braun and UZI280 by Stefan Nitschke.
 #include "config.h"
 #include "cpu.h"
 
-#ifndef DEFAULT_ROOT
-#define DEFAULT_ROOT 0
-#endif
-
 #ifndef NULL
 #define NULL (void *)0
 #endif

--- a/Kernel/kdata.c
+++ b/Kernel/kdata.c
@@ -8,7 +8,7 @@ char bootline[BOOTLINE_LEN];
 uint16_t ramsize, procmem, maxproc, nproc, nready;
 uint16_t runticks;
 bool inint;
-uint16_t root_dev = DEFAULT_ROOT;
+uint16_t root_dev;
 uint8_t ticks_this_dsecond;
 inoptr root;
 uint16_t waitno;


### PR DESCRIPTION
John Coffman reports that when he tries to boot Fuzix (which he does without CP/M) the command line area is full of 0xFF bytes and Fuzix does not offer him the opportunity to enter a boot device number. This is an attempt to improve how we prompt. 
