### PR TITLE
zeta-v2: RAM disk cleanup, README fixes

### DIFF
--- a/Kernel/platform-zeta-v2/README
+++ b/Kernel/platform-zeta-v2/README
@@ -113,5 +113,5 @@ cat fuzix_48k.rom zeta_v2_rootfs.img > fuzix_zeta_v2_bootfs.rom
 6. Program the image (fuzix_zeta_v2_bootfs.rom) to the Flash ROM using an
 EPROM programmer
 
-7. Power on the the system. At bootdev: prompt enter either or device number 256 to boot from the RAM disk.
+7. Power on the the system. At bootdev: prompt enter either rd0 or device number 256 to boot from the RAM disk.
 

--- a/Kernel/platform-zeta-v2/README
+++ b/Kernel/platform-zeta-v2/README
@@ -107,11 +107,11 @@ chmod 0755 umount
 exit
 
 5. Create ROM image:
-dd if=fuzix.rom of=fuzix_48k.rom bs=48k count=1 conv=syn
+dd if=fuzix.rom of=fuzix_48k.rom bs=48k count=1 conv=sync
 cat fuzix_48k.rom zeta_v2_rootfs.img > fuzix_zeta_v2_bootfs.rom
 
 6. Program the image (fuzix_zeta_v2_bootfs.rom) to the Flash ROM using an
 EPROM programmer
 
-7. Power on the the system. Enter device number 256 to boot from the RAM disk.
+7. Power on the the system. At bootdev: prompt enter either or device number 256 to boot from the RAM disk.
 

--- a/Kernel/platform-zeta-v2/README
+++ b/Kernel/platform-zeta-v2/README
@@ -53,10 +53,10 @@ mknod tty1  20660 513
 mknod tty2  20660 514
 mknod tty3  20660 515
 mknod tty4  20660 516
-mknod hda   60660 0
-mknod hda1  60660 1
-mknod fd0   60660 256
-mknod fd1   60660 257
+mknod fd0   60660 0
+mknod fd1   60660 1
+mknod rd0   60660 256
+mknod rd1   60660 257
 mknod null  20666 1024
 mknod mem   20660 1025
 mknod zero  20444 1026

--- a/Kernel/platform-zeta-v2/config.h
+++ b/Kernel/platform-zeta-v2/config.h
@@ -35,7 +35,7 @@
 
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL  /* Location of root dev name */
-#define BOOTDEVICENAMES "fd,hd#"
+#define BOOTDEVICENAMES "fd,rd"
 
 //#define SWAPDEV  (256 + 1)  /* Device for swapping */
 #define NBUFS    10       /* Number of block buffers */

--- a/Kernel/platform-zeta-v2/devrd.c
+++ b/Kernel/platform-zeta-v2/devrd.c
@@ -98,9 +98,7 @@ int ramdisk_transfer(bool is_read, uint8_t minor, uint8_t rawflag)
 #ifdef DEBUG
 		kprintf("page_cpy(src_page=%x, src_offset=%x, dst_page=%x, dst_offset=%x, cpy_count=%x)\n", src_page, src_offset, dst_page, dst_offset, cpy_count);
 #endif
-		__critical {
-			page_copy();
-		}
+		page_copy();
 		xfer_count -= cpy_count;
 		buffer_addr += cpy_count;
 		rd_addr += cpy_count;

--- a/Kernel/platform-zeta-v2/devrd_hw.s
+++ b/Kernel/platform-zeta-v2/devrd_hw.s
@@ -1,7 +1,7 @@
 	.module devrd_hw
 
 	; imported symbols - from zeta-v2.s
-	.globl map_table
+	.globl map_kernel,mpgsel_cache
 
 	; exported symbols (used by devrd.c)
 	.globl _page_copy
@@ -19,15 +19,16 @@
 ;   _dst_page - page number of the destination page (uint8_t)
 ;   _dst_offset - offset in the destination page (uint16_t)
 ;   _cpy_count - number of bytes to copy (uint16_t)
-;   map_table - current page register values, used to restore paging registers
 ; Outputs:
 ;   Data copied
 ;   Destroys AF, BC, DE, HL
 ;=========================================================================
 _page_copy:
 	ld a,(_src_page)
+	ld (mpgsel_cache+1),a		; save the mapping
 	out (MPGSEL_1),a		; map source page to bank #1
 	ld a,(_dst_page)
+	ld (mpgsel_cache+2),a		; save the mapping
 	out (MPGSEL_2),a		; map destination page to bank #2
 	ld hl,(_src_offset)		; load offset in source page
 	ld a,#0x40			; add bank #1 offset - 0x4000
@@ -39,10 +40,7 @@ _page_copy:
 	ld d,a
 	ld bc,(_cpy_count)		; bytes to copy
 	ldir				; do the copy
-	ld a,(map_table+1)
-	out (MPGSEL_1),a		; restore the mapping of bank #1
-	ld a,(map_table+2)
-	out (MPGSEL_2),a		; restore the mapping of bank #2
+	call map_kernel			; map the kernel
 	ret
 
 ; variables

--- a/Kernel/platform-zeta-v2/tricks.s
+++ b/Kernel/platform-zeta-v2/tricks.s
@@ -18,6 +18,7 @@
         .globl interrupt_handler
 	.globl map_kernel
 	.globl _ramtop
+	.globl mpgsel_cache
 
         ; imported debug symbols
         .globl outstring, outde, outhl, outbc, outnewline, outchar, outcharhex
@@ -232,6 +233,7 @@ fork_next:
 	call map_kernel		; put the maps back so we can look in p_tab
 	djnz fork_next
 	ld a, c
+	ld (mpgsel_cache+3),a	; cache the page number
 	out (MPGSEL_3), a	; our last bank repeats up to common
 	; --- we are now on the stack copy, parent stack is locked away ---
 	ret			; this stack is copied so safe to return on

--- a/Kernel/platform-zeta-v2/zeta-v2.s
+++ b/Kernel/platform-zeta-v2/zeta-v2.s
@@ -14,8 +14,8 @@
 	.globl map_restore
 	.globl _kernel_flag
 	.globl _irqvector
-        .globl platform_interrupt_all
-	.globl map_table
+	.globl platform_interrupt_all
+	.globl mpgsel_cache
 	.globl _kernel_pages
 
         ; imported symbols
@@ -245,7 +245,7 @@ map_kernel:
 map_process_2:
 	push de
 	push af
-	ld de,#map_table		; paging registers are write only
+	ld de,#mpgsel_cache		; paging registers are write only
 					; so cache their content in RAM
 	ld a,(hl)			; memory page number for bank #0
 	ld (de),a
@@ -277,25 +277,30 @@ map_restore:
 	ret
 
 ;=========================================================================
-; map_save - save the current page mapping
+; map_save - save the current page mapping to map_savearea
 ; Inputs: none
 ; Outputs: none
 ;=========================================================================
 map_save:
 	push hl
-	ld hl,(map_table)
+	ld hl,(mpgsel_cache)
 	ld (map_savearea),hl
-	ld hl,(map_table+2)
+	ld hl,(mpgsel_cache+2)
 	ld (map_savearea+2),hl
 	pop hl
 	ret
 
-map_table:
-	.db	32,33,34,35
+; MPGSEL registers are read only, so their content is cached here
+mpgsel_cache:
+	.db	0,0,0,0
+
+; kernel page mapping
 _kernel_pages:
 	.db	32,33,34,35
+
+; memory page mapping save area for map_save/map_restore
 map_savearea:
-	.db	32,33,34,35
+	.db	0,0,0,0
 
 ; has to live in common
 _kernel_flag:


### PR DESCRIPTION
As discussed I modified RAM disk code to update the MPGSEL (MMU page select) registers cache, so that now it can run with interrupts enabled (in case of interrupt map_save will have valid page numbers).
It also has several other minor fixes:
* rd added to BOOTDEVICENAMES
* README updates:
  - Updated device names and numbers for block devices
  - rd0 can be used as a boot device
  - Fixed cut-and-paste error in dd command line
