### PR TITLE
binman: tidy up, fail when _DISCARD grows to overlap _COMMONMEM

### DIFF
--- a/Kernel/tools/binman.c
+++ b/Kernel/tools/binman.c
@@ -15,18 +15,10 @@ static unsigned int s__CODE, s__CODE2, s__INITIALIZER, s__DATA,
 static void ProcessMap(FILE * fp)
 {
 	char buf[512];
-	int addr = 0;
-	int naddr;
-	char name[100];
-	char nname[100];
-	int hogs = 0;
 
 	while (fgets(buf, 511, fp)) {
 		char *p1 = strtok(buf, " \t\n");
 		char *p2 = NULL;
-		int match = 0;
-
-		match = memcmp(buf, "     000", 8);
 
 		if (p1)
 			p2 = strtok(NULL, " \t\n");

--- a/Kernel/tools/binman.c
+++ b/Kernel/tools/binman.c
@@ -115,6 +115,14 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+	/* linker will allow us to overlap _DISCARD (which may grow)
+	   with with _COMMONMEM. */
+	if(s__DISCARD && s__DISCARD+l__DISCARD > s__COMMONMEM){
+		fprintf(stderr, "Move _DISCARD down by at least %d bytes\n",
+			s__DISCARD + l__DISCARD - s__COMMONMEM);
+		exit(1);
+	}
+
         printf("Scanning data from 0x%x to 0x%x\n",
                 s__DATA, s__DATA + l__DATA);
 	base = s__DATA;

--- a/Kernel/tools/binman.c
+++ b/Kernel/tools/binman.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* linker will allow us to overlap _DISCARD (which may grow)
-	   with with _COMMONMEM. */
+	   with _COMMONMEM. */
 	if(s__DISCARD && s__DISCARD+l__DISCARD > s__COMMONMEM){
 		fprintf(stderr, "Move _DISCARD down by at least %d bytes\n",
 			s__DISCARD + l__DISCARD - s__COMMONMEM);


### PR DESCRIPTION
_DISCARD can grow to overlap _COMMONMEM, linker is happy with this, makebin is happy with the overwriting in the .ihx, only binman can save us now!