### PR TITLE
Kernel: readi() - when reading whole sectors, transfer them directly into user memory.

### DIFF
--- a/Kernel/inode.c
+++ b/Kernel/inode.c
@@ -11,6 +11,8 @@ void readi(inoptr ino, uint8_t flag)
 	unsigned char *bp;
 	uint16_t dev;
 	bool ispipe;
+	off_t uostash;
+	usize_t ucstash;
 
 	dev = ino->c_dev;
 	ispipe = false;
@@ -51,19 +53,29 @@ void readi(inoptr ino, uint8_t flag)
 
 	      loop:
 		while (toread) {
-			if ((pblk =
-			     bmap(ino, udata.u_offset >> BLKSHIFT,
-				  1)) != NULLBLK)
-				bp = bread(dev, pblk, 0);
-			else
-				bp = zerobuf();
+			amount = min(toread, BLKSIZE - (udata.u_offset&BLKMASK));
+			pblk = bmap(ino, udata.u_offset >> BLKSHIFT, 1);
 
-			amount =
-			    min(toread, BLKSIZE - (udata.u_offset&BLKMASK));
+			if(!ispipe && amount == BLKSIZE && bfind(dev, pblk) == 0){
+				/* we can transfer direct from disk to the userspace buffer */
+				uostash = udata.u_offset;	            /* stash file offset */
+				ucstash = udata.u_count;		    /* stash byte count */
+				udata.u_count = amount;                     /* transfer one sector */
+				udata.u_offset = ((off_t)pblk) << BLKSHIFT; /* replace with sector offset on device */
+				((*dev_tab[major(dev)].dev_read) (minor(dev), 1, 0)); /* read */
+				udata.u_offset = uostash;		    /* restore file offset */
+				udata.u_count = ucstash;                    /* restore byte count */
+			}else{
+				/* we transfer through the buffer pool */
+				if (pblk == NULLBLK)
+					bp = zerobuf();
+				else
+					bp = bread(dev, pblk, 0);
 
-			uputsys(bp + (udata.u_offset & BLKMASK), amount);
+				uputsys(bp + (udata.u_offset & BLKMASK), amount);
 
-			brelse(bp);
+				brelse(bp);
+			}
 
 			udata.u_base += amount;
 			udata.u_offset += amount;
@@ -145,7 +157,7 @@ void writei(inoptr ino, uint8_t flag)
 	      loop:
 
 		while (towrite) {
-			amount = min(towrite, 512 - (udata.u_offset&BLKMASK));
+			amount = min(towrite, BLKSIZE - (udata.u_offset&BLKMASK));
 
 			if ((pblk =
 			     bmap(ino, udata.u_offset >> BLKSHIFT,

--- a/Kernel/inode.c
+++ b/Kernel/inode.c
@@ -56,7 +56,7 @@ void readi(inoptr ino, uint8_t flag)
 			amount = min(toread, BLKSIZE - (udata.u_offset&BLKMASK));
 			pblk = bmap(ino, udata.u_offset >> BLKSHIFT, 1);
 
-			if(!ispipe && amount == BLKSIZE && bfind(dev, pblk) == 0){
+			if(!ispipe && amount == BLKSIZE && !udata.u_sysio && bfind(dev, pblk) == 0){
 				/* we can transfer direct from disk to the userspace buffer */
 				uostash = udata.u_offset;	            /* stash file offset */
 				ucstash = udata.u_count;		    /* stash byte count */

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -12,6 +12,8 @@
 #undef CONFIG_CPM_EMU
 /* Fixed banking */
 #define CONFIG_BANK_FIXED
+/* Permit large I/O requests to bypass cache and go direct to userspace */
+#define CONFIG_LARGE_IO_DIRECT
 /* 8 60K banks, 1 is kernel */
 #define MAX_MAPS	8
 #define MAP_SIZE	0xF000U

--- a/Kernel/platform-p112/config.h
+++ b/Kernel/platform-p112/config.h
@@ -12,6 +12,8 @@
 #undef CONFIG_CPM_EMU
 /* Fixed banking */
 #define CONFIG_BANK_FIXED
+/* Permit large I/O requests to bypass cache and go direct to userspace */
+#define CONFIG_LARGE_IO_DIRECT
 /* 8 60K banks, 1 is kernel */
 #define MAX_MAPS	16
 #define MAP_SIZE	0xF000U


### PR DESCRIPTION
Similar could be done for writei() if required.