### PR TITLE
DS1302/DS1202 RTC driver

### DIFF
--- a/Kernel/cpu-z180/z180.def
+++ b/Kernel/cpu-z180/z180.def
@@ -63,6 +63,13 @@ ESCC_DATA_A                 .equ 0xE1                   ; ESCC Channel A data re
 ESCC_CTRL_B                 .equ 0xE2                   ; ESCC Channel B control register
 ESCC_DATA_B                 .equ 0xE3                   ; ESCC Channel B data register
 
+PORT_A_DDR                  .equ 0xED                   ; Port A data direction register
+PORT_A_DATA                 .equ 0xEE                   ; Port A data register
+PORT_B_DDR                  .equ 0xE4                   ; Port B data direction register
+PORT_B_DATA                 .equ 0xE5                   ; Port B data register
+PORT_C_DDR                  .equ 0xDD                   ; Port C data direction register
+PORT_C_DATA                 .equ 0xDE                   ; Port C data register
+
 Z182_SYSCONFIG              .equ 0xEF                   ; System Configuration Register
 Z182_ROMBR                  .equ 0xE8                   ; ROMBR register
 

--- a/Kernel/cpu-z180/z180.h
+++ b/Kernel/cpu-z180/z180.h
@@ -49,9 +49,17 @@ __sfr __at (Z180_IO_BASE + 0x1D) ASCI_ASTC1H;   /* ASCI time constant register c
 __sfr __at (Z180_IO_BASE + 0x0A) CSIO_CNTR;     /* CSI/O control/status register              */
 __sfr __at (Z180_IO_BASE + 0x0B) CSIO_TRDR;     /* CSI/O transmit/receive data register       */
 
+/* On Z80182 the MIMIC, ESCC, PIA and MISC registers are at fixed addresses */
 __sfr __at (0xE0)                ESCC_CTRL_A;   /* ESCC Channel A control register            */
 __sfr __at (0xE1)                ESCC_DATA_A;   /* ESCC Channel A data register               */
 __sfr __at (0xE2)                ESCC_CTRL_B;   /* ESCC Channel B control register            */
 __sfr __at (0xE3)                ESCC_DATA_B;   /* ESCC Channel B data register               */
+
+__sfr __at (0xED)                PORT_A_DDR;    /* Port A data direction register             */
+__sfr __at (0xEE)                PORT_A_DATA;   /* Port A data register                       */
+__sfr __at (0xE4)                PORT_B_DDR;    /* Port B data direction register             */
+__sfr __at (0xE5)                PORT_B_DATA;   /* Port B data register                       */
+__sfr __at (0xDD)                PORT_C_DDR;    /* Port C data direction register             */
+__sfr __at (0xDE)                PORT_C_DATA;   /* Port C data register                       */
 
 #endif

--- a/Kernel/dev/ds1302.c
+++ b/Kernel/dev/ds1302.c
@@ -1,0 +1,214 @@
+/*-----------------------------------------------------------------------*/
+/* DS1202 and DS1302 Serial Real Time Clock driver                       */
+/* 2014-12-30 Will Sowerbutts                                            */
+/*-----------------------------------------------------------------------*/
+
+#include <kernel.h>
+#include <kdata.h>
+#include <stdbool.h>
+#include <printf.h>
+#include <ds1302.h>
+
+static void ds1302_send_byte(uint8_t byte)
+{
+    uint8_t i;
+
+#ifdef DS1302_DEBUG
+    kprintf("ds1302: send byte 0x%x\n", byte);
+#endif
+    /* drive the data pin */
+    ds1302_set_pin_data_driven(true);
+
+    /* clock out one byte, LSB first */
+    for(i=0; i<8; i++){
+        ds1302_set_pin_clk(false);
+        /* for data input to the chip the data must be valid on the rising edge of the clock */
+        ds1302_set_pin_data(byte & 1);
+        byte >>= 1;
+        ds1302_set_pin_clk(true);
+    }
+}
+
+static uint8_t ds1302_receive_byte(void)
+{
+    uint8_t i, b;
+
+    /* tri-state the data pin */
+    ds1302_set_pin_data_driven(false);
+
+    /* clock in one byte, LSB first */
+    b = 0;
+    for(i=0; i<8; i++){
+        ds1302_set_pin_clk(false);
+        b >>= 1;
+        /* data output from the chip is presented on the falling edge of each clock */
+        /* note that output pin goes high-impedance on the rising edge of each clock */
+        if(ds1302_get_pin_data())
+            b |= 0x80;
+        ds1302_set_pin_clk(true);
+    }
+
+    return b;
+}
+
+static uint8_t from_bcd(uint8_t value)
+{
+    return (value & 0x0F) + (10 * (value >> 4));
+}
+
+void ds1302_read_clock(uint8_t *buffer, uint8_t length)
+{
+    uint8_t i;
+    irqflags_t irq = di();
+
+    ds1302_set_pin_ce(true);
+    ds1302_send_byte(0x81 | 0x3E); /* burst read all calendar data */
+    for(i=0; i<length; i++){
+        buffer[i] = ds1302_receive_byte();
+#ifdef DS1302_DEBUG
+        kprintf("ds1302: received byte 0x%x index %d\n", buffer[i], i);
+#endif
+    }
+    ds1302_set_pin_ce(false);
+    irqrestore(irq);
+}
+
+/* define CONFIG_RTC in platform's config.h to hook this into timer.c */
+uint8_t rtc_secs(void)
+{
+    uint8_t buffer;
+    ds1302_read_clock(&buffer, 1);   /* read out only the seconds value */
+    return from_bcd(buffer & 0x7F); /* mask off top bit (clock-halt) */
+}
+
+/****************************************************************************/
+/* Code below this point used only once, at startup, so we want it to live  */
+/* in the DISCARD segment. sdcc only allows us to specify one segment for   */
+/* each source file. This "solution" is a bit (well, very) hacky ...        */
+/****************************************************************************/
+static void DISCARDSEG(void) __naked { __asm .area _DISCARD __endasm; }
+
+/* we avoid using 32x32 bit multiply ds1302_read_rtc, because it causes sdcc to pull 
+   in a huge __mullong helper -- which is nearly 500 bytes! */
+static uint32_t multiply_8x32(uint8_t a, uint32_t b) __naked /* return a * b */
+{
+    __asm
+        ; WRS -- simple 8x32 multiply routine
+        ; low 16 bits in main registers, high 16 bits in alternate registers
+        ; DE contains b, shifts left, HL contains accumulated result, A contains a, shifts right.
+        ld iy, #0       ; load parameters from stack
+        add iy, sp
+        ld a, 2(iy)     ; load a
+        ld e, 3(iy)     ; load low 16 bits of b
+        ld d, 4(iy)
+        and a           ; clear carry flag
+        sbc hl, hl      ; low result = 0
+        exx
+        sbc hl, hl      ; high result = 0
+        ld e, 5(iy)     ; load high 16 bits of b
+        ld d, 6(iy)
+        exx
+mulgo:                  ; loop executes at most 8 times (depends on highest bit set in a)
+        or a            ; test value of A
+        jr z, muldone   ; if A is now zero we are done
+        rra             ; shift A right one bit, rotate low bit into carry flag
+        jr nc, mulnext  ; if low bit was zero, skip the accumulate
+        add hl, de      ; add low 16 bits
+        exx
+        adc hl, de      ; add high 16 bits
+        exx
+mulnext:
+        and a           ; clear carry flag
+        rl e            ; double low 16 bits
+        rl d
+        exx
+        rl e            ; double high 16 bits
+        rl d
+        exx
+        jr mulgo        ; go again
+muldone:
+        exx             ; get the high 16 bits into DE
+        push hl
+        exx
+        pop de
+        ret             ; return with 32-bit result in DEHL, as per sdcc callng convention
+    __endasm;
+    a; b;  /* squelch compiler warning */
+}
+
+static const uint16_t mktime_moffset[12] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+
+uint32_t ds1302_read_rtc(void)
+{
+    uint32_t ret;
+    uint8_t buffer[7];
+    uint8_t year, month, day, hour, minute, second;
+
+    ds1302_read_clock(buffer, 7); /* read all calendar data */
+
+    year   = from_bcd(buffer[6]);
+    month  = from_bcd(buffer[4] & 0x1F);
+    day    = from_bcd(buffer[3] & 0x3F);
+    if(buffer[2] & 0x80) /* AM/PM 12-hour mode */
+        hour   = from_bcd(buffer[2] & 0x1F) + (buffer[2] & 0x20 ? 12 : 0);
+    else /* sensible 24-hour mode */
+        hour   = from_bcd(buffer[2] & 0x3F);
+    minute = from_bcd(buffer[1]);
+    second = from_bcd(buffer[0] & 0x7F);
+
+    if(year < 70)
+        year += 100;
+
+    /* following code is based on utc_mktime() from ELKS 
+       https://github.com/jbruchon/elks/blob/master/elkscmd/sh_utils/date.c */
+
+    /* uses zero-based month index */
+    month--;
+
+    /* calculate days from years */
+    ret = multiply_8x32(year - 70, 365);
+
+    /* count leap days in preceding years */
+    ret += ((year - 69) >> 2);
+
+    /* calculate days from months */
+    ret += mktime_moffset[month];
+
+    /* add in this year's leap day, if any */
+    if (((year & 3) == 0) && (month > 1)) {
+        ret ++;
+    }
+
+    /* add in days in this month */
+    ret += (day - 1);
+
+    /* convert to hours */
+    ret = multiply_8x32(24, ret);
+    ret += hour;
+
+    /* convert to minutes */
+    ret = multiply_8x32(60, ret);
+    ret += minute;
+
+    /* convert to seconds */
+    ret = multiply_8x32(60, ret);
+    ret += second;
+
+    /* return the result */
+    return ret;
+}
+
+void ds1302_init(void)
+{
+    time_t tod;
+
+    /* initialise the hardware into a sensible state */
+    ds1302_set_pin_data_driven(true);
+    ds1302_set_pin_data(false);
+    ds1302_set_pin_ce(false);
+    ds1302_set_pin_clk(false);
+
+    tod.high = 0;                   /* until 2106 */
+    tod.low = ds1302_read_rtc();
+    wrtime(&tod);
+}

--- a/Kernel/dev/ds1302.c
+++ b/Kernel/dev/ds1302.c
@@ -70,6 +70,7 @@ void ds1302_read_clock(uint8_t *buffer, uint8_t length)
 #endif
     }
     ds1302_set_pin_ce(false);
+    ds1302_set_pin_clk(false);
     irqrestore(irq);
 }
 

--- a/Kernel/dev/ds1302.h
+++ b/Kernel/dev/ds1302.h
@@ -1,0 +1,18 @@
+#ifndef __DS1302_DOT_H__
+#define __DS1302_DOT_H__
+
+/* public interface */
+void ds1302_init(void);
+uint8_t rtc_secs(void);
+/* consult the DS1302 datasheet for data format;
+   http://datasheets.maximintegrated.com/en/ds/DS1302.pdf table 3 */
+void ds1302_read_clock(uint8_t *buffer, uint8_t length);
+
+/* platform code must provide these functions */
+void ds1302_set_pin_clk(bool state);
+void ds1302_set_pin_ce(bool state);
+void ds1302_set_pin_data(bool state);
+bool ds1302_get_pin_data(void);
+void ds1302_set_pin_data_driven(bool state); /* 0=tristate for input, 1=driven for output */
+
+#endif

--- a/Kernel/platform-n8vem-mark4/Makefile
+++ b/Kernel/platform-n8vem-mark4/Makefile
@@ -1,7 +1,6 @@
 CSRCS += devices.c main.c devtty.c devsdspi.c
-DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c
-
-ASRCS = crt0.s z180.s mark4.s commonmem.s
+DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c ../dev/ds1302.c
+ASRCS = crt0.s z180.s commonmem.s mark4.s ds1302-mark4.s
 
 AOBJS = $(ASRCS:.s=.rel)
 COBJS = $(CSRCS:.c=.rel)

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -57,3 +57,6 @@
 
 #define DEVICE_SD
 #define SD_DRIVE_COUNT 1
+
+/* We have a DS1302, we can read the time of day from it */
+#define CONFIG_RTC

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -60,3 +60,4 @@
 
 /* We have a DS1302, we can read the time of day from it */
 #define CONFIG_RTC
+#define CONFIG_RTC_INTERVAL 30 /* deciseconds between reading RTC seconds counter */

--- a/Kernel/platform-n8vem-mark4/crt0.s
+++ b/Kernel/platform-n8vem-mark4/crt0.s
@@ -7,6 +7,7 @@
         ; we don't use them all, because their ordering is set
         ; when they are first seen.
         .area _CODE
+        .area _HOME     ; compiler stores __mullong etc in here if you use them
         .area _CODE2
         .area _CONST
         .area _DATA

--- a/Kernel/platform-n8vem-mark4/devices.c
+++ b/Kernel/platform-n8vem-mark4/devices.c
@@ -6,6 +6,7 @@
 #include <devtty.h>
 #include <devide.h>
 #include <devsd.h>
+#include <ds1302.h>
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
@@ -38,4 +39,5 @@ void device_init(void)
 {
     devide_init();
     devsd_init();
+    ds1302_init();
 }

--- a/Kernel/platform-n8vem-mark4/ds1302-mark4.s
+++ b/Kernel/platform-n8vem-mark4/ds1302-mark4.s
@@ -1,0 +1,77 @@
+; 2014-12-31 William R Sowerbutts
+; N8VEM Mark IV SBC DS1302 real time clock interface code
+
+        .module ds1302-mark4
+        .z180
+
+        ; exported symbols
+        .globl _ds1302_set_pin_ce
+        .globl _ds1302_set_pin_clk
+        .globl _ds1302_set_pin_data
+        .globl _ds1302_set_pin_data_driven
+        .globl _ds1302_get_pin_data
+
+        .include "kernel.def"
+        .include "../cpu-z180/z180.def"
+        .include "../kernel.def"
+
+; -----------------------------------------------------------------------------
+; DS1302 interface
+; -----------------------------------------------------------------------------
+
+MARK4_RTC       = MARK4_IO_BASE + 0x0A
+PIN_CE          = 0x10
+PIN_DATA_HIZ    = 0x20
+PIN_CLK         = 0x40
+PIN_DATA_OUT    = 0x80
+PIN_DATA_IN     = 0x01
+
+.area _DATA
+
+rtc_shadow:     .db 0           ; we can't read back the latch contents, so we must keep a copy
+
+.area _CODE
+
+_ds1302_get_pin_data:
+        in a, (MARK4_RTC)       ; read input register
+        and #PIN_DATA_IN        ; mask off data pin
+        ld l, a                 ; return result in L
+        ret
+
+_ds1302_set_pin_data_driven:
+        ld hl, #2               ; get address of function argument
+        add hl, sp
+        ld b, (hl)              ; load argument from stack
+        ld a, (rtc_shadow)
+        and #~PIN_DATA_HIZ      ; 0 - output pin
+        bit 0, b                ; test bit
+        jr nz, writereg
+        or #PIN_DATA_HIZ
+        jr writereg
+
+_ds1302_set_pin_data:
+        ld bc, #(((~PIN_DATA_OUT) << 8) | PIN_DATA_OUT)
+        jr setpin
+
+_ds1302_set_pin_ce:
+        ld bc, #(((~PIN_CE) << 8) | PIN_CE)
+        jr setpin
+
+_ds1302_set_pin_clk:
+        ld bc, #(((~PIN_CLK) << 8) | PIN_CLK)
+        jr setpin
+
+setpin:
+        ld a, (rtc_shadow)      ; load current register contents
+        and b                   ; unset the pin
+        ld hl, #2               ; get address of function argument
+        add hl, sp
+        ld b, (hl)              ; load argument from stack
+        bit 0, b                ; test bit
+        jr z, writereg          ; arg is false
+        or c                    ; arg is true
+writereg:
+        out (MARK4_RTC), a      ; write out new register contents
+        ld (rtc_shadow), a      ; update our shadow copy
+        ret
+

--- a/Kernel/platform-n8vem-mark4/kernel.def
+++ b/Kernel/platform-n8vem-mark4/kernel.def
@@ -10,6 +10,7 @@ OS_BANK                     .equ 0x00         ; value from include/kernel.h
 FIRST_RAM_BANK              .equ 0x80         ; low 512K of physical memory is ROM/ECB window.
 RAM_KB                      .equ 512
 Z180_IO_BASE                .equ 0x40
+MARK4_IO_BASE               .equ 0x80
 
 ; No standard clock speed for the Mark IV board, but this is a common choice.
 CPU_CLOCK_KHZ               .equ 36864        ; 18.432MHz * 2

--- a/Kernel/platform-n8vem-mark4/uzi.lnk
+++ b/Kernel/platform-n8vem-mark4/uzi.lnk
@@ -36,4 +36,6 @@ platform-n8vem-mark4/devide.rel
 platform-n8vem-mark4/devsd.rel
 platform-n8vem-mark4/devsdspi.rel
 platform-n8vem-mark4/mbr.rel
+platform-n8vem-mark4/ds1302.rel
+platform-n8vem-mark4/ds1302-mark4.rel
 -e

--- a/Kernel/platform-p112/Makefile
+++ b/Kernel/platform-p112/Makefile
@@ -1,7 +1,6 @@
 CSRCS += devices.c main.c devtty.c
-DSRCS = ../dev/devide.c ../dev/mbr.c
-
-ASRCS = crt0.s z180.s p112.s commonmem.s
+DSRCS = ../dev/devide.c ../dev/mbr.c ../dev/ds1302.c
+ASRCS = crt0.s z180.s commonmem.s p112.s ds1302-p112.s
 
 AOBJS = $(ASRCS:.s=.rel)
 COBJS = $(CSRCS:.c=.rel)

--- a/Kernel/platform-p112/config.h
+++ b/Kernel/platform-p112/config.h
@@ -54,3 +54,6 @@
 #define IDE_REG_CS0_FIRST
 #define IDE_REG_CS0_BASE   (IDE_REG_BASE+0x00)
 #define IDE_REG_CS1_BASE   (IDE_REG_BASE+0x08)
+
+/* We have a DS1302, we can read the time of day from it */
+#define CONFIG_RTC

--- a/Kernel/platform-p112/config.h
+++ b/Kernel/platform-p112/config.h
@@ -57,3 +57,4 @@
 
 /* We have a DS1302, we can read the time of day from it */
 #define CONFIG_RTC
+#define CONFIG_RTC_INTERVAL 30 /* deciseconds between reading RTC seconds counter */

--- a/Kernel/platform-p112/crt0.s
+++ b/Kernel/platform-p112/crt0.s
@@ -7,6 +7,7 @@
         ; we don't use them all, because their ordering is set
         ; when they are first seen.
         .area _CODE
+        .area _HOME     ; compiler stores __mullong etc in here if you use them
         .area _CODE2
         .area _CONST
         .area _DATA

--- a/Kernel/platform-p112/devices.c
+++ b/Kernel/platform-p112/devices.c
@@ -5,6 +5,7 @@
 #include <devsys.h>
 #include <devtty.h>
 #include <devide.h>
+#include <ds1302.h>
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
@@ -36,4 +37,5 @@ bool validdev(uint16_t dev)
 void device_init(void)
 {
     devide_init();
+    ds1302_init();
 }

--- a/Kernel/platform-p112/ds1302-p112.s
+++ b/Kernel/platform-p112/ds1302-p112.s
@@ -1,0 +1,71 @@
+; 2015-01-01 William R Sowerbutts
+; DX-Designs P112 SBC DS1202 real time clock interface code
+
+        .module ds1302-p112
+        .z180
+
+        ; exported symbols
+        .globl _ds1302_set_pin_ce
+        .globl _ds1302_set_pin_clk
+        .globl _ds1302_set_pin_data_driven
+        .globl _ds1302_set_pin_data
+        .globl _ds1302_get_pin_data
+
+        .include "kernel.def"
+        .include "../cpu-z180/z180.def"
+        .include "../kernel.def"
+
+; -----------------------------------------------------------------------------
+; DS1202 interface
+; -----------------------------------------------------------------------------
+
+PIN_DATA        = 0x01  ; PA0
+PIN_CLK         = 0x02  ; PA1
+PIN_CE          = 0x04  ; PA2
+
+.area _CODE
+
+_ds1302_get_pin_data:
+        in0 a, (PORT_A_DATA)    ; read IO pins
+        and #PIN_DATA           ; mask off data bit
+        ld l, a                 ; return result in L
+        ret
+
+_ds1302_set_pin_data_driven:
+        in0 a, (PORT_A_DDR)     ; a 1 in each bit makes the corresponding pin tristate (input), 0 makes it an output
+        and #~(PIN_DATA|PIN_CE|PIN_CLK) ; bits to 0 -> set all pins as outputs
+        ld hl, #2               ; get address of function argument
+        add hl, sp
+        ld b, (hl)              ; load argument from stack
+        bit 0, b                ; test bit
+        jr nz, writeddr         ; nonzero -> we want an output
+        or #PIN_DATA            ; zero -> we want an input; change bit to 1 -> set data pin as input
+writeddr:
+        out0 (PORT_A_DDR), a    ; update data direction register
+        ret
+
+_ds1302_set_pin_data:
+        ld bc, #(((~PIN_DATA) << 8) | PIN_DATA)
+        jr setpin
+
+_ds1302_set_pin_ce:
+        ld bc, #(((~PIN_CE) << 8) | PIN_CE)
+        jr setpin
+
+_ds1302_set_pin_clk:
+        ld bc, #(((~PIN_CLK) << 8) | PIN_CLK)
+        jr setpin
+
+setpin:
+        in0 a, (PORT_A_DATA)    ; load current register contents
+        and b                   ; unset the pin
+        ld hl, #2               ; get address of function argument
+        add hl, sp
+        ld b, (hl)              ; load argument from stack
+        bit 0, b                ; test bit
+        jr z, writereg          ; arg is false, bit is already 0
+        or c                    ; arg is true, set bit to 1
+writereg:
+        out0 (PORT_A_DATA), a   ; write out new register contents
+        ret
+

--- a/Kernel/platform-p112/uzi.lnk
+++ b/Kernel/platform-p112/uzi.lnk
@@ -34,4 +34,6 @@ devsys.rel
 platform-p112/devtty.rel
 platform-p112/devide.rel
 platform-p112/mbr.rel
+platform-p112/ds1302.rel
+platform-p112/ds1302-p112.rel
 -e

--- a/Kernel/timer.c
+++ b/Kernel/timer.c
@@ -65,6 +65,9 @@ void updatetod(void)
 #else
 
 static uint8_t rtcsec;
+#ifdef CONFIG_RTC_INTERVAL
+static uint8_t tod_deci;
+#endif
 
 /*
  *	We use the seconds counter on the RTC as a time counter and lock our
@@ -77,8 +80,18 @@ static uint8_t rtcsec;
  */
 void updatetod(void)
 {
-	uint8_t rtcnew = rtc_secs();	/* platform function */
+	uint8_t rtcnew;
 	int8_t slide;
+
+#ifdef CONFIG_RTC_INTERVAL
+	/* on some platforms reading the RTC is expensive so we don't do it
+	   every decisecond. */
+	if(++tod_deci != CONFIG_RTC_INTERVAL)
+	    return;
+	tod_deci = 0;
+#endif
+
+	rtcnew = rtc_secs();		/* platform function */
 
 	if (rtcnew == rtcsec)
 		return;


### PR DESCRIPTION
Alan

Happy new year!

This pull request is for a driver for the DS1302/DS1202 RTC chip which is used on both p112 and n8vem-mark4.

It is structured in a similar style to the SD driver, ie one generic driver that knows how to talk to the chip, and per-platform drivers that implement the actual hardware operations. The platform drivers are both written in assembler as I found sdcc generated quite verbose code for small functions when I wrote them in C. I also tried using one C function that manipulated all the hardware pins but it just made the code hard to follow.

On boot the ds1302_init() function is called from the platform setup code. This reads out the full RTC date and time, converts to posix time, and calls wrtime(). One problem I found with this was that naively telling the compiler to multiply 32-bit values pulls in the __mullong helper which is huge (nearly 500 bytes) and which lives in the _HOME segment, which the linker didn't know where to place; hilarity ensues. Instead of this I've written a small function to do 8x32 bit mulitplies which turns out to be all we need for the time conversion.

Please be aware that there is a slightly hacky trick in ds1302.c to get all the startup code into the DISCARD segment without separating the driver into two files and complicating the platform Makefile. This is done by jamming ".area _DISCARD" into the assembler output at the right point.

Reading the RTC is quite an expensive operation on these platforms, so the final commit introduces an optional value CONFIG_RTC_INTERVAL which sets the number of deciseconds between calls to rtc_secs().

Best wishes

Will