### PR TITLE
Fix for unmounting filesystem, fix for dd count= option, change bf_free to tristate for unfreeable superblocks

### DIFF
--- a/Applications/util/dd.c
+++ b/Applications/util/dd.c
@@ -71,6 +71,7 @@ void main(int argc, char *argv[])
     long skipval;
     long intotal;
     long outtotal;
+    long inmax;
     char *buf;
 
     infile = NULL;
@@ -79,6 +80,7 @@ void main(int argc, char *argv[])
     skipval = 0;
     blocksize = 512;
     count = 0x7fffffff;
+    inmax = 0;
 
     while (--argc > 0) {
 	str = *++argv;
@@ -204,6 +206,8 @@ void main(int argc, char *argv[])
 	    goto cleanup;
 	}
     }
+    if(count != 0x7fffffff)
+        inmax = count * blocksize;
     while ((incc = read(infd, buf, blocksize)) > 0) {
 	intotal += incc;
 	cp = buf;
@@ -222,6 +226,8 @@ void main(int argc, char *argv[])
 	    cp += outcc;
 	    incc -= outcc;
 	}
+        if(inmax && intotal >= inmax)
+            break;
     }
 
     if (incc < 0)

--- a/Kernel/filesys.c
+++ b/Kernel/filesys.c
@@ -1071,9 +1071,11 @@ bool fmount(uint16_t dev, inoptr ino, uint16_t flags)
         udata.u_error = EMFILE;
         return true;	/* Table is full */
     }
-    /* Pin the buffer at dev 0 blk 1, it will only be released
-       by umount */
+
+    /* Pin the buffer with the superblock (block 1), it 
+     * will only be released by umount */
     fp = (filesys *)bread(dev, 1, 0);
+    ((bufptr)fp)->bf_busy = BF_SUPERBLOCK; /* really really busy */
 
     //   kprintf("fp->s_mounted=0x%x, fp->s_isize=0x%x, fp->s_fsize=0x%x\n", 
     //   fp->s_mounted, fp->s_isize, fp->s_fsize);

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -93,6 +93,11 @@ typedef uint16_t blkno_t;    /* Can have 65536 512-byte blocks in filesystem */
 #define BLKSHIFT	9
 #define BLKMASK		511
 
+/* we need a busier-than-busy state for superblocks, so that if those blocks
+ * are read by userspace through bread() they are not subsequently freed by 
+ * bfree() until the filesystem is unmounted */
+typedef enum { BF_FREE=0, BF_BUSY, BF_SUPERBLOCK } bf_busy_t;
+
 /* FIXME: if we could split the data and the header we could keep blocks
    outside of our kernel data (as ELKS does) which would be a win, but need
    some more care on copies, block indexes and directory ops */
@@ -101,7 +106,7 @@ typedef struct blkbuf {
     uint16_t    bf_dev;
     blkno_t     bf_blk;
     bool        bf_dirty;
-    bool        bf_busy;
+    bf_busy_t   bf_busy;
     uint16_t    bf_time;         /* LRU time stamp */
 } blkbuf, *bufptr;
 

--- a/Kernel/start.c
+++ b/Kernel/start.c
@@ -37,7 +37,7 @@ void bufinit(void)
 
 	for (bp = bufpool; bp < bufpool + NBUFS; ++bp) {
 		bp->bf_dev = NO_DEVICE;
-		bp->bf_busy = false;
+		bp->bf_busy = BF_FREE;
 	}
 }
 

--- a/Kernel/syscall_other.c
+++ b/Kernel/syscall_other.c
@@ -350,7 +350,6 @@ int16_t _umount(void)
 
 	_sync();
 
-	mnt->m_fs->s_mounted = 0;
 	i_deref(mnt->m_fs->s_mntpt);
 	/* Give back the buffer we pinned at mount time */
 	bfree((bufptr)mnt->m_fs, 2);

--- a/Kernel/syscall_other.c
+++ b/Kernel/syscall_other.c
@@ -352,6 +352,7 @@ int16_t _umount(void)
 
 	i_deref(mnt->m_fs->s_mntpt);
 	/* Give back the buffer we pinned at mount time */
+	((bufptr)mnt->m_fs)->bf_busy = BF_BUSY; /* downgrade from BF_SUPERBLOCK */
 	bfree((bufptr)mnt->m_fs, 2);
 	/* Vanish the entry */
 	mnt->m_dev = NO_DEVICE;


### PR DESCRIPTION
Also only includes bufdump() if CONFIG_IDUMP is set (since that is the only place from which it is called).