### PR TITLE
Introduce new "blkdev" layer for 512-byte sector partitioned drives.

### DIFF
--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -1,0 +1,149 @@
+#include <kernel.h>
+#include <kdata.h>
+#include <printf.h>
+#include <blkdev.h>
+#include <mbr.h>
+
+/*
+   Minor numbers
+
+   The kernel identifies our storage devices with an 8-bit minor number.
+
+   The top four bits of the minor identify the drive, allowing a maximum of
+   sixteen drives.
+
+   The bottom four bits of the minor identify the partition number. Partition
+   zero addresses "the whole drive", with no translation. Due to limitations
+   within the kernel only the first 32MB can currently be accessed through
+   partition zero.
+
+   Partition zero is intended to be used primarily for writing a partition
+   table to the drive, although it can also be used to store a single Fuzix
+   filesystem on an unpartitioned disk.
+
+   Partitions 1 through 15 are identified by reading a PC-style MBR partition
+   table from the drive. The first four partitions are always the primary
+   partitions on the drive, the remainder are logical partitions stored within
+   an extended partition.
+
+   To create the required device nodes, use:
+
+       mknod /dev/hda 60660 0
+       mknod /dev/hdb 60660 16
+       mknod /dev/hdc 60660 32
+       mknod /dev/hdd 60660 48
+       ... (etc) ...
+       mknod /dev/hdp 60660 240
+
+       mknod /dev/hda1 60660 1
+       mknod /dev/hda2 60660 2
+       mknod /dev/hda3 60660 3
+       ... (etc) ...
+       mknod /dev/hda15 60660 15
+
+       mknod /dev/hdb1 60660 17
+       mknod /dev/hdb2 60660 18
+       mknod /dev/hdb3 60660 19
+       ... (etc) ...
+       mknod /dev/hdb15 60660 31
+*/
+
+static blkdev_t blkdev_table[MAX_BLKDEV];
+
+int blkdev_open(uint8_t minor, uint16_t flags)
+{
+    uint8_t drive, partition;
+
+    flags; /* unused */
+
+    drive = minor >> 4;
+    partition = minor & 0x0F;
+
+    if(drive < MAX_BLKDEV){
+	if(blkdev_table[drive].drive_lba_count && (partition == 0 || blkdev_table[drive].lba_count[partition-1]))
+	    return 0; /* that is a valid minor number */
+    }
+
+    /* sorry, can't find it */
+    udata.u_error = ENODEV;
+    return -1;
+}
+
+static int blkdev_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
+{
+    void *target;
+    uint32_t lba;
+    uint8_t partition;
+    blkdev_t *blk;
+
+    /* we trust that blkdev_open() has already verified that this minor number is valid */
+    blk = &blkdev_table[minor >> 4];
+    partition = minor & 0x0F;
+
+    if(rawflag == 0) {
+        target = udata.u_buf->bf_data;
+        lba = udata.u_buf->bf_blk;
+    }else
+        goto xferfail;
+
+    if(partition == 0){
+	/* partition 0 is the whole disk and requires no translation */
+	if(lba >= blk->drive_lba_count)
+	    goto xferfail;
+    }else{
+	/* partitions 1+ require us to add in an offset */
+	if(lba >= blk->lba_count[partition-1])
+	    goto xferfail;
+
+	lba += blk->lba_first[partition-1];
+    }
+
+    if(blk->transfer(blk->drive_number, lba, target, is_read))
+	return 1; /* 10/10, would transfer sectors again */
+
+xferfail:
+    udata.u_error = EIO;
+    return -1;
+}
+
+int blkdev_read(uint8_t minor, uint8_t rawflag, uint8_t flag)
+{
+    flag; /* not used */
+    return blkdev_transfer(minor, true, rawflag);
+}
+
+int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
+{
+    flag; /* not used */
+    return blkdev_transfer(minor, false, rawflag);
+}
+
+void blkdev_add(transfer_function_t transfer, uint8_t drive_number, uint32_t lba_count)
+{
+    char letter;
+    blkdev_t *blk = NULL;
+
+    letter = 'a';
+    blk = &blkdev_table[0];
+
+    /* find an empty slot */
+    while(blk <= &blkdev_table[MAX_BLKDEV-1]){
+	if(blk->drive_lba_count == 0){
+	    blk->drive_lba_count = lba_count;
+	    blk->drive_number = drive_number;
+	    blk->transfer = transfer;
+
+	    /* now we parse the partition table; might need a hook for platforms to
+	       parse their platform-specific partition table first? eg P112 has its
+	       own partitioning scheme */
+	    kprintf("hd%c: ", letter);
+	    mbr_parse(blk, letter);
+	    kputchar('\n');
+	    return;
+	}
+	blk++;
+	letter++;
+    }
+
+    kputs("blkdev: full!\n");
+}

--- a/Kernel/dev/blkdev.h
+++ b/Kernel/dev/blkdev.h
@@ -1,0 +1,24 @@
+#ifndef __BLKDEV_DOT_H__
+#define __BLKDEV_DOT_H__
+
+/* block device drives should call blkdev_add() for each block device found,
+   and implement a sector transfer function matching the following prototype. */
+typedef bool (*transfer_function_t)(uint8_t drive, uint32_t lba, void *buffer, bool read_notwrite);
+
+/* public interface */
+void blkdev_add(transfer_function_t transfer, uint8_t drive_number, uint32_t lba_count);
+int blkdev_open(uint8_t minor, uint16_t flags);
+int blkdev_read(uint8_t minor, uint8_t rawflag, uint8_t flag);
+int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
+
+/* the following details should be required only by partition parsing code */
+#define MAX_PARTITIONS 15		    /* must be at least 4, at most 15 */
+typedef struct {
+    uint32_t drive_lba_count;		    /* count of sectors on raw disk device */
+    uint8_t drive_number;		    /* driver's drive number */
+    uint32_t lba_first[MAX_PARTITIONS];	    /* LBA of first sector of each partition; 0 if partition absent */
+    uint32_t lba_count[MAX_PARTITIONS];	    /* count of sectors in each partition; 0 if partition absent */
+    transfer_function_t transfer;	    /* function to read and write sectors */
+} blkdev_t;
+
+#endif

--- a/Kernel/dev/devide.h
+++ b/Kernel/dev/devide.h
@@ -21,9 +21,6 @@
 */
 
 void devide_init(void);
-int  devide_open(uint8_t minor, uint16_t flags);
-int  devide_read(uint8_t minor, uint8_t rawflag, uint8_t flag);
-int  devide_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
 
 #ifdef IDE_REG_BASE
 #ifdef IDE_REG_CS0_FIRST

--- a/Kernel/dev/devsd.h
+++ b/Kernel/dev/devsd.h
@@ -15,9 +15,6 @@
 
 
 /* public interface */
-int devsd_open(uint8_t minor, uint16_t flags);
-int devsd_read(uint8_t minor, uint8_t rawflag, uint8_t flag);
-int devsd_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
 void devsd_init(void);
 
 /* platform-specific SPI functions */

--- a/Kernel/dev/mbr.h
+++ b/Kernel/dev/mbr.h
@@ -1,6 +1,6 @@
 #ifndef __MBR_DOT_H__
 #define __MBR_DOT_H__
 
-void parse_partition_table(void *buffer, uint32_t *first_lba, uint8_t *slice_count, uint8_t max_slices);
+void mbr_parse(blkdev_t *blk, char letter);
 
 #endif

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -88,8 +88,6 @@ typedef uint16_t blkno_t;    /* Can have 65536 512-byte blocks in filesystem */
 #define BLKSHIFT	9
 #define BLKMASK		511
 
-#define SLICE_SIZE_LOG2_SECTORS 16    /* 32MB slices */
-
 /* FIXME: if we could split the data and the header we could keep blocks
    outside of our kernel data (as ELKS does) which would be a win, but need
    some more care on copies, block indexes and directory ops */

--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -1,5 +1,5 @@
 
-CSRCS = ../dev/devsd.c ../dev/mbr.c devfd.c devhd.c devlpr.c
+CSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c devfd.c devhd.c devlpr.c
 CSRCS += devices.c main.c devtty.c
 DSRCS = devmegasd.c
 ASRCS = msx2.s crt0.s vdp.s

--- a/Kernel/platform-msx2/config.h
+++ b/Kernel/platform-msx2/config.h
@@ -43,3 +43,5 @@
 
 #define DEVICE_SD
 #define SD_DRIVE_COUNT 1
+
+#define MAX_BLKDEV 1      /* Single SD drive */

--- a/Kernel/platform-msx2/devices.c
+++ b/Kernel/platform-msx2/devices.c
@@ -8,7 +8,8 @@
 #include <tty.h>
 #include <vt.h>
 #include <devtty.h>
-#include <../dev/devsd.h>
+#include <devsd.h>
+#include <blkdev.h>
 
 extern int megasd_probe();
 
@@ -16,8 +17,8 @@ struct devsw dev_tab[] =  /* The device driver switch table */
 {
   /* 0: /dev/fd		Floppy disc block devices */
   {  no_open,     no_close,    no_rdwr,   no_rdwr,   no_ioctl },
-  /* 1: /dev/sd		MegaSD Interface */
-  {  devsd_open,     no_close,    devsd_read,   devsd_write,   no_ioctl },
+  /* 1: /dev/hd		MegaSD Interface */
+  {  blkdev_open,    no_close,   blkdev_read,  blkdev_write,   no_ioctl },
   /* 2: /dev/tty	TTY devices */
   {  tty_open,     tty_close,   tty_read,  tty_write,  vt_ioctl },
   /* 3: /dev/lpr	Printer devices */

--- a/Kernel/platform-msx2/fuzix.lnk
+++ b/Kernel/platform-msx2/fuzix.lnk
@@ -36,6 +36,7 @@ vt.rel
 devsys.rel
 usermem.rel
 usermem_std-z80.rel
+platform-msx2/blkdev.rel
 platform-msx2/devsd.rel
 platform-msx2/devmegasd.rel
 platform-msx2/mbr.rel

--- a/Kernel/platform-n8vem-mark4/Makefile
+++ b/Kernel/platform-n8vem-mark4/Makefile
@@ -1,5 +1,5 @@
 CSRCS += devices.c main.c devtty.c devsdspi.c
-DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c ../dev/ds1302.c
+DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c ../dev/ds1302.c
 ASRCS = crt0.s z180.s commonmem.s mark4.s ds1302-mark4.s
 
 AOBJS = $(ASRCS:.s=.rel)

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -50,6 +50,8 @@
 #define Z180_IO_BASE       0x40
 #define MARK4_IO_BASE      0x80
 
+#define MAX_BLKDEV 3	    /* 2 IDE drives, 1 SD drive */
+
 #define DEVICE_IDE                  /* enable if IDE interface present */
 #define IDE_REG_BASE       MARK4_IO_BASE
 #define IDE_8BIT_ONLY

--- a/Kernel/platform-n8vem-mark4/devices.c
+++ b/Kernel/platform-n8vem-mark4/devices.c
@@ -6,23 +6,17 @@
 #include <devtty.h>
 #include <devide.h>
 #include <devsd.h>
+#include <blkdev.h>
 #include <ds1302.h>
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-// minor    open         close        read      write       ioctl
-// -----------------------------------------------------------------
-  /* 0: /dev/hd		IDE-8 interface */
-  {  devide_open, no_close, devide_read, devide_write, no_ioctl },
-  /* 1: /dev/sd		SD interface */
-  {  devsd_open,  no_close, devsd_read,  devsd_write,  no_ioctl },
-  /* 2: /dev/tty	serial ports */
-  {  tty_open,    tty_close,   tty_read,  tty_write,  tty_ioctl },
-  /* 3: /dev/lpr	Unused slot (pad to keep system devices at index 4) */
-  {  no_open,     no_close,    no_rdwr,   no_rdwr,   no_ioctl },
-  /* 4: /dev/mem etc	System devices (one offs) */
-  {  no_open,      no_close,    sys_read, sys_write, sys_ioctl  },
-  /* Pack to 7 with nxio if adding private devices and start at 8 */
+/*   open	    close	read		write		ioctl */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/platform-n8vem-mark4/fuzix.lnk
+++ b/Kernel/platform-n8vem-mark4/fuzix.lnk
@@ -36,6 +36,7 @@ platform-n8vem-mark4/devide.rel
 platform-n8vem-mark4/devsd.rel
 platform-n8vem-mark4/devsdspi.rel
 platform-n8vem-mark4/mbr.rel
+platform-n8vem-mark4/blkdev.rel
 platform-n8vem-mark4/ds1302.rel
 platform-n8vem-mark4/ds1302-mark4.rel
 -e

--- a/Kernel/platform-p112/Makefile
+++ b/Kernel/platform-p112/Makefile
@@ -1,5 +1,5 @@
 CSRCS += devices.c main.c devtty.c
-DSRCS = ../dev/devide.c ../dev/mbr.c ../dev/ds1302.c
+DSRCS = ../dev/blkdev.c ../dev/devide.c ../dev/mbr.c ../dev/ds1302.c
 ASRCS = crt0.s z180.s commonmem.s p112.s ds1302-p112.s
 
 AOBJS = $(ASRCS:.s=.rel)

--- a/Kernel/platform-p112/config.h
+++ b/Kernel/platform-p112/config.h
@@ -49,6 +49,8 @@
 /* Hardware parameters */
 #define Z180_IO_BASE       0x00
 
+#define MAX_BLKDEV  2		    /* 2 IDE drives */
+
 #define DEVICE_IDE                  /* enable if IDE interface present */
 #define IDE_REG_BASE       0x50
 #define IDE_REG_CS0_FIRST

--- a/Kernel/platform-p112/devices.c
+++ b/Kernel/platform-p112/devices.c
@@ -5,23 +5,17 @@
 #include <devsys.h>
 #include <devtty.h>
 #include <devide.h>
+#include <blkdev.h>
 #include <ds1302.h>
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-// minor    open         close        read      write       ioctl
-// -----------------------------------------------------------------
-  /* 0: /dev/hd		IDE-8 interface */
-  {  devide_open, no_close, devide_read, devide_write, no_ioctl },
-  /* 1: /dev/sd		SD interface */
-  {  no_open,     no_close,    no_rdwr,   no_rdwr,   no_ioctl },
-  /* 2: /dev/tty	serial ports */
-  {  tty_open,     tty_close,   tty_read,  tty_write,  tty_ioctl },
-  /* 3: /dev/lpr	Unused slot (pad to keep system devices at index 4) */
-  {  no_open,     no_close,    no_rdwr,   no_rdwr,   no_ioctl },
-  /* 4: /dev/mem etc	System devices (one offs) */
-  {  no_open,      no_close,    sys_read, sys_write, sys_ioctl  },
-  /* Pack to 7 with nxio if adding private devices and start at 8 */
+/*   open	    close	read		write		ioctl */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/platform-p112/fuzix.lnk
+++ b/Kernel/platform-p112/fuzix.lnk
@@ -33,6 +33,7 @@ swap.rel
 devsys.rel
 platform-p112/devtty.rel
 platform-p112/devide.rel
+platform-p112/blkdev.rel
 platform-p112/mbr.rel
 platform-p112/ds1302.rel
 platform-p112/ds1302-p112.rel


### PR DESCRIPTION
Hardware drivers are now responsible for the bare mimumum -- identify
the storage devices present, figure out how large they are, and provide
a function to read/write sectors.

The concept of "slices" goes away, instead we will use a separate
partition for each file system.

The blkdev layer handles PC-style MBR partition tables, both primary and
extended partitions, up to a maximum of 15 partitions per drive. The
partition numbering is chosen to be compatible with Linux.

Storage drivers no longer each require a separate entry in the device
switch table.

This includes patches for n8vem-mark4, p112 and msx2 all of which are using
devsd or devide.