### PR TITLE
Kernel: The platform rules.mk should define the CPU used

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -1,15 +1,12 @@
 TARGET_LIST = platform-nc100 platform-micropack platform-pcw8256 platform-socz80 platform-zx128 platform-trs80 platform-z80pack platform-z80pack-lite platform-z80pack32 platform-dragon platform-tgl6502
 
 export TARGET= zx128
-export CPU = z80
 #export TARGET = dragon
-#export CPU = 6809
 #export TARGET = tgl6502
-#export CPU = 6502
-#export TARGET=atarist
-#export CPU = 68000
+#export TARGET = atarist
 #export TARGET = 8086test
-#export CPU = 8086
+#export TARGET = n8vem-mark4
+#export TARGET = p112
 
 export VERSION = "0.1"
 export SUBVERSION = "ac1"
@@ -21,8 +18,8 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 all:	fuzix.bin
 
 
-include cpu-$(CPU)/rules.mk
 -include platform-$(TARGET)/rules.mk
+include cpu-$(CPU)/rules.mk
 
 
 

--- a/Kernel/platform-8086test/rules.mk
+++ b/Kernel/platform-8086test/rules.mk
@@ -1,0 +1,1 @@
+export CPU = 8086

--- a/Kernel/platform-atarist/rules.mk
+++ b/Kernel/platform-atarist/rules.mk
@@ -1,0 +1,1 @@
+export CPU = 68000

--- a/Kernel/platform-dragon/rules.mk
+++ b/Kernel/platform-dragon/rules.mk
@@ -1,0 +1,1 @@
+export CPU = 6809

--- a/Kernel/platform-n8vem-mark4/README
+++ b/Kernel/platform-n8vem-mark4/README
@@ -13,9 +13,8 @@ The PropIO V2 can be enabled by editing config.h and setting PROPIO2_IO_BASE to
 the base IO port address of the board. If enabled, the PropIO will be used as
 the system console.
 
-To build the kernel, edit the CPU and TARGET lines in Kernel/Makefile to read:
+To build the kernel, edit the TARGET line in Kernel/Makefile to read:
     export TARGET=n8vem-mark4
-    export CPU=z180
 Then run "make clean; make all" in the "Kernel" directory.
 
 There are two ways to boot the system.

--- a/Kernel/platform-n8vem-mark4/rules.mk
+++ b/Kernel/platform-n8vem-mark4/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z180

--- a/Kernel/platform-p112/README
+++ b/Kernel/platform-p112/README
@@ -9,9 +9,8 @@ Supported hardware:
  - G-IDE hard disk drive controller
  - First serial port (ESCC channel A, tty1)
 
-To build the kernel, edit the CPU and TARGET lines in Kernel/Makefile to read:
+To build the kernel, edit the TARGET line in Kernel/Makefile to read:
     export TARGET=p112
-    export CPU=z180
 Then run "make clean; make all" in the "Kernel" directory.
 
 There are two ways to boot the system.

--- a/Kernel/platform-p112/rules.mk
+++ b/Kernel/platform-p112/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z180

--- a/Kernel/platform-socz80/rules.mk
+++ b/Kernel/platform-socz80/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z80

--- a/Kernel/platform-tgl6502/rules.mk
+++ b/Kernel/platform-tgl6502/rules.mk
@@ -1,0 +1,1 @@
+export CPU = 6502

--- a/Kernel/platform-z80pack-lite/rules.mk
+++ b/Kernel/platform-z80pack-lite/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z80

--- a/Kernel/platform-z80pack/rules.mk
+++ b/Kernel/platform-z80pack/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z80

--- a/Kernel/platform-zx128/rules.mk
+++ b/Kernel/platform-zx128/rules.mk
@@ -1,0 +1,1 @@
+export CPU = z80


### PR DESCRIPTION
This means that only the PLATFORM variable needs to be specified in
Kernel/Makefile, instead both PLATFORM and CPU in combination.