### PR TITLE
Fixes to standard library

### DIFF
--- a/Applications/util/Makefile
+++ b/Applications/util/Makefile
@@ -117,7 +117,7 @@ $(OBJSBAD): $(SRCSBAD)
 	$(FCC) $< -o $@
 
 clean:
-	rm -f $(OBJS) $(APPS) $(SRCS:.c=) core *~ *.asm *.lst *.sym *.map *.noi *.lk *.ihx *.tmp
+	rm -f $(OBJS) $(APPS) $(SRCS:.c=) core *~ *.asm *.lst *.sym *.map *.noi *.lk *.ihx *.tmp *.bin
 
 rmbak:
 	rm -f *~ core

--- a/Applications/util/cmp.c
+++ b/Applications/util/cmp.c
@@ -112,7 +112,7 @@ void main(int argc, char *argv[])
 			pos++;
 
 		putstr("Files differ at byte position ");
-		bp1 = ultostr(pos, buf1, 10);
+		bp1 = _ultoa(pos);
 		putstr(bp1);
 		putstr("\n");
 		goto differ;

--- a/Library/include/stdlib.h
+++ b/Library/include/stdlib.h
@@ -46,8 +46,8 @@ extern char *_itoa __P((int value));
 extern char *_ltoa __P((long value));
 extern char *_ultoa __P((unsigned long value));
 
-extern char *ultostr __P((unsigned long value, char *buf, int radix));
-extern char *ltostr __P((long value, char *buf, int radix));
+extern char *__ultostr __P((unsigned long value, int radix));
+extern char *__ltostr __P((long value, int radix));
 
 extern long strtol __P ((const char * nptr, char ** endptr, int base));
 extern unsigned long strtoul __P ((const char * nptr,

--- a/Library/libs/ltoa.c
+++ b/Library/libs/ltoa.c
@@ -4,7 +4,7 @@
  */
 
 
-char * ultoa(unsigned long val)
+char *_ultoa(unsigned long val)
 {
    char *p;
    static char buf[12];
@@ -21,12 +21,12 @@ char * ultoa(unsigned long val)
    return p;
 }
 
-char * ltoa(long val)
+char *_ltoa(long val)
 {
    char *p;
    int flg = 0;
    if( val < 0 ) { flg++; val= -val; }
-   p = ultoa(val);
+   p = _ultoa(val);
    if(flg) *--p = '-';
    return p;
 }

--- a/Library/libs/ltostr.c
+++ b/Library/libs/ltostr.c
@@ -3,10 +3,12 @@
  * under the GNU Library General Public License.
  */
 
+#include <string.h>
+
 static char buf[34];
 
 
-char * ultostr(unsigned long val, int radix)
+char * __ultostr(unsigned long val, int radix)
 {
    register char *p;
    register int c;
@@ -26,12 +28,25 @@ char * ultostr(unsigned long val, int radix)
    return p;
 }
 
-char * ltostr(long val, int radix)
+char * __ltostr(long val, int radix)
 {
    char *p;
    int flg = 0;
    if( val < 0 ) { flg++; val= -val; }
-   p = ultostr(val, radix);
+   p = __ultostr(val, radix);
    if(p && flg) *--p = '-';
    return p;
+}
+
+/* sadly we do not know the size of the user-provided buffer so we cannot write
+   it backwards, so just copy the result from our own buffer whose size we know */
+
+char *ultoa (unsigned long value, char *strP, int radix)
+{
+    return strcpy(strP, __ultostr(value, radix));
+}
+
+char *ltoa (long value, char *strP, int radix)
+{
+    return strcpy(strP, __ltostr(value, radix));
 }

--- a/Library/libs/tcflow.c
+++ b/Library/libs/tcflow.c
@@ -1,7 +1,10 @@
 #include <termios.h>
 #include <unistd.h>
+#include <errno.h>
 
-int tcflush(int fd, int q)
+int tcflow(int fd, int action)
 {
-  return ioctl(fd, TIOCFLUSH, q);
+	/* TODO */
+	errno = EINVAL;
+	return -1;
 }

--- a/Library/libs/vfprintf.c
+++ b/Library/libs/vfprintf.c
@@ -148,10 +148,9 @@ int vfprintf(FILE * op, char *fmt, va_list ap)
 
 			case 'd':	/* Signed decimal */
 			case 'i':
-				ptmp = ltostr((long) ((lval) ?
+				ptmp = __ltostr((long) ((lval) ?
 						    va_arg(ap, long) :
-						    va_arg(ap, short)),
-					    tmp, 10);
+						    va_arg(ap, short)), 10);
 				goto printit;
 
 			case 'b':	/* Unsigned binary */
@@ -181,7 +180,7 @@ int vfprintf(FILE * op, char *fmt, va_list ap)
 			      usproc:val = lval ? va_arg(ap, unsigned long) :
 				    va_arg(ap,
 					   unsigned short);
-				ptmp = ultostr(val, tmp + 4, radix);
+				ptmp = __ultostr(val, radix);
 				add = "";
 				if (hash) {
 					if (radix == 2)

--- a/Library/libs/xitoa.c
+++ b/Library/libs/xitoa.c
@@ -6,6 +6,5 @@
 /*********************** xitoa.c ***************************/
 char *_itoa(int i)
 {
-	static char buf[16];
-	return ltostr((long) i, buf, 10);
+    return _ltoa((long)i);
 }

--- a/Library/tools/libclean
+++ b/Library/tools/libclean
@@ -23,5 +23,5 @@ cp ${SDCC_LIB}/z80/z80.lib tmp.lib
 sdar d tmp.lib putchar.rel heap.rel fstubs.rel setjmp.rel errno.rel
 sdar d tmp.lib rand.rel _calloc.rel _malloc.rel _realloc.rel _free.rel
 sdar d tmp.lib printf_large.rel puts.rel gets.rel assert.rel time.rel
-sdar d tmp.lib tolower.rel toupper.rel
+sdar d tmp.lib tolower.rel toupper.rel _ltoa.rel _itoa.rel abs.rel
 mv tmp.lib sdccz80.lib


### PR DESCRIPTION
Alan

Here are the fixes to ltoa, strtol and friends plus associated fixes. Checked library and all utils build. I found there were some duplicate symbols in syslib.lib, mostly that we were importing from the SDCC libraries and also implementing ourselves, fixed by dropping the SDCC versions. We also had two implementations of tcflush(), one hiding inside tcflow.c. That's also fixed although we are still lacking a tcflow() function -- I've made a stub that returns an error for now.

Will