### PR TITLE
move keyboard matrices to discard

### DIFF
--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -1,6 +1,6 @@
 
-DSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c 
-CSRCS = devfd.c devhd.c devlpr.c
+CSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c
+CSRCS += devfd.c devhd.c devlpr.c
 CSRCS += devices.c main.c devtty.c ../dev/rp5c01.c devrtc.c
 COMMON_CSRCS = devmegasd.c
 DISCARD_CSRCS = discard.c

--- a/Kernel/platform-msx2/devtty.c
+++ b/Kernel/platform-msx2/devtty.c
@@ -22,66 +22,8 @@ struct s_queue ttyinq[NUM_DEV_TTY + 1] = {	/* ttyinq[0] is never used */
 	{tbuf2, tbuf2, tbuf2, TTYSIZ, 0, TTYSIZ / 2}
 };
 
-/*
- * International key matrix
- */
-uint8_t keyboard[11][8] = {
-	{'0','1','2', '3','4','5','6','7'},
-	{'8','9','-','=','\\','[',']',';'},
-	{ 39, '`', ',', '.','/',' ','a','b'},
-	{'c','d','e', 'f','g','h','i','j'},
-	{'k','l','m', 'n','o','p','q','r'},
-	{'s','t','u', 'v','w','x','y','z'},
-	{0/*SHIFT*/,0/*CTRL*/,0/*GRPH*/,0/*CAPS*/,0/*CODE*/ , KEY_F3 , KEY_F2 , KEY_F1 },
-	{KEY_F4 , KEY_F5,  KEY_ESC , '\t', KEY_STOP ,KEY_BS , 0 , 13},
-	{32 , KEY_HOME,  KEY_INSERT , KEY_DEL, KEY_LEFT , KEY_UP , KEY_DOWN , KEY_RIGHT},
-	{'*','+','/','0','1' ,'2','3','4'},
-	{'5','6','7','8','9' ,'-',',','.'}
-};
-
-uint8_t shiftkeyboard[11][8] = {
-	{')','!','@', '#','$','%','^','&'},
-	{'*','(','_','+','|','{','}',':'},
-	{'"','~','<','>','?',' ','A','B'},
-	{'C','D','E', 'F','G','H','I','J'},
-	{'K','L','M', 'N','O','P','Q','R'},
-	{'S','T','U', 'V','W','X','Y','Z'},
-	{0/*SHIFT*/,0/*CTRL*/,0/*GRPH*/,0/*CAPS*/,0/*CODE*/, KEY_F3 , KEY_F2 , KEY_F1 },
-	{KEY_F4 , KEY_F5,  KEY_ESC , '\t', KEY_STOP ,KEY_BS , 0/*SELECT*/ , 13},
-	{32 ,KEY_HOME,  KEY_INSERT , KEY_DEL, KEY_LEFT , KEY_UP , KEY_DOWN , KEY_RIGHT},
-	{'*','+','/','0','1' ,'2','3','4'},
-	{'5','6','7','8','9' ,'-',',','.'}
-};
-
-/*
- * Japan
- */
-uint8_t keyboard_jp[3][8] = {
-	{'0','1','2', '3','4','5','6','7'},
-	{'8','9','-','^',KEY_YEN,'@','[',';'},
-	{':',']', ',', '.','/',' ','a','b'}};
-
-uint8_t shiftkeyboard_jp[3][8] = {
-	{' ','!','"', '#','$','%','&',39},
-	{'(',')','=','~','|','`','{','+'},
-	{'*','}','<','>','?','_','A','B'}};
-/*
- * UK
- */
-uint8_t shiftkeyboard_uk[1][8] = {
-	{39,'`', ',', '.','/',KEY_POUND,'A','B'}};  /* row 2 */
-
-/*
- * Spanish
- */
-uint8_t keyboard_es[2][8] = {
-	{'8','9','-','=','\\','[',']', 'N'/* Ñ */}, /* row 1 */
-	{39, ':', ',', '.','/',' ','a','b'}};
-
-uint8_t shiftkeyboard_es[2][8] = {
-	{'*','(','_','+','|','{','}', 'n' /* ñ */},  /* row 1 */
-	{'"',':','<','>','?',' ','A','B'}};
-
+uint8_t keyboard[11][8];
+uint8_t shiftkeyboard[11][8];
 
 /* tty1 is the screen tty2 is the debug port */
 
@@ -126,19 +68,7 @@ void tty_setup(uint8_t minor)
 	ttydata[1].termios.c_cc[VERASE] = KEY_BS;
 	ttydata[1].termios.c_cc[VSTOP] = KEY_STOP;
 	ttydata[1].termios.c_cc[VSTART] = KEY_STOP;
-
-	/* keyboard layout selection: default is international */
-	if ((infobits & KBDTYPE_MASK) == KBDTYPE_JPN) {
-	    memcpy(keyboard, keyboard_jp, 24);
-	    memcpy(shiftkeyboard, shiftkeyboard_jp, 24);
-	} else if ((infobits & KBDTYPE_MASK) == KBDTYPE_UK) {
-	    memcpy(&shiftkeyboard[2][0],shiftkeyboard_uk,8);
-	} else if ((infobits & KBDTYPE_MASK) == KBDTYPE_ES) {
-	    memcpy(&keyboard[1][0], keyboard_es, 16);
-	    memcpy(&shiftkeyboard[1][0], shiftkeyboard_es, 16);
-	}
 }
-
 
 uint8_t keymap[11];
 static uint8_t keyin[11];

--- a/Kernel/platform-msx2/discard.c
+++ b/Kernel/platform-msx2/discard.c
@@ -2,7 +2,11 @@
 #include <kdata.h>
 #include <devsd.h>
 #include <printf.h>
+#include <vt.h>
+#include <tty.h>
 #include "msx2.h"
+#include "devtty.h"
+#include "kbdmatrix.h"
 
 extern int megasd_probe();
 
@@ -14,8 +18,7 @@ void device_init(void)
 
     kprintf ("Running on a ");
     if (machine_type == MACHINE_MSX1) {
-	kprintf("MSX1 not supported\n");
-	// hang!
+	panic("MSX1 not supported\n");
     } else if (machine_type == MACHINE_MSX2) {
 	kprintf("MSX2 ");
     } else if (machine_type == MACHINE_MSX2P) {
@@ -24,11 +27,26 @@ void device_init(void)
 	kprintf("MSX TurboR ");
     }
 
+    /* keyboard layout initialization: default is international,
+     * localized variations overlay on top */
+    memcpy(keyboard, keyboard_int, sizeof(keyboard_int));
+    memcpy(shiftkeyboard, shiftkeyboard_int, sizeof(shiftkeyboard_int));
+
     if ((infobits & KBDTYPE_MASK) == KBDTYPE_JPN) {
-	kprintf("JP ");
+	kprintf("JPN ");
+	memcpy(keyboard, keyboard_jp, sizeof(keyboard_jp));
+	memcpy(shiftkeyboard, shiftkeyboard_jp, sizeof(shiftkeyboard_jp));
+    } else if ((infobits & KBDTYPE_MASK) == KBDTYPE_UK) {
+	kprintf("UK ");
+	memcpy(&shiftkeyboard[2][0],shiftkeyboard_uk, sizeof(shiftkeyboard_uk));
+    } else if ((infobits & KBDTYPE_MASK) == KBDTYPE_ES) {
+	kprintf("ES ");
+	memcpy(&keyboard[1][0], keyboard_es, sizeof(keyboard_es));
+	memcpy(&shiftkeyboard[1][0], shiftkeyboard_es, sizeof(shiftkeyboard_es));
     } else {
 	kprintf("INT ");
     }
+
     if ((infobits & INTFREQ_MASK) == INTFREQ_60Hz) {
 	kprintf("60Hz\n");
 	ticks_per_dsecond = 6;

--- a/Kernel/platform-msx2/kbdmatrix.h
+++ b/Kernel/platform-msx2/kbdmatrix.h
@@ -1,0 +1,64 @@
+#ifndef __KBDMATRIX_DOT_H__
+#define __KBDMATRIX_DOT_H__
+/*
+ * International key matrix
+ */
+const uint8_t keyboard_int[11][8] = {
+	{'0','1','2', '3','4','5','6','7'},
+	{'8','9','-','=','\\','[',']',';'},
+	{ 39, '`', ',', '.','/',' ','a','b'},
+	{'c','d','e', 'f','g','h','i','j'},
+	{'k','l','m', 'n','o','p','q','r'},
+	{'s','t','u', 'v','w','x','y','z'},
+	{0/*SHIFT*/,0/*CTRL*/,0/*GRPH*/,0/*CAPS*/,0/*CODE*/ , KEY_F3 , KEY_F2 , KEY_F1 },
+	{KEY_F4 , KEY_F5,  KEY_ESC , '\t', KEY_STOP ,KEY_BS , 0 , 13},
+	{32 , KEY_HOME,  KEY_INSERT , KEY_DEL, KEY_LEFT , KEY_UP , KEY_DOWN , KEY_RIGHT},
+	{'*','+','/','0','1' ,'2','3','4'},
+	{'5','6','7','8','9' ,'-',',','.'}
+};
+
+const uint8_t shiftkeyboard_int[11][8] = {
+	{')','!','@', '#','$','%','^','&'},
+	{'*','(','_','+','|','{','}',':'},
+	{'"','~','<','>','?',' ','A','B'},
+	{'C','D','E', 'F','G','H','I','J'},
+	{'K','L','M', 'N','O','P','Q','R'},
+	{'S','T','U', 'V','W','X','Y','Z'},
+	{0/*SHIFT*/,0/*CTRL*/,0/*GRPH*/,0/*CAPS*/,0/*CODE*/, KEY_F3 , KEY_F2 , KEY_F1 },
+	{KEY_F4 , KEY_F5,  KEY_ESC , '\t', KEY_STOP ,KEY_BS , 0/*SELECT*/ , 13},
+	{32 ,KEY_HOME,  KEY_INSERT , KEY_DEL, KEY_LEFT , KEY_UP , KEY_DOWN , KEY_RIGHT},
+	{'*','+','/','0','1' ,'2','3','4'},
+	{'5','6','7','8','9' ,'-',',','.'}
+};
+
+/*
+ * Japan overlay
+ */
+const uint8_t keyboard_jp[3][8] = {
+	{'0','1','2', '3','4','5','6','7'},
+	{'8','9','-','^',KEY_YEN,'@','[',';'},
+	{':',']', ',', '.','/',' ','a','b'}};
+
+const uint8_t shiftkeyboard_jp[3][8] = {
+	{' ','!','"', '#','$','%','&',39},
+	{'(',')','=','~','|','`','{','+'},
+	{'*','}','<','>','?','_','A','B'}};
+/*
+ * UK overlay
+ */
+const uint8_t shiftkeyboard_uk[1][8] = {
+	{39,'`', ',', '.','/',KEY_POUND,'A','B'}};  /* row 2 */
+
+/*
+ * Spanish overlay
+ */
+const uint8_t keyboard_es[2][8] = {
+	{'8','9','-','=','\\','[',']', 'N'/* Ñ */}, /* row 1 */
+	{39, ':', ',', '.','/',' ','a','b'}};
+
+const uint8_t shiftkeyboard_es[2][8] = {
+	{'*','(','_','+','|','{','}', 'n' /* ñ */},  /* row 1 */
+	{'"',':','<','>','?',' ','A','B'}};
+
+
+#endif


### PR DESCRIPTION
also move some code to CODE2 to avoid overlapping of BOOT.

I think I will prepare a patch to switch to a banked rom cartridge instead of the linear one we have now; that will solve the problem of overlaps and will also make the bootstrap discardable.