### PR TITLE
Exponential backoff at unsuccessful login attempts  and preliminary initscript support

### DIFF
--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -25,7 +25,7 @@ void backoff(int);
 int main(int argc, char *argv[])
 {
     int fdtty1, sh_pid, pid;
-    char* rc_arg={"/etc/rc",NULL};
+    char* rc_arg·[]={"/etc/rc",NULL};
     signal(SIGINT, SIG_IGN);
 
     /* remove any stale /etc/mtab file */

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -26,7 +26,7 @@ void backoff(int);
 int main(int argc, char *argv[])
 {
     int fdtty1, sh_pid, pid;
-    char* rc_arg·[]={"/etc/rc",NULL};
+    char* rc_arg·[]={"sh","/etc/rc",NULL};
     signal(SIGINT, SIG_IGN);
 
     /* remove any stale /etc/mtab file */

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     close(2);
     dup(fdtty1);
 
-    putstr("init version 0.8.1ac\n");
+    putstr("init version 0.8.1ac-1erkinalp-0ac\n");
     
     if (pid=fork()) execve("/bin/sh",rc_arg,NULL);
     else waitpid(pid,NULL,0);

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pwd.h>
+#include <sys/wait.h>
 
 
 char *argp[] = { "sh", NULL };

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <pwd.h>
 
+
 char *argp[] = { "sh", NULL };
 
 #define crlf   write(1, "\n", 1)
@@ -24,7 +25,7 @@ void backoff(int);
 int main(int argc, char *argv[])
 {
     int fdtty1, sh_pid, pid;
-
+    char* rc_arg={"/etc/rc",NULL};
     signal(SIGINT, SIG_IGN);
 
     /* remove any stale /etc/mtab file */
@@ -48,6 +49,8 @@ int main(int argc, char *argv[])
 
     putstr("init version 0.8.1ac\n");
     
+    if (pid=fork()) execve("/bin/sh",rc_arg,NULL);
+    else waitpid(pid,NULL,0);
     /* then call the login procedure on it */
 
     for (;;) {


### PR DESCRIPTION
If five consecutive login attempts are unsuccessful, a backoff ranging from one minute to 512 minutes will be applied with this pull.