### PR TITLE
msx2: generate 8k banked ascii rom

### DIFF
--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -44,4 +44,5 @@ clean:
 
 image:
 	dd if=../fuzix.bin of=../fuzix.com bs=256 skip=1
-	dd if=../fuzix.bin of=../fuzix.rom bs=16384 conv=sync
+	dd if=../fuzix_boot.bin of=../fuzix.ascii8.rom skip=1 bs=16384 conv=sync
+	dd if=../fuzix.bin of=../fuzix.ascii8.rom seek=1 bs=16384 conv=sync

--- a/Kernel/platform-msx2/crt0.s
+++ b/Kernel/platform-msx2/crt0.s
@@ -31,6 +31,9 @@
 	        .globl l__COMMONMEM
 		.globl s__INITIALIZER
 	        .globl kstack_top
+		.globl _ramsize
+		.globl _procmem
+		.globl _msxmaps
 
 		; Just for the benefit of the map file
 		.globl start
@@ -60,12 +63,13 @@ start:
 		ld a, #'@'
 		out (OPENMSX_DEBUG2), a
 		;
-		; unstash info bits
+		; unstash info bits and memory size
 		;
 		pop af
 		pop hl
 		pop bc
 		pop de
+		pop ix
 
 		ld sp, #kstack_top
 		;
@@ -105,6 +109,22 @@ start:
 		ld bc, #l__DATA - 1
 		ld (hl), #0
 		ldir
+
+		; finally update memory size
+		;
+		push ix
+		pop hl
+		ld (_msxmaps), hl
+		add hl, hl			; x 16 for Kb
+		add hl, hl
+		add hl, hl
+		add hl, hl
+
+		; set system RAM size in KB
+		ld (_ramsize), hl
+		ld de, #0xFFD0
+		add hl, de			; subtract 48K for the kernel
+		ld (_procmem), hl
 
 		call init_early
 		call init_hardware

--- a/Kernel/platform-msx2/fuzix.lnk
+++ b/Kernel/platform-msx2/fuzix.lnk
@@ -1,11 +1,9 @@
 -mwxuy
 -i fuzix.ihx
 -b _CODE=0x0000
--b _BOOT=0x4000
 -b _COMMONMEM=0xF000
 -b _DISCARD=0xE000
 -l z80
-platform-msx2/bootrom.rel
 platform-msx2/crt0.rel
 platform-msx2/commonmem.rel
 platform-msx2/msx2.rel

--- a/Kernel/platform-msx2/fuzix_boot.lnk
+++ b/Kernel/platform-msx2/fuzix_boot.lnk
@@ -1,0 +1,6 @@
+-mwxuy
+-i fuzix_boot.ihx
+-b _BOOT=0x4000
+-l z80
+platform-msx2/bootrom.rel
+-e

--- a/Kernel/platform-msx2/image.mk
+++ b/Kernel/platform-msx2/image.mk
@@ -1,0 +1,14 @@
+fuzix.ihx: target $(OBJS) platform-$(TARGET)/fuzix.lnk tools/bankld/sdldz80
+	$(CROSS_LD) -n -k $(LIBZ80) -f platform-$(TARGET)/fuzix.lnk
+	$(CROSS_LD) -n -k $(LIBZ80) -f platform-$(TARGET)/fuzix_boot.lnk
+
+fuzix.bin: fuzix.ihx bootrom.bin tools/bihx tools/analysemap tools/memhogs tools/binman tools/bintomdv cpm-loader/cpmload.bin
+	-cp hogs.txt hogs.txt.old
+	tools/memhogs <fuzix.map |sort -nr >hogs.txt
+	head -5 hogs.txt
+	tools/bihx fuzix.ihx
+	tools/analysemap <fuzix.map
+	tools/binman common.bin fuzix.map fuzix.bin
+	tools/bihx fuzix_boot.ihx
+	-cp common.bin fuzix_boot.bin
+	+make -C platform-$(TARGET) image

--- a/Kernel/platform-msx2/msx2.def
+++ b/Kernel/platform-msx2/msx2.def
@@ -12,3 +12,32 @@ RAM_PAGE0		    .equ 0xFC         ; memory mapper registers
 RAM_PAGE1		    .equ 0xFD
 RAM_PAGE2		    .equ 0xFE
 RAM_PAGE3		    .equ 0xFF
+
+;
+; ASCII 8Kb Mapper addresses
+;
+ASCII8_PAGE0_BASE	    .equ 0x4000
+ASCII8_PAGE1_BASE	    .equ 0x6000
+ASCII8_PAGE2_BASE	    .equ 0x8000
+ASCII8_PAGE3_BASE	    .equ 0xA000
+
+ASCII8_ROM_PAGE0	    .equ 0x6000
+ASCII8_ROM_PAGE1	    .equ 0x6800
+ASCII8_ROM_PAGE2	    .equ 0x7000
+ASCII8_ROM_PAGE3	    .equ 0x7800
+
+;
+; BIOS machine info addresses
+;
+BIOS_VERSION1		    .equ 0x002B
+BIOS_VERSION2		    .equ 0x002C
+BIOS_MACHINE_TYPE	    .equ 0x002D
+BIOS_VDP_IOPORT		    .equ 0x0006
+
+;
+; OpenMSX Debug ports
+;
+OPENMSX_DEBUG1		    .equ 0x2E
+OPENMSX_DEBUG2		    .equ 0x2F
+
+

--- a/Kernel/platform-msx2/msx2.s
+++ b/Kernel/platform-msx2/msx2.s
@@ -15,6 +15,7 @@
 	    .globl map_process_always
 	    .globl map_save
 	    .globl map_restore
+	    .globl enaslt
 	    .globl _mapslot_bank1
 	    .globl _mapslot_bank2
 	    .globl _kernel_flag
@@ -314,18 +315,15 @@ map_save:   push hl
 ;   can be in bank1 or 2 because those are the ones usually used to
 ;   map the io ports.
 ;
-;   XXX: this code is duplicated in _BOOT, but I see no way to remove it from
-;         from there and still be able to boot; specially if we have a >48Kb kernel
-
 		.area _CODE
 
 _mapslot_bank1:
 		ld hl,#0x4000
-		jp mapslot
+		jr enaslt
 _mapslot_bank2:
 		ld hl,#0x8000
-		jp mapslot
-mapslot:
+
+enaslt:
 		call setprm         ; calculate bit pattern and mask code
 		jp m, mapsec        ; if expanded set secondary first
 		in a,(0xa8)
@@ -338,7 +336,7 @@ mapsec:
 		; here need to store the slot that is being set....
 		call setexp         ; set secondary slot
 		pop hl
-		jr mapslot
+		jr enaslt
 
 		; calculate bit pattern and mask
 setprm:

--- a/Kernel/platform-msx2/msx2.s
+++ b/Kernel/platform-msx2/msx2.s
@@ -27,11 +27,6 @@
             .globl _trap_monitor
             .globl outchar
 
-            ; imported symbols
-            .globl _ramsize
-            .globl _procmem
-	    .globl _msxmaps
-
             .globl _tty_inproc
             .globl unix_syscall_entry
             .globl trap_illegal
@@ -98,9 +93,6 @@ init_early:
 	    ret
 
 init_hardware:
-	    ; Size RAM
-	    call size_memory
-
             ; set up interrupt vectors for the kernel mapped low page and
             ; data area
             ld hl, #0
@@ -132,68 +124,6 @@ init_hardware:
 ; COMMON MEMORY PROCEDURES FOLLOW
 
             .area _COMMONMEM
-
-;
-; Size currently selected memory mapper (this should be done during bootstrap)
-;
-size_memory:
-	    ld bc, #0x03FC		; make sure ram page 3 is selected
-	    out (c), b
-	    ld hl, #0x3FFF		; careful, there is code in page 3
-	    ld (hl), #0xAA		; we know there is a low page!
-	    ld bc, #0x04FC		; continue with page 4
-ramscan_2:
-	    ld a, #0xAA
-ramscan:
-	    out (c), b
-	    cp (hl)			; is it 0xAA
-	    jr z, ramwrapped		; we've wrapped (hopefully)
-	    inc b
-	    jr nz, ramscan
-	    jr ramerror			; not an error we *could* have 256 pages!
-ramwrapped:
-	    ld a, #3
-	    out (c), a
-	    ld (hl), #0x55
-	    out (c), b
-	    ld a, (hl)
-	    cp #0x55
-	    jr z, ramerror		; Cool we wrapped both change to 0x55
-	    ; Fluke RAM was 0xAA already
-	    ld a, #3
-	    out (c), a
-	    ld a, #0xAA
-	    ld (hl), a			; put the marker back as 0xAA
-	    inc b
-	    jr nz, ramscan_2		; Continue our memory walk
-ramerror:   				; Ok so there are 256-b-3 pages of 16K)
-	    ld a,#3
-	    out (c), a			; always put page 0 back
-	    ;
-	    ;	Address map back to normal so can update kernel data
-	    ;
-	    dec b			; take into account we started at page 3
-	    dec b
-	    dec b
-	    ld l, b
-	    ld h, #0
-	    ld a, l
-	    or a			; zero count -> 256 pages
-	    jr nz, pageslt256
-	    inc h
-pageslt256:
-	    ld (_msxmaps), hl
-	    add hl, hl			; x 16 for Kb
-	    add hl, hl
-	    add hl, hl
-	    add hl, hl
-
-	    ; set system RAM size in KB
-	    ld (_ramsize), hl
-	    ld de, #0xFFD0
-	    add hl, de			; subtract 48K for the kernel
-	    ld (_procmem), hl
-	    ret
 
 _program_vectors:
             ; we are called, with interrupts disabled, by both newproc() and crt0


### PR DESCRIPTION
Switching to a banked rom simplifies the bootstrap, allows us to
discard it and also opens the possibility of appending a romfs
after the kernel