### PR TITLE
Remove scanf dependencies to reduce the size of the apps

### DIFF
--- a/Applications/util/df.c
+++ b/Applications/util/df.c
@@ -6,6 +6,9 @@
 #include <dirent.h>
 #include <errno.h>
 
+/* Assumed length of a line in /etc/mtab */
+#define MTAB_LINE 160
+
 const char *devname(dev_t);
 const char *mntpoint(const char *);
 void df_path(const char *path);
@@ -116,13 +119,15 @@ void df_dev(dev_t dev)
 void df_all(void)
 {
     FILE *f;
-    static char tmp[256];
-    static char dev[20], mntpt[20], fstype[20], rwflag[20];
+	char tmp[MTAB_LINE];
+	char* dev;
+	char* mntpt;
     
     f = fopen("/etc/mtab", "r");
     if (f) {
-        while (fgets(tmp, 256, f)) {
-            sscanf(tmp, "%s %s %s %s\n", dev, mntpt, fstype, rwflag);
+        while (fgets(tmp, sizeof(MTAB_LINE), f)) {
+			dev = strtok(tmp, " ");
+			mntpt = strtok(NULL, " ");
             df_path(mntpt);
         }
         fclose(f);
@@ -164,16 +169,18 @@ const char *devname(dev_t devno)
 const char *mntpoint(const char *devname)
 {
     FILE *f;
-    static char tmp[256];
-    static char dev[20], mntpt[20], fstype[20], rwflag[20];
+	char tmp[MTAB_LINE];
+	char* dev;
+	char* mntpt;
     
     f = fopen("/etc/mtab", "r");
     if (f) {
-        while (fgets(tmp, 256, f)) {
-            sscanf(tmp, "%s %s %s %s\n", dev, mntpt, fstype, rwflag);
+        while (fgets(tmp, sizeof(tmp), f)) {
+			dev = strtok(tmp, " ");
+			mntpt = strtok(NULL, " ");
             if (strcmp(dev, devname) == 0) {
                 fclose(f);
-                return mntpt;
+                return strdup(mntpt);
             }
         }
         fclose(f);

--- a/Applications/util/mknod.c
+++ b/Applications/util/mknod.c
@@ -2,15 +2,25 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+static long parse_number(const char* p, int base)
+{
+	char* end;
+	unsigned long result;
+	
+	errno = 0;
+	result = strtoul(p, &end, base);
+	if (errno || *end)
+		return -1;
+	return result;
+}
 
 int do_mknod(char *path, char *modes, char *devs)
 {
     int mode;
     int dev;
 
-    mode = -1;
-    sscanf(modes, "%o", &mode);
-    if (mode == -1) {
+	mode = parse_number(modes, 8);
+    if (mode < 0) {
         printf("mknod: bad mode\n");
         return (-1);
     }
@@ -20,7 +30,8 @@ int do_mknod(char *path, char *modes, char *devs)
         return (-1);
     }
 
-    if (sscanf(devs, "%d", &dev) != 1) {
+	dev = parse_number(devs, 10);
+	if (dev < 0) {
         printf("mknod: bad device\n");
         return (-1);
     }

--- a/Applications/util/umount.c
+++ b/Applications/util/umount.c
@@ -2,21 +2,24 @@
 #include <string.h>
 #include <stdlib.h>
 
-
-char tmp[256];
+/* Assumed length of a line in /etc/mtab */
+#define MTAB_LINE 160
 
 char *getdev(char *arg)
 {
     FILE *f;
-    static char dev[20], mntpt[20], fstype[20], rwflag[20];
+	char tmp[MTAB_LINE];
+	char* dev;
+	char* mntpt;
     
     f = fopen("/etc/mtab", "r");
     if (f) {
-        while (fgets(tmp, 256, f)) {
-            sscanf(tmp, "%s %s %s %s\n", dev, mntpt, fstype, rwflag);
+        while (fgets(tmp, sizeof(tmp), f)) {
+			dev = strtok(tmp, " ");
+			mntpt = strtok(NULL, " ");
             if ((strcmp(dev, arg) == 0) || (strcmp(mntpt, arg) == 0)) {
                 fclose(f);
-                return dev;
+                return strdup(dev);
             }
         }
         fclose(f);
@@ -30,7 +33,9 @@ int rm_mtab(char *devname)
 {
     FILE *inpf, *outf;
     char *tmp_fname;
-    static char dev[20], mntpt[20], fstype[20], rwflag[20];
+	char tmp[MTAB_LINE];
+	char* dev;
+	char* mntpt;
 
     if ((tmp_fname = tmpnam(NULL)) == NULL) {
         perror("Error getting temporary file name");
@@ -46,8 +51,9 @@ int rm_mtab(char *devname)
         perror("Can't create temporary file");
         exit(1);
     }
-    while (fgets(tmp, 255, inpf)) {
-        sscanf(tmp, "%s %s %s %s\n", dev, mntpt, fstype, rwflag);
+    while (fgets(tmp, sizeof(tmp), inpf)) {
+		dev = strtok(tmp, " ");
+		mntpt = strtok(NULL, " ");
         if (strcmp(dev, devname) == 0) {
             continue;
         } else {


### PR DESCRIPTION
This takes calls to scanf out of some of the applications, reducing the size of the binaries significantly. (mknod, which is nigh trivial but which calls out to both printf and scanf, won't fit on a small system I'm working on.)
