### PR TITLE
Cache flush (take 2)

### DIFF
--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -120,6 +120,19 @@ int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
     return blkdev_transfer(minor, false, rawflag);
 }
 
+int blkdev_flush(uint8_t minor)
+{
+    blkdev_t *blk;
+
+    /* we trust that blkdev_open() has already verified that this minor number is valid */
+    blk = &blkdev_table[minor >> 4];
+
+    if(blk->flush)
+	return blk->flush(blk->drive_number);
+    else
+	return 0;
+}
+
 /* FIXME: this would tidier and handle odd partition types sanely if split
    into blkdev_alloc() - just returns a device, and blkdev_scan() */
 

--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -120,9 +120,15 @@ int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
     return blkdev_transfer(minor, false, rawflag);
 }
 
-int blkdev_flush(uint8_t minor)
+int blkdev_ioctl(uint8_t minor, uint16_t request, char *data)
 {
     blkdev_t *blk;
+    data; /* unused */
+
+    if(request != BLOCK_FLUSH_CACHE){
+	udata.u_error = ENXIO;
+	return -1;
+    }
 
     /* we trust that blkdev_open() has already verified that this minor number is valid */
     blk = &blkdev_table[minor >> 4];

--- a/Kernel/dev/blkdev.h
+++ b/Kernel/dev/blkdev.h
@@ -26,5 +26,6 @@ extern int blkdev_open(uint8_t minor, uint16_t flags);
 extern int blkdev_read(uint8_t minor, uint8_t rawflag, uint8_t flag);
 extern int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
 extern int blkdev_flush(uint8_t minor);
+extern int blkdev_ioctl(uint8_t minor, uint16_t request, char *data);
 
 #endif

--- a/Kernel/dev/blkdev.h
+++ b/Kernel/dev/blkdev.h
@@ -4,12 +4,13 @@
 /* block device drives should call blkdev_add() for each block device found,
    and implement a sector transfer function matching the following prototype. */
 typedef bool (*transfer_function_t)(uint8_t drive, uint32_t lba, void *buffer, bool read_notwrite);
-
+typedef int (*flush_function_t)(uint8_t drive);
 
 /* the following details should be required only by partition parsing code */
 #define MAX_PARTITIONS 15		    /* must be at least 4, at most 15 */
 typedef struct {
     transfer_function_t transfer;	    /* function to read and write sectors */
+    flush_function_t flush;		    /* flush device cache */
     uint32_t drive_lba_count;		    /* count of sectors on raw disk device */
     uint32_t lba_first[MAX_PARTITIONS];	    /* LBA of first sector of each partition; 0 if partition absent */
     uint32_t lba_count[MAX_PARTITIONS];	    /* count of sectors in each partition; 0 if partition absent */
@@ -24,5 +25,6 @@ extern void blkdev_scan(blkdev_t *blk, uint8_t flags);
 extern int blkdev_open(uint8_t minor, uint16_t flags);
 extern int blkdev_read(uint8_t minor, uint8_t rawflag, uint8_t flag);
 extern int blkdev_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
+extern int blkdev_flush(uint8_t minor);
 
 #endif

--- a/Kernel/dev/devide.h
+++ b/Kernel/dev/devide.h
@@ -64,6 +64,7 @@ void devide_init(void);
 /* IDE command codes */
 #define IDE_CMD_READ_SECTOR     0x20
 #define IDE_CMD_WRITE_SECTOR    0x30
+#define IDE_CMD_FLUSH_CACHE     0xE7
 #define IDE_CMD_IDENTIFY        0xEC
 #define IDE_CMD_SET_FEATURES    0xEF
 

--- a/Kernel/devio.c
+++ b/Kernel/devio.c
@@ -288,7 +288,7 @@ int d_flush(uint16_t dev)
 {
 	if (!validdev(dev))
 		panic("d_flush: bad device");
-	return (*dev_tab[major(dev)].dev_flush) (minor(dev));
+	return (*dev_tab[major(dev)].dev_ioctl) (minor(dev), BLOCK_FLUSH_CACHE, 0);
 }
 
 /*
@@ -335,12 +335,6 @@ int no_ioctl(uint8_t minor, uint16_t a, char *b)
 	b;
 	udata.u_error = ENOTTY;
 	return -1;
-}
-
-int no_flush(uint8_t minor)
-{
-	minor;
-	return 0;
 }
 
 /*

--- a/Kernel/devio.c
+++ b/Kernel/devio.c
@@ -122,6 +122,7 @@ void bufsync(void)
 			bdwrite(bp);
 			if (!bp->bf_busy)
 				bp->bf_dirty = false;
+			d_flush(bp->bf_dev);
 		}
 	}
 }
@@ -283,6 +284,13 @@ int d_ioctl(uint16_t dev, uint16_t request, char *data)
 	return 0;
 }
 
+int d_flush(uint16_t dev)
+{
+	if (!validdev(dev))
+		panic("d_flush: bad device");
+	return (*dev_tab[major(dev)].dev_flush) (minor(dev));
+}
+
 /*
  *	No such device handler
  */
@@ -327,6 +335,12 @@ int no_ioctl(uint8_t minor, uint16_t a, char *b)
 	b;
 	udata.u_error = ENOTTY;
 	return -1;
+}
+
+int no_flush(uint8_t minor)
+{
+	minor;
+	return 0;
 }
 
 /*

--- a/Kernel/include/kdata.h
+++ b/Kernel/include/kdata.h
@@ -53,6 +53,7 @@ typedef int (*dev_init_t)(void);
 typedef int (*dev_open_t)(uint8_t minor, uint16_t flag);
 typedef int (*dev_close_t)(uint8_t minor);
 typedef int (*dev_ioctl_t)(uint8_t minor, uint16_t request, char *data); // note: data is in userspace
+typedef int (*dev_flush_t)(uint8_t minor);
 
 typedef struct devsw {
     dev_open_t dev_open;  /* The routines for reading, etc */
@@ -60,6 +61,7 @@ typedef struct devsw {
     dev_read_t dev_read;  /* Offset would be ignored for block devices */
     dev_write_t dev_write; /* Blkno and offset ignored for tty, etc. */
     dev_ioctl_t dev_ioctl; /* Count is rounded to 512 for block devices */
+    dev_flush_t dev_flush; /* Flush device write cache */
 } devsw;
 
 extern struct devsw dev_tab[];

--- a/Kernel/include/kdata.h
+++ b/Kernel/include/kdata.h
@@ -53,7 +53,6 @@ typedef int (*dev_init_t)(void);
 typedef int (*dev_open_t)(uint8_t minor, uint16_t flag);
 typedef int (*dev_close_t)(uint8_t minor);
 typedef int (*dev_ioctl_t)(uint8_t minor, uint16_t request, char *data); // note: data is in userspace
-typedef int (*dev_flush_t)(uint8_t minor);
 
 typedef struct devsw {
     dev_open_t dev_open;  /* The routines for reading, etc */
@@ -61,7 +60,6 @@ typedef struct devsw {
     dev_read_t dev_read;  /* Offset would be ignored for block devices */
     dev_write_t dev_write; /* Blkno and offset ignored for tty, etc. */
     dev_ioctl_t dev_ioctl; /* Count is rounded to 512 for block devices */
-    dev_flush_t dev_flush; /* Flush device write cache */
 } devsw;
 
 extern struct devsw dev_tab[];

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -507,6 +507,7 @@ struct s_argblk {
  */
 #define SELECT_BEGIN		0x8000
 #define SELECT_END		0x8001
+#define BLOCK_FLUSH_CACHE       0x8002
 
 struct sysinfoblk {
   uint8_t infosize;		/* For expandability */
@@ -608,7 +609,6 @@ CODE1 int no_open(uint8_t minor, uint16_t flag);
 CODE1 int no_close(uint8_t minor);
 CODE1 int no_rdwr(uint8_t minir, uint8_t rawflag, uint8_t flag);
 CODE1 int no_ioctl(uint8_t minor, uint16_t a, char *b);
-CODE1 int no_flush(uint8_t minor);
 
 /* filesys.c */
 /* open file, "name" in user address space */

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -596,6 +596,7 @@ CODE1 int cdread(uint16_t dev, uint8_t flag);
 CODE1 int d_open(uint16_t dev, uint8_t flag);
 CODE1 int d_close(uint16_t dev);
 CODE1 int d_ioctl(uint16_t dev, uint16_t request, char *data);
+CODE1 int d_flush(uint16_t dev);
 CODE1 int cdwrite(uint16_t dev, uint8_t flag);
 CODE1 bool insq(struct s_queue *q, unsigned char c);
 CODE1 bool remq(struct s_queue *q, unsigned char *cp);
@@ -607,6 +608,7 @@ CODE1 int no_open(uint8_t minor, uint16_t flag);
 CODE1 int no_close(uint8_t minor);
 CODE1 int no_rdwr(uint8_t minir, uint8_t rawflag, uint8_t flag);
 CODE1 int no_ioctl(uint8_t minor, uint16_t a, char *b);
+CODE1 int no_flush(uint8_t minor);
 
 /* filesys.c */
 /* open file, "name" in user address space */

--- a/Kernel/platform-n8vem-mark4/devices.c
+++ b/Kernel/platform-n8vem-mark4/devices.c
@@ -11,12 +11,12 @@
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-/*   open	    close	read		write		ioctl	    flush */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl,   blkdev_flush },	/* 0: /dev/hd -- standard block device interface */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 1: unused slot */
-  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl,  no_flush },		/* 2: /dev/tty -- serial ports */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 3: unused slot */
-  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl,  no_flush },		/* 4: /dev/mem etc	System devices (one offs) */
+/*   open	    close	read		write		ioctl */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/platform-n8vem-mark4/devices.c
+++ b/Kernel/platform-n8vem-mark4/devices.c
@@ -11,12 +11,12 @@
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-/*   open	    close	read		write		ioctl */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
-  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
-  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
+/*   open	    close	read		write		ioctl	    flush */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl,   blkdev_flush },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl,  no_flush },		/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl,  no_flush },		/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/platform-n8vem-mark4/devices.c
+++ b/Kernel/platform-n8vem-mark4/devices.c
@@ -12,7 +12,7 @@
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
 /*   open	    close	read		write		ioctl */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	blkdev_ioctl },	/* 0: /dev/hd -- standard block device interface */
   {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
   {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
   {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */

--- a/Kernel/platform-p112/devices.c
+++ b/Kernel/platform-p112/devices.c
@@ -10,12 +10,12 @@
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-/*   open	    close	read		write		ioctl	    flush */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl,   blkdev_flush },	/* 0: /dev/hd -- standard block device interface */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 1: unused slot */
-  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl,  no_flush },		/* 2: /dev/tty -- serial ports */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 3: unused slot */
-  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl,  no_flush },		/* 4: /dev/mem etc	System devices (one offs) */
+/*   open	    close	read		write		ioctl */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/platform-p112/devices.c
+++ b/Kernel/platform-p112/devices.c
@@ -11,7 +11,7 @@
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
 /*   open	    close	read		write		ioctl */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	blkdev_ioctl },	/* 0: /dev/hd -- standard block device interface */
   {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
   {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
   {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */

--- a/Kernel/platform-p112/devices.c
+++ b/Kernel/platform-p112/devices.c
@@ -10,12 +10,12 @@
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-/*   open	    close	read		write		ioctl */
-  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl },	/* 0: /dev/hd -- standard block device interface */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 1: unused slot */
-  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl },	/* 2: /dev/tty -- serial ports */
-  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl },	/* 3: unused slot */
-  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl  },	/* 4: /dev/mem etc	System devices (one offs) */
+/*   open	    close	read		write		ioctl	    flush */
+  {  blkdev_open,   no_close,	blkdev_read,	blkdev_write,	no_ioctl,   blkdev_flush },	/* 0: /dev/hd -- standard block device interface */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 1: unused slot */
+  {  tty_open,	    tty_close,	tty_read,	tty_write,	tty_ioctl,  no_flush },		/* 2: /dev/tty -- serial ports */
+  {  no_open,	    no_close,	no_rdwr,	no_rdwr,	no_ioctl,   no_flush },		/* 3: unused slot */
+  {  no_open,	    no_close,	sys_read,	sys_write,	sys_ioctl,  no_flush },		/* 4: /dev/mem etc	System devices (one offs) */
 };
 
 bool validdev(uint16_t dev)

--- a/Kernel/syscall_fs.c
+++ b/Kernel/syscall_fs.c
@@ -87,6 +87,7 @@ int16_t _sync(void)
 		if (ino->c_refs > 0 && (ino->c_flags & CDIRTY)) {
 			wr_inode(ino);
 			ino->c_flags &= ~CDIRTY;
+			/* WRS: also call d_flush(ino->c_dev) here? */
 		}
 
         /* This now also indirectly does the superblocks as they


### PR DESCRIPTION
How about something like this?

This patch requires platforms to change their device tables, only the two Z180 platforms are modified, so changes to other platforms would be required also.

Not completely happy with how _sync() and bufsync() call d_flush() but wanted to get your input at this stage in case this is not to your liking.

W