### PR TITLE
PropIOv2

### DIFF
--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -1,3 +1,5 @@
+/* 2015-01-04 Will Sowerbutts */
+
 #include <kernel.h>
 #include <kdata.h>
 #include <printf.h>

--- a/Kernel/dev/mbr.c
+++ b/Kernel/dev/mbr.c
@@ -1,3 +1,5 @@
+/* 2015-01-04 Will Sowerbutts */
+
 #include <kernel.h>
 #include <kdata.h>
 #include <printf.h>

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -32,16 +32,9 @@
 #define SWAPTOP	    0xFF00	/* can we stop at the top? not sure how. let's stop short. */
 #define MAX_SWAPS	10	    /* Well, that depends really, hmmmmmm. Pick a number, any number. */
 
-#define BOOT_TTY (512 + 1)/* Set this to default device for stdio, stderr */
-                          /* In this case, the default is the first TTY device */
-
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	(0x0081)  /* Location of root dev name */
 
-/* Device parameters */
-#define NUM_DEV_TTY 2
-
-#define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */
 //#define SWAPDEV  (256 + 1)  /* Device for swapping. (z80pack drive J) */
 #define NBUFS    10       /* Number of block buffers */
 #define NMOUNTS	 4	  /* Number of mounts at a time */
@@ -63,3 +56,22 @@
 /* We have a DS1302, we can read the time of day from it */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL 30 /* deciseconds between reading RTC seconds counter */
+
+/* We have a PropIOv2 board */
+#define CONFIG_PROPIO2
+#define PROPIO2_IO_BASE		0xA8
+
+/* Device parameters */
+#ifdef CONFIG_PROPIO2
+	#define NUM_DEV_TTY 3
+
+	/* PropIO as the console */
+	#define BOOT_TTY (512 + 3)
+#else
+	#define NUM_DEV_TTY 2
+
+	/* ANSI0 as the console */
+	#define BOOT_TTY (512 + 1)
+#endif
+
+#define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -45,20 +45,22 @@
 
 #define MAX_BLKDEV 3	    /* 2 IDE drives, 1 SD drive */
 
-#define DEVICE_IDE                  /* enable if IDE interface present */
+/* On-board IDE on Mark IV */
+#define DEVICE_IDE
 #define IDE_REG_BASE       MARK4_IO_BASE
 #define IDE_8BIT_ONLY
 #define IDE_REG_CS1_FIRST
 
+/* On-board SD on Mark IV */
 #define DEVICE_SD
 #define SD_DRIVE_COUNT 1
 
-/* We have a DS1302, we can read the time of day from it */
+/* On-board DS1302 on Mark IV, we can read the time of day from it */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL 30 /* deciseconds between reading RTC seconds counter */
 
-/* We have a PropIOv2 board */
-#define CONFIG_PROPIO2
+/* Optional PropIOv2 board on ECB bus */
+//#define CONFIG_PROPIO2		/* #define CONFIG_PROPIO2 to enable as tty3 */
 #define PROPIO2_IO_BASE		0xA8
 
 /* Device parameters */
@@ -70,7 +72,7 @@
 #else
 	#define NUM_DEV_TTY 2
 
-	/* ANSI0 as the console */
+	/* ASCI0 as the console */
 	#define BOOT_TTY (512 + 1)
 #endif
 

--- a/Kernel/platform-n8vem-mark4/devtty.c
+++ b/Kernel/platform-n8vem-mark4/devtty.c
@@ -4,17 +4,14 @@
 #include <stdbool.h>
 #include <tty.h>
 #include <devtty.h>
-#include "config.h"
 #include <z180.h>
+#include <n8vem.h>
 
 char tbuf1[TTYSIZ];
 char tbuf2[TTYSIZ];
 
 #ifdef CONFIG_PROPIO2
 char tbufp[TTYSIZ];
-
-__sfr __at (PROPIO2_IO_BASE + 0x00) PROPIO2_STAT;
-__sfr __at (PROPIO2_IO_BASE + 0x01) PROPIO2_TERM;
 #endif
 
 struct  s_queue  ttyinq[NUM_DEV_TTY+1] = {       /* ttyinq[0] is never used */
@@ -40,16 +37,14 @@ int tty_carrier(uint8_t minor)
 
 void tty_pollirq_asci0(void)
 {
-    while(ASCI_STAT0 & 0x80){
+    while(ASCI_STAT0 & 0x80)
         tty_inproc(1, ASCI_RDR0);
-    }
 }
 
 void tty_pollirq_asci1(void)
 {
-    while(ASCI_STAT1 & 0x80){
+    while(ASCI_STAT1 & 0x80)
         tty_inproc(2, ASCI_RDR1);
-    }
 }
 
 #ifdef CONFIG_PROPIO2

--- a/Kernel/platform-n8vem-mark4/devtty.h
+++ b/Kernel/platform-n8vem-mark4/devtty.h
@@ -4,4 +4,8 @@ void tty_putc(uint8_t minor, unsigned char c);
 bool tty_writeready(uint8_t minor);
 void tty_pollirq_asci0(void);
 void tty_pollirq_asci1(void);
+
+#ifdef CONFIG_PROPIO2
+void tty_poll_propio2(void);
+#endif
 #endif

--- a/Kernel/platform-n8vem-mark4/main.c
+++ b/Kernel/platform-n8vem-mark4/main.c
@@ -16,6 +16,11 @@ void z180_timer_interrupt(void)
     a = TIME_TMDR0L;
     a = TIME_TCR;
 
+#ifdef CONFIG_PROPIO2
+    /* The PropIO2 does not have an interrupt on keypress. */
+    tty_poll_propio2();
+#endif
+
     timer_interrupt();
 }
 

--- a/Kernel/platform-n8vem-mark4/n8vem.h
+++ b/Kernel/platform-n8vem-mark4/n8vem.h
@@ -1,0 +1,9 @@
+#ifndef __N8VEM_DOT_H__
+#define __N8VEM_DOT_H__
+
+#include "config.h"
+
+__sfr __at (PROPIO2_IO_BASE + 0x00) PROPIO2_STAT;
+__sfr __at (PROPIO2_IO_BASE + 0x01) PROPIO2_TERM;
+
+#endif


### PR DESCRIPTION
Alan

This branch includes a contributed patch from Anthony DeStefano for using the PropIO v2 serial card as tty3 on n8vem-mark4.

Sorry I just pushed 9ff0d73 on here as well, meant for that to go to the separate mbr (one byte!) pull request.

Will