### PR TITLE
Kernel: Bug fix for syscall_exec

### DIFF
--- a/Kernel/syscall_exec.c
+++ b/Kernel/syscall_exec.c
@@ -25,7 +25,7 @@ static int bload(inoptr i, uint16_t bl, uint16_t base, uint16_t len)
 #else
 			/* Might be worth spotting sequential blocks and
 			   merging ? */
-			udata.u_offset = blk << 9;
+			udata.u_offset = (off_t)blk << 9;
 			udata.u_count = 512;
 			udata.u_base = (uint8_t *)base;
 			if (cdread(i->c_dev, 0) < 0) {


### PR DESCRIPTION
Convert block number to off_t before shifting, otherwise we're restricted to accessing only the first 64KB of the disk.