### PR TITLE
Better root device name parsing

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -17,7 +17,7 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 all:	fuzix.bin
 
-# Platform propertyies
+# Platform properties
 include platform-$(TARGET)/target.mk
 # CPU properties
 include cpu-$(CPU)/rules.mk

--- a/Kernel/include/kdata.h
+++ b/Kernel/include/kdata.h
@@ -4,8 +4,6 @@
 #include <stdbool.h>
 
 extern unsigned char *cmdline;
-#define BOOTLINE_LEN 6
-extern unsigned char bootline[BOOTLINE_LEN];
 
 extern struct u_block ub;
 

--- a/Kernel/kdata.c
+++ b/Kernel/kdata.c
@@ -4,7 +4,6 @@
 
 p_tab *init_process;
 unsigned char *cmdline = (unsigned char *) CMDLINE;
-unsigned char bootline[BOOTLINE_LEN];
 uint16_t ramsize, procmem, maxproc, nproc, nready;
 uint16_t runticks;
 bool inint;

--- a/Kernel/platform-n8vem-mark4/Makefile
+++ b/Kernel/platform-n8vem-mark4/Makefile
@@ -1,14 +1,16 @@
-CSRCS += devices.c main.c devtty.c devsdspi.c
-DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c ../dev/ds1302.c
-DDSRCS = ../dev/devide_discard.c ../dev/devsd_discard.c ../dev/ds1302_discard.c
 ASRCS = crt0.s z180.s commonmem.s mark4.s ds1302-mark4.s monitor.s
+CSRCS += devices.c main.c devtty.c devsdspi.c
+DISCARD_CSRCS = discard.c
+DISCARD_DSRCS = ../dev/devide_discard.c ../dev/devsd_discard.c ../dev/ds1302_discard.c
+DSRCS = ../dev/devide.c ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c ../dev/ds1302.c
 
 AOBJS = $(ASRCS:.s=.rel)
 COBJS = $(CSRCS:.c=.rel)
+DISCARD_COBJS = $(DISCARD_CSRCS:.c=.rel)
+DISCARD_DOBJS = $(patsubst ../dev/%.c,%.rel, $(DISCARD_DSRCS))
 DOBJS = $(patsubst ../dev/%.c,%.rel, $(DSRCS))
-DDOBJS = $(patsubst ../dev/%.c,%.rel, $(DDSRCS))
 
-OBJS  = $(AOBJS) $(COBJS) $(DOBJS) $(DDOBJS)
+OBJS  = $(AOBJS) $(COBJS) $(DOBJS) $(DISCARD_DOBJS) $(DISCARD_COBJS)
 
 CROSS_CCOPTS += -I../dev/
 
@@ -25,7 +27,10 @@ $(COBJS): %.rel: %.c
 $(DOBJS): %.rel: ../dev/%.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -c $<
 
-$(DDOBJS): %.rel: ../dev/%.c
+$(DISCARD_COBJS): %.rel: %.c
+	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
+
+$(DISCARD_DOBJS): %.rel: ../dev/%.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
 
 clean:

--- a/Kernel/platform-n8vem-mark4/README
+++ b/Kernel/platform-n8vem-mark4/README
@@ -27,7 +27,7 @@ load.
 The file "Kernel/platform-n8vem-mark4/diskboot.bin" is an UNA BIOS compatible
 boot sector which will allow the system to be booted directly from an IDE or SD
 drive. The boot sector will load the kernel image starting from the third
-sector of the drive.
+sector of the drive (ie counting from 0, sector number 2).
 
 The kernel image (fuzix.bin) should be written to the disk drive from the third
 sector onwards, in the space before the first partition starts. Be careful to
@@ -47,6 +47,20 @@ table, you can use dd as follows;
 To write the kernel image to the disk drive, use dd as follows;
     dd if=fuzix.bin bs=512 seek=2 of=/dev/sdX
 
+The root filesystem device can be specified as either a decimal number, or as a
+a device name (without the /dev prefix); hda, hdb, hda1, hda2, etc.
+
 When booting the system from both UNA BIOS and CP/M you can specify the root
-filesystem device number on the command line after the command name or unit
-number.
+filesystem device on the command line after the command name or unit number.
+
+For example, with root filesystem on /dev/hdb1 (minor #17) at the CP/M command
+prompt:
+
+    A> FUZIX hdb1
+or  A> FUZIX 17
+
+And to boot from unit 3 in UNA BIOS:
+
+    Boot UNA unit number or ROM? [R,X,0..3] (R): 3 hdb1
+or  Boot UNA unit number or ROM? [R,X,0..3] (R): 3 17
+

--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -14,6 +14,8 @@
 #define CONFIG_BANK_FIXED
 /* Permit large I/O requests to bypass cache and go direct to userspace */
 #define CONFIG_LARGE_IO_DIRECT
+/* Platform defined bootdevice() */
+#define CONFIG_BOOTDEVICE
 /* 8 60K banks, 1 is kernel */
 #define MAX_MAPS	8
 #define MAP_SIZE	0xF000U

--- a/Kernel/platform-n8vem-mark4/discard.c
+++ b/Kernel/platform-n8vem-mark4/discard.c
@@ -1,0 +1,76 @@
+#include <kernel.h>
+#include <kdata.h>
+#include <printf.h>
+#include <devtty.h>
+#include "config.h"
+#include <z180.h>
+
+void pagemap_init(void)
+{
+    int i;
+
+    /* N8VEM SBC Mark IV has RAM in the top 512K of physical memory. 
+     * First 64K is used by the kernel. 
+     * Each process gets the full 64K for now.
+     * Page size is 4KB. */
+    for(i = 0x90; i < 0x100; i+=0x10)
+        pagemap_add(i);
+}
+
+void map_init(void)
+{
+    /* clone udata and stack into a regular process bank, return with common memory
+       for the new process loaded */
+    copy_and_map_process(&init_process->p_page);
+    /* kernel bank udata (0x300 bytes) is never used again -- could be reused? */
+}
+
+uint16_t bootdevice(unsigned char *s)
+{
+    unsigned int b = 0, n = 0;
+    unsigned char c;
+    bool ok = false;
+
+    /* skip spaces */
+    while(*s == ' ')
+        s++;
+
+    /* we're expecting one of;
+     * hdX<num>
+     * fd<num>
+     * <num>
+     */
+
+
+    switch(*s | 32){
+        case 'f': /* fd */
+            b += 256;
+        case 'h': /* hd */
+            s++;
+            ok = true;
+            if((*s | 32) != 'd')
+                return -1;
+            s++;
+            if(b == 0){ /* hdX */
+                c = (*s | 32) - 'a';
+                if(c & 0xF0)
+                    return -1;
+                b += c << 4;
+                s++;
+            }
+            break;
+        default:
+            break;
+    }
+
+    while(*s >= '0' && *s <= '9'){
+        n = (n*10) + (*s - '0');
+        s++;
+        ok = true;
+    }
+
+    if(ok)
+        return (b + n);
+    else
+        return -1;
+}

--- a/Kernel/platform-n8vem-mark4/fuzix.lnk
+++ b/Kernel/platform-n8vem-mark4/fuzix.lnk
@@ -31,6 +31,7 @@ mm.rel
 bankfixed.rel
 swap.rel
 devsys.rel
+platform-n8vem-mark4/discard.rel
 platform-n8vem-mark4/devtty.rel
 platform-n8vem-mark4/devide.rel
 platform-n8vem-mark4/devide_discard.rel

--- a/Kernel/platform-n8vem-mark4/main.c
+++ b/Kernel/platform-n8vem-mark4/main.c
@@ -24,19 +24,6 @@ void z180_timer_interrupt(void)
     timer_interrupt();
 }
 
-
-void pagemap_init(void)
-{
-    int i;
-
-    /* N8VEM SBC Mark IV has RAM in the top 512K of physical memory. 
-     * First 64K is used by the kernel. 
-     * Each process gets the full 64K for now.
-     * Page size is 4KB. */
-    for(i = 0x90; i < 0x100; i+=0x10)
-        pagemap_add(i);
-}
-
 void platform_idle(void)
 {
     /* Let's go to sleep while we wait for something to interrupt us;
@@ -61,12 +48,4 @@ void platform_interrupt(void)
         default:
             return;
     }
-}
-
-void map_init(void)
-{
-    /* clone udata and stack into a regular process bank, return with common memory
-       for the new process loaded */
-    copy_and_map_process(&init_process->p_page);
-    /* kernel bank udata (0x300 bytes) is never used again -- could be reused? */
 }

--- a/Kernel/platform-p112/Makefile
+++ b/Kernel/platform-p112/Makefile
@@ -1,14 +1,16 @@
-CSRCS += devices.c main.c devtty.c devfd.c
-DSRCS = ../dev/blkdev.c ../dev/devide.c ../dev/mbr.c ../dev/ds1302.c
-DDSRCS = ../dev/devide_discard.c ../dev/ds1302_discard.c
 ASRCS = crt0.s z180.s commonmem.s p112.s ds1302-p112.s devfd2.s monitor.s flopboot.s
+CSRCS += devices.c main.c devtty.c devfd.c
+DISCARD_CSRCS = discard.c
+DISCARD_DSRCS = ../dev/devide_discard.c ../dev/ds1302_discard.c
+DSRCS = ../dev/blkdev.c ../dev/devide.c ../dev/mbr.c ../dev/ds1302.c
 
 AOBJS = $(ASRCS:.s=.rel)
 COBJS = $(CSRCS:.c=.rel)
+DISCARD_COBJS = $(DISCARD_CSRCS:.c=.rel)
+DISCARD_DOBJS = $(patsubst ../dev/%.c,%.rel, $(DISCARD_DSRCS))
 DOBJS = $(patsubst ../dev/%.c,%.rel, $(DSRCS))
-DDOBJS = $(patsubst ../dev/%.c,%.rel, $(DDSRCS))
 
-OBJS  = $(AOBJS) $(COBJS) $(DOBJS) $(DDOBJS)
+OBJS  = $(AOBJS) $(COBJS) $(DOBJS) $(DISCARD_DOBJS) $(DISCARD_COBJS)
 
 CROSS_CCOPTS += -I../dev/
 
@@ -25,7 +27,10 @@ $(COBJS): %.rel: %.c
 $(DOBJS): %.rel: ../dev/%.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -c $<
 
-$(DDOBJS): %.rel: ../dev/%.c
+$(DISCARD_COBJS): %.rel: %.c
+	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
+
+$(DISCARD_DOBJS): %.rel: ../dev/%.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
 
 clean:

--- a/Kernel/platform-p112/README
+++ b/Kernel/platform-p112/README
@@ -36,4 +36,6 @@ floppy boot sector can read the kernel directly out of a Fuzix file system on
 the floppy disk.
 
 When booting the system from CP/M you can specify the root filesystem device
-number on the command line after the command name.
+number on the command line after the command name. This can be specified as
+either a decimal number, or as a a device name (without the /dev prefix). For
+example hda, hdb, hda1, hda2, fd0, fd1, etc.

--- a/Kernel/platform-p112/config.h
+++ b/Kernel/platform-p112/config.h
@@ -14,6 +14,8 @@
 #define CONFIG_BANK_FIXED
 /* Permit large I/O requests to bypass cache and go direct to userspace */
 #define CONFIG_LARGE_IO_DIRECT
+/* Platform defined bootdevice() */
+#define CONFIG_BOOTDEVICE
 /* 8 60K banks, 1 is kernel */
 #define MAX_MAPS	16
 #define MAP_SIZE	0xF000U

--- a/Kernel/platform-p112/discard.c
+++ b/Kernel/platform-p112/discard.c
@@ -1,0 +1,80 @@
+#include <kernel.h>
+#include <kdata.h>
+#include <printf.h>
+#include <devtty.h>
+#include <z180.h>
+#include "config.h"
+#ifdef CONFIG_P112_FLOPPY
+#include "devfd.h"
+#endif
+
+void pagemap_init(void)
+{
+    int i;
+
+    /* P112 has RAM across the full physical 1MB address space
+     * First 64K is used by the kernel. 
+     * Each process gets the full 64K for now.
+     * Page size is 4KB. */
+    for(i = 0x10; i < 0x100; i+=0x10){
+        pagemap_add(i);
+    }
+}
+
+void map_init(void)
+{
+    /* clone udata and stack into a regular process bank, return with common memory
+       for the new process loaded */
+    copy_and_map_process(&init_process->p_page);
+    /* kernel bank udata (0x300 bytes) is never used again -- could be reused? */
+}
+
+uint16_t bootdevice(unsigned char *s)
+{
+    unsigned int b = 0, n = 0;
+    unsigned char c;
+    bool ok = false;
+
+    /* skip spaces */
+    while(*s == ' ')
+        s++;
+
+    /* we're expecting one of;
+     * hdX<num>
+     * fd<num>
+     * <num>
+     */
+
+
+    switch(*s | 32){
+        case 'f': /* fd */
+            b += 256;
+        case 'h': /* hd */
+            s++;
+            ok = true;
+            if((*s | 32) != 'd')
+                return -1;
+            s++;
+            if(b == 0){ /* hdX */
+                c = (*s | 32) - 'a';
+                if(c & 0xF0)
+                    return -1;
+                b += c << 4;
+                s++;
+            }
+            break;
+        default:
+            break;
+    }
+
+    while(*s >= '0' && *s <= '9'){
+        n = (n*10) + (*s - '0');
+        s++;
+        ok = true;
+    }
+
+    if(ok)
+        return (b + n);
+    else
+        return -1;
+}

--- a/Kernel/platform-p112/fuzix.lnk
+++ b/Kernel/platform-p112/fuzix.lnk
@@ -31,6 +31,7 @@ mm.rel
 bankfixed.rel
 swap.rel
 devsys.rel
+platform-p112/discard.rel
 platform-p112/devtty.rel
 platform-p112/devide.rel
 platform-p112/devide_discard.rel

--- a/Kernel/platform-p112/main.c
+++ b/Kernel/platform-p112/main.c
@@ -26,20 +26,6 @@ void z180_timer_interrupt(void)
     timer_interrupt();
 }
 
-
-void pagemap_init(void)
-{
-    int i;
-
-    /* P112 has RAM across the full physical 1MB address space
-     * First 64K is used by the kernel. 
-     * Each process gets the full 64K for now.
-     * Page size is 4KB. */
-    for(i = 0x10; i < 0x100; i+=0x10){
-        pagemap_add(i);
-    }
-}
-
 void platform_idle(void)
 {
     /* Let's go to sleep while we wait for something to interrupt us;
@@ -68,12 +54,4 @@ void platform_interrupt(void)
             kprintf("[int:%d?]", irqvector);
             return;
     }
-}
-
-void map_init(void)
-{
-    /* clone udata and stack into a regular process bank, return with common memory
-       for the new process loaded */
-    copy_and_map_process(&init_process->p_page);
-    /* kernel bank udata (0x300 bytes) is never used again -- could be reused? */
 }


### PR DESCRIPTION
With these changes you can specify (eg) "hdb1" or "fd0" at the boot device prompt (or on the command line). Backward compatible with the old numeric parsing.