### PR TITLE
Kernel: Remove the tty_writeready() function

### DIFF
--- a/Kernel/PORTING
+++ b/Kernel/PORTING
@@ -290,11 +290,6 @@ Copy the struct s_queue from another filled in for your devices/buffers.
 
 Provide putchar(c) if it is not already provided by your asm code
 
-bool tty_writeready(uint8_t minor)
-
-Returns true fi you can write bytes to this port (1..n). For things like
-video consoles just return true
-
 void tty_putc(uint8_t minor, char c)
 
 Write a character to the tty minor

--- a/Kernel/dev/z80pack/devtty.c
+++ b/Kernel/dev/z80pack/devtty.c
@@ -32,27 +32,17 @@ void kputchar(char c)
     tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-    uint8_t s;
-
-    if (minor == 1)
-        return 1;
-    if (minor == 2)
-        s = tty2stat;
-    else
-        s = tty3stat;
-    return s & 2;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
     if (minor == 1)
         tty1data = c;
-    else if (minor == 2)
+    else if (minor == 2){
+        while(!(tty2stat & 2));
         tty2data = c;
-    else
+    }else{
+        while(!(tty3stat & 2));
         tty3data = c;
+    }
 }
 
 /* Called every timer tick */
@@ -71,10 +61,6 @@ void tty_pollirq(void)
         c = tty3data;
         tty_inproc(3, c);
     }
-    if (tty2stat & 2)
-        wakeup(&ttydata[2]);
-    if (tty3stat & 2)
-        wakeup(&ttydata[3]);
 }    
 
 void tty_setup(uint8_t minor)

--- a/Kernel/dev/z80pack/devtty.h
+++ b/Kernel/dev/z80pack/devtty.h
@@ -1,7 +1,6 @@
 #ifndef __DEVTTY_DOT_H__
 #define __DEVTTY_DOT_H__
 void tty_putc(uint8_t minor, unsigned char c);
-bool tty_writeready(uint8_t minor);
 void tty_pollirq(void);
 void tty_setup(uint8_t minor);
 #endif

--- a/Kernel/include/tty.h
+++ b/Kernel/include/tty.h
@@ -195,7 +195,6 @@ extern CODE1 void tty_putc_wait(uint8_t minor, unsigned char c);
 
 /* provided by platform */
 extern struct s_queue ttyinq[NUM_DEV_TTY + 1];
-extern CODE2 bool tty_writeready(uint8_t minor);
 extern CODE2 void tty_putc(uint8_t minor, unsigned char c);
 extern CODE2 void tty_setup(uint8_t minor);
 extern CODE2 int tty_carrier(uint8_t minor);

--- a/Kernel/platform-6502test/devtty.c
+++ b/Kernel/platform-6502test/devtty.c
@@ -33,15 +33,6 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-	uint8_t c;
-	if (minor == 1)
-		return 1;
-	c = *uartb;
-	return c & 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;
@@ -51,6 +42,7 @@ void tty_putc(uint8_t minor, unsigned char c)
 		return;
 	}
 #endif	
+	while(!(*uartb & 1));
 	*uarta = c;
 }
 

--- a/Kernel/platform-6809test/devtty.c
+++ b/Kernel/platform-6809test/devtty.c
@@ -35,15 +35,6 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-	uint8_t c;
-	if (minor == 1)
-		return 1;
-	c = *uartb;
-	return c & 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;
@@ -53,6 +44,7 @@ void tty_putc(uint8_t minor, unsigned char c)
 		return;
 	}
 #endif	
+	while(!(*uartb & 1));
 	*uarta = c;
 }
 

--- a/Kernel/platform-dragon/devtty.c
+++ b/Kernel/platform-dragon/devtty.c
@@ -33,23 +33,16 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-	uint8_t c;
-	if (minor == 1)
-		return 1;
-	c = *uart_status;
-	return c & 16;	/* TX DATA empty */
-}
-
 /* For DragonPlus we should perhaps support both monitors 8) */
 
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	if (minor == 1) {
 		vtoutput(&c, 1);
-	} else
+	} else {
+		while( !(*uart_status & 16) ); /* wait for TX DATA empty */
 		*uart_data = c;	/* Data */
+	}
 }
 
 void tty_setup(uint8_t minor)

--- a/Kernel/platform-msx1/devtty.c
+++ b/Kernel/platform-msx1/devtty.c
@@ -30,13 +30,6 @@ void kputchar(char c)
 	tty_putc(2, c);
 }
 
-/* Both console and debug port are always ready */
-bool tty_writeready(uint8_t minor)
-{
-	minor;
-	return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;
@@ -166,8 +159,6 @@ void tty_interrupt(void)
 #if 0
 	uint8_t a = irqmap;
 	uint8_t c;
-	if (!(a & 2))
-		wakeup(&ttydata[2]);
 	if (!(a & 1)) {
 		/* work around sdcc bug */
 		c = uarta;

--- a/Kernel/platform-msx2/devtty.c
+++ b/Kernel/platform-msx2/devtty.c
@@ -32,13 +32,6 @@ void kputchar(char c)
 	tty_putc(2, c);
 }
 
-/* Both console and debug port are always ready */
-bool tty_writeready(uint8_t minor)
-{
-	minor;
-	return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;

--- a/Kernel/platform-mtx/devtty.c
+++ b/Kernel/platform-mtx/devtty.c
@@ -45,16 +45,6 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-	uint8_t reg = 0xFF;
-	if (minor == 3)
-		reg = serialAc;
-	if (minor == 4)
-		reg = serialBc;
-	return reg & 4;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	irqflags_t irq;
@@ -70,10 +60,13 @@ void tty_putc(uint8_t minor, unsigned char c)
 		irqrestore(irq);
 		return;
 	}
-	if (minor == 3)
+	if (minor == 3){
+		while(!(serialAc & 4));
 		serialAd = c;
-	else
+	}else{
+		while(!(serialBc & 4));
 		serialBd = c;
+	}
 }
 
 int tty_carrier(uint8_t minor)

--- a/Kernel/platform-n8vem-mark4/devtty.c
+++ b/Kernel/platform-n8vem-mark4/devtty.c
@@ -75,12 +75,6 @@ void tty_putc(uint8_t minor, unsigned char c)
     }
 }
 
-bool tty_writeready(uint8_t minor)
-{
-    minor;
-    return 1;
-}
-
 /* kernel writes to system console -- never sleep! */
 void kputchar(char c)
 {

--- a/Kernel/platform-n8vem-mark4/devtty.h
+++ b/Kernel/platform-n8vem-mark4/devtty.h
@@ -1,7 +1,6 @@
 #ifndef __DEVTTY_DOT_H__
 #define __DEVTTY_DOT_H__
 void tty_putc(uint8_t minor, unsigned char c);
-bool tty_writeready(uint8_t minor);
 void tty_pollirq_asci0(void);
 void tty_pollirq_asci1(void);
 

--- a/Kernel/platform-nc100/devtty.c
+++ b/Kernel/platform-nc100/devtty.c
@@ -86,15 +86,6 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-	uint8_t c;
-	if (minor == 1)
-		return 1;
-	c = uartb;
-	return c & 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;
@@ -102,6 +93,7 @@ void tty_putc(uint8_t minor, unsigned char c)
 		vtoutput(&c, 1);
 		return;
 	}
+	while(!(uartb & 1));
 	uarta = c;
 }
 
@@ -281,8 +273,6 @@ void platform_interrupt(void)
 	uint8_t a = irqmap;
 	uint8_t c;
 	if (!(a & 4)) {
-		/* FIXME: need to check uart itself to see wake cause */
-		wakeup(&ttydata[2]);
 		/* work around sdcc bug */
 		c = uarta;
 		tty_inproc(2, c);
@@ -324,8 +314,6 @@ void platform_interrupt(void)
 {
 	uint8_t a = irqmap;
 	uint8_t c;
-	if (!(a & 2))
-		wakeup(&ttydata[2]);
 	if (!(a & 1)) {
 		/* work around sdcc bug */
 		c = uarta;

--- a/Kernel/platform-p112/devtty.c
+++ b/Kernel/platform-p112/devtty.c
@@ -87,12 +87,6 @@ void tty_putc(uint8_t minor, unsigned char c)
     }
 }
 
-bool tty_writeready(uint8_t minor)
-{
-    minor;
-    return 1;
-}
-
 /* kernel writes to system console -- never sleep! */
 void kputchar(char c)
 {

--- a/Kernel/platform-p112/devtty.h
+++ b/Kernel/platform-p112/devtty.h
@@ -1,7 +1,6 @@
 #ifndef __DEVTTY_DOT_H__
 #define __DEVTTY_DOT_H__
 void tty_putc(uint8_t minor, unsigned char c);
-bool tty_writeready(uint8_t minor);
 void tty_pollirq_escc(void);
 void tty_pollirq_asci0(void);
 void tty_pollirq_asci1(void);

--- a/Kernel/platform-pcw8256/devtty.c
+++ b/Kernel/platform-pcw8256/devtty.c
@@ -70,14 +70,6 @@ static void dartwr(uint8_t minor, uint8_t r, uint8_t v)
     irqrestore(irq);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-    if (minor == 1)
-        return 1;	/* VT */
-    else
-        return dartrr(minor, 0) & 4;
-}
-
 extern void bugout(uint16_t c);
 
 void tty_putc(uint8_t minor, unsigned char c)
@@ -85,8 +77,12 @@ void tty_putc(uint8_t minor, unsigned char c)
     if (minor == 1) {
         bugout(c);
         vtoutput(&c, 1);
+	return;
     }
-    else if (minor == 2)
+
+    while(!(dartrr(minor, 0) & 4));
+
+    if (minor == 2)
         dart0d = c;
     else
         dart1d = c;

--- a/Kernel/platform-pcw8256/devtty.h
+++ b/Kernel/platform-pcw8256/devtty.h
@@ -2,7 +2,6 @@
 #define __DEVTTY_DOT_H__
 
 void tty_putc(uint8_t minor, char c);
-bool tty_writeready(uint8_t minor);
 void tty_init_port(void);
 void tty_irq(void);
 

--- a/Kernel/platform-px4plus/devtty.c
+++ b/Kernel/platform-px4plus/devtty.c
@@ -23,13 +23,6 @@ void kputchar(char c)
     tty_putc(1, c);
 }
 
-/* It's the console display, always ready */
-static bool tty_writeready(uint8_t minor)
-{
-    minor;
-    return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
     minor;

--- a/Kernel/platform-px4plus/devtty.h
+++ b/Kernel/platform-px4plus/devtty.h
@@ -1,7 +1,6 @@
 #ifndef __DEVTTY_DOT_H__
 #define __DEVTTY_DOT_H__
 void tty_putc(uint8_t minor, unsigned char c);
-bool tty_writeready(uint8_t minor);
 void tty_pollirq(void);
 void tty_setup(uint8_t minor);
 #endif

--- a/Kernel/platform-socz80/socz80.s
+++ b/Kernel/platform-socz80/socz80.s
@@ -11,7 +11,6 @@
             .globl interrupt_handler
             .globl _program_vectors
             .globl _tty_putc
-            .globl _tty_writeready
             .globl _tty_outproc
 	    .globl map_kernel
 	    .globl map_process
@@ -205,32 +204,6 @@ init_hardware:
             pop hl
 
             im 1 ; set CPU interrupt mode
-            ret
-
-
-; tty_writeready(uint8_t minor, uint8_t char)
-_tty_writeready:
-            ; stack has: return address, minor
-            ;                   0 1      2    
-            ; set HL to point to character on stack
-            ld hl, #2
-            add hl,sp
-            ld a, (hl) ; load tty device minor number
-            cp #1
-            jr z, uart0wr
-            cp #2
-            jr z, uart1wr
-            call _trap_monitor
-            ret ; not a console we recognise
-uart1wr:    in a, (UART1_STATUS)
-            jr testready
-uart0wr:    in a, (UART0_STATUS)
-            ; fall through
-testready:  bit 6, a ; transmitter busy?
-            jr nz, notready ; 0=idle, 1=busy
-            ld l, #1
-            ret
-notready:   ld l, #0
             ret
 
 

--- a/Kernel/platform-tgl6502/devtty.c
+++ b/Kernel/platform-tgl6502/devtty.c
@@ -30,11 +30,6 @@ void kputchar(uint8_t c)
 	tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-        return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;

--- a/Kernel/platform-trs80/devtty.c
+++ b/Kernel/platform-trs80/devtty.c
@@ -29,23 +29,14 @@ void kputchar(char c)
     tty_putc(1, c);
 }
 
-bool tty_writeready(uint8_t minor)
-{
-    uint8_t reg;
-    if (minor == 1)
-        return 1;
-    reg = tr1865_status;
-    if (reg & 0x40)
-        return 1;
-    return 0;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
     if (minor == 1)
         vtoutput(&c, 1);
-    if (minor == 2)
+    if (minor == 2){
+	while(!(tr1865_status & 0x40));
         tr1865_rxtx = c;
+    }
 }
 
 void tty_interrupt(void)

--- a/Kernel/platform-ubee/devtty.c
+++ b/Kernel/platform-ubee/devtty.c
@@ -29,12 +29,6 @@ void kputchar(char c)
 	tty_putc(1, c);
 }
 
-static bool tty_writeready(uint8_t minor)
-{
-	minor;
-	return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;

--- a/Kernel/platform-zx128/devtty.c
+++ b/Kernel/platform-zx128/devtty.c
@@ -59,13 +59,6 @@ void kputchar(char c)
 	tty_putc(0, c);
 }
 
-/* Both console and debug port are always ready */
-bool tty_writeready(uint8_t minor)
-{
-	minor;
-	return 1;
-}
-
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	minor;


### PR DESCRIPTION
I added tty_writeready() to socz80-UZI as a way to get better
concurrency by causing a process writing to a busy UART port to sleep,
thus allowing a second process to run, and later waking up the sleeping
process once a UART interrupt arrives to indicate it is ready for
another byte.

This worked well enough on socz80-UZI with its 128MHz processor, but on
real Z80 hardware this scheme actually hurts performance at most
reasonable baud rates; the necessary overhead of sleeping the process,
switching to another process, taking an interrupt and switching back
takes much longer than just waiting for the UART to finish transmitting.

This patch removes tty_writeready in the core kernel and for each
platform. Note that an individual platform which wishes to retain the
old "sleep on busy UART" behaviour can still do so simply by
implementing this inside the platform tty_putc() routine.