### PR TITLE
Libc tweaks

### DIFF
--- a/Library/include/stdlib.h
+++ b/Library/include/stdlib.h
@@ -67,7 +67,7 @@ extern int atexit __P((atexit_t));
 
 extern char *crypt __P((char *__key, char *__salt));
 
-typedef int (*cmp_func_t) __P((void *, void *));
+typedef int (*cmp_func_t) __P((const void *, const void *));
 
 extern int _bsearch;
 extern void *bsearch __P((void *key, void *base, size_t num, size_t size, cmp_func_t cmp));

--- a/Library/include/string.h
+++ b/Library/include/string.h
@@ -12,8 +12,8 @@ extern char * strcat __P ((char*, const char*));
 extern char * strcpy __P ((char*, const char*));
 extern int strcmp __P ((const char*, const char*));
 
-extern char * strncat __P ((const char*, const char*, size_t));
-extern char * strncpy __P ((const char*, const char*, size_t));
+extern char * strncat __P ((char*, const char*, size_t));
+extern char * strncpy __P ((char*, const char*, size_t));
 extern int strncmp __P((const char*, const char*, size_t));
 
 extern int stricmp __P((const char*, const char*));

--- a/Library/include/string.h
+++ b/Library/include/string.h
@@ -39,7 +39,7 @@ extern void * memmove __P ((void*, const void*, size_t));
 extern char *index __P ((const char *, int));
 extern char *rindex __P ((const char *, int));
 extern void bcopy __P ((const void*, void*, size_t));
-extern void bzero __P ((void*, int));
+extern void bzero __P ((void*, size_t));
 
 /* Other common BSD functions */
 extern char *strpbrk __P ((const char *, const char *));

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -74,8 +74,9 @@ struct hd_geometry {
 #define HDIO_GET_IDENTITY	0x0102	/* Not yet implemented anywhere */
 
 struct times;
-struct utsname;
 struct tms;
+struct utimbuf;
+struct utsname;
 
 extern void _exit(int code);
 extern int open(const char *path, int flags, ...);
@@ -150,7 +151,7 @@ extern int alarm(uint16_t seconds);
 extern time_t time(time_t *t);
 extern int stime(const time_t *t);
 extern int times(struct tms *tms);
-//extern int utime(const char *filename, const struct utimbuf *utim);
+extern int utime(const char *filename, const struct utimbuf *utim);
 extern int uname(struct utsname *buf);
 extern int profil(unsigned short *bufbase, size_t bufsize, unsigned long offset,
                   unsigned int scale);

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -73,7 +73,11 @@ struct hd_geometry {
 #define HDIO_GETGEO		0x0101
 #define HDIO_GET_IDENTITY	0x0102	/* Not yet implemented anywhere */
 
-extern int _exit(int code);
+struct times;
+struct utsname;
+struct tms;
+
+extern void _exit(int code);
 extern int open(const char *path, int flags, ...);
 extern int close(int fd);
 extern int creat(const char *path, mode_t mode);
@@ -146,7 +150,7 @@ extern int alarm(uint16_t seconds);
 extern time_t time(time_t *t);
 extern int stime(const time_t *t);
 extern int times(struct tms *tms);
-extern int utime(const char *filename, const struct utimbuf *utim);
+//extern int utime(const char *filename, const struct utimbuf *utim);
 extern int uname(struct utsname *buf);
 extern int profil(unsigned short *bufbase, size_t bufsize, unsigned long offset,
                   unsigned int scale);

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -122,7 +122,7 @@ extern int fchown(int fd, uid_t owner, gid_t group);
 extern int mkdir(const char *path, mode_t mode);
 extern int rmdir(const char *path);
 extern pid_t setpgrp(void);
-extern int waitpid(pid_t pid, int *status, int options);
+extern pid_t waitpid(pid_t pid, int *status, int options);
 extern int uadmin(int cmd, int ctrl, void *ptr);
 extern int nice(int prio);
 extern int rename(const char *path, const char *newpath);

--- a/Library/libs/bcmp.c
+++ b/Library/libs/bcmp.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-int bcmp(const void *dest, const void *src, int len)
+int bcmp(const void *dest, const void *src, size_t len)
 {
    return memcmp(dest, src, len);
 }

--- a/Library/libs/bzero.c
+++ b/Library/libs/bzero.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-void bzero(void *dest, int len)
+void bzero(void *dest, size_t len)
 {
    (void) memset(dest, '\0', len);
 }

--- a/Library/libs/calloc.c
+++ b/Library/libs/calloc.c
@@ -9,9 +9,9 @@
     
 #include "malloc-l.h"
 
-void *calloc(unsigned int elm, unsigned int sz) 
+void *calloc(size_t elm, size_t sz) 
 {
-	register unsigned v = elm * sz;
+	register size_t v = elm * sz;
 	register void *ptr = malloc(v);
 	
 	if (ptr)

--- a/Library/libs/memchr.c
+++ b/Library/libs/memchr.c
@@ -7,13 +7,13 @@
 #include <string.h>
     
 /********************** Function memchr ************************************/ 
-void *memchr(void *str, int c, size_t l) 
+void *memchr(const void *str, int c, size_t l) 
 {
-	register char *p = (char *) str;
+	register const char *p = str;
 
 	while (l-- != 0) {
 		if (*p == c)
-			return p;
+			return (void*) p;
 		p++;
 	}
 	return NULL;

--- a/Library/libs/memcmp.c
+++ b/Library/libs/memcmp.c
@@ -1,61 +1,21 @@
-/* memcmp.c
- * Copyright (C) 1995,1996 Robert de Bath <rdebath@cix.compulink.co.uk>
- * This file is part of the Linux-8086 C library and is distributed
- * under the GNU Library General Public License.
- *
- * Z80 rewrite from UMZIX
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
  */
- 
-#include <stdlib.h>
 
-/********************** Function memcmp ************************************/
-int memcmp(void *s, void *d, size_t l) __naked
+#include	<string.h>
+
+int
+memcmp(const void *s1, const void *s2, size_t n)
 {
-__asm
+	register const unsigned char *p1 = s1, *p2 = s2;
 
-        push    ix
-        ld      ix,#0
-        add     ix,sp
-
-        ; d = BC, s=HL, l=DE
-	
-        ld      l, 4(ix)
-        ld      h, 5(ix)
-        ld      c, 6(ix)
-        ld      b, 7(ix)
-        ld      e, 8(ix)
-        ld      d, 9(ix)
-        push    bc
-        pop     iy      ; IY=d
-        ld      bc,#0x0000    ; char1, char2
-l_1:      
-	ld      a,(hl)
-        ld      b,a
-        ld      a,(iy)  ; char1 != char 2 ?
-        ld      c,a
-        cp      b
-        jr      nz,l_2
-        inc     hl	; s++
-        inc     iy	; d++
-        dec     de	; l--
-        ld      a,d
-        or      e
-        jp      nz,l_1	; l != 0, continue
-l_2:      
-	ld      a,c	; char1 - char2
-        ld      e,a
-	rla
-	sbc	a,a
-	ld	d,a
-        ld      a,b
-        ld      l,b
-	rla
-	sbc	a,a
-	ld	h,a
-	or	a
-	sbc	hl,de
-
-	pop ix
-	ret
-__endasm;
+	if (n) {
+		n++;
+		while (--n > 0) {
+			if (*p1++ == *p2++) continue;
+			return *--p1 - *--p2;
+		}
+	}
+	return 0;
 }

--- a/Library/libs/memcmp.c
+++ b/Library/libs/memcmp.c
@@ -1,6 +1,7 @@
 /*
  * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
- * This file is licensed under the terms of the MIT open source license.
+ * This file is licensed under the terms of the 3-clause BSD open source
+ * license.
  */
 
 #include	<string.h>

--- a/Library/libs/memcpy.c
+++ b/Library/libs/memcpy.c
@@ -1,31 +1,22 @@
-#include <string.h>
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
+ */
 
-/* Z80 rewrite from UMZIX */
+#include	<string.h>
 
-void *memcpy(void *dst, void *src, size_t count) __naked
+void *
+memcpy(void *s1, const void *s2, register size_t n)
 {
-__asm
-        push    ix
-        ld      ix,#0
-        add     ix,sp
-	
-        ld e, 4(ix)
-        ld d, 5(ix)
-        ld l, 6(ix)
-        ld h, 7(ix)
-        ld c, 8(ix)
-        ld b, 9(ix)
-	push de
-        ld      a,b
-        or      c
-        jr      z,_skip
+	register char *p1 = s1;
+	register const char *p2 = s2;
 
-        ldir
 
-_skip:
-	pop hl
-
-	pop ix
-	ret
-__endasm;
+	if (n) {
+		n++;
+		while (--n > 0) {
+			*p1++ = *p2++;
+		}
+	}
+	return s1;
 }

--- a/Library/libs/memcpy.c
+++ b/Library/libs/memcpy.c
@@ -1,6 +1,7 @@
 /*
  * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
- * This file is licensed under the terms of the MIT open source license.
+ * This file is licensed under the terms of the 3-clause BSD open source
+ * license.
  */
 
 #include	<string.h>

--- a/Library/libs/memmove.c
+++ b/Library/libs/memmove.c
@@ -1,0 +1,31 @@
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
+ */
+
+#include	<string.h>
+
+void *
+memmove(void *s1, const void *s2, register size_t n)
+{
+	register char *p1 = s1;
+	register const char *p2 = s2;
+
+	if (n>0) {
+		if (p2 <= p1 && p2 + n > p1) {
+			/* overlap, copy backwards */
+			p1 += n;
+			p2 += n;
+			n++;
+			while (--n > 0) {
+				*--p1 = *--p2;
+			}
+		} else {
+			n++;
+			while (--n > 0) {
+				*p1++ = *p2++;
+			}
+		}
+	}
+	return s1;
+}

--- a/Library/libs/memmove.c
+++ b/Library/libs/memmove.c
@@ -1,6 +1,7 @@
 /*
  * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
- * This file is licensed under the terms of the MIT open source license.
+ * This file is licensed under the terms of the 3-clause BSD open source
+ * license.
  */
 
 #include	<string.h>

--- a/Library/libs/memset.c
+++ b/Library/libs/memset.c
@@ -1,6 +1,7 @@
 /*
  * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
- * This file is licensed under the terms of the MIT open source license.
+ * This file is licensed under the terms of the 3-clause BSD open source
+ * license.
  */
 #include	<string.h>
 

--- a/Library/libs/memset.c
+++ b/Library/libs/memset.c
@@ -1,44 +1,19 @@
-/* memset.c
- * Copyright (C) 1995,1996 Robert de Bath <rdebath@cix.compulink.co.uk>
- * This file is part of the Linux-8086 C library and is distributed
- * under the GNU Library General Public License.
- *
- * Z80 rewrite from UMZIX
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
  */
+#include	<string.h>
 
-#include <stdlib.h>
-
-/********************** Function memset ************************************/
-void *memset(void *str, int c, size_t l) __naked
+void *
+memset(void *s, register int c, register size_t n)
 {
-__asm
-        push    ix
-        ld      ix,#0
-        add     ix,sp
+	register char *s1 = s;
 
-	ld l, 4(ix)
-	ld h, 5(ix)
-	ld d, 6(ix)
-	ld c, 8(ix)
-	ld b, 9(ix)
-	ld a,b
-	or c	; l=0? so return
-	jr z,_retw
-	ld a,d
-	ld (hl),a	; fill first byte
-	ld d,h
-	ld e,l
-	inc de	; DE=str+1
-	dec bc
-	ld a,b	; l=1? so return
-	or c
-	jr z,_retw
-	push hl
-	ldir
-	pop hl
-	
-_retw:
-	pop ix
-	ret
-__endasm;
+	if (n>0) {
+		n++;
+		while (--n > 0) {
+			*s1++ = c;
+		}
+	}
+	return s;
 }

--- a/Library/libs/putchar.c
+++ b/Library/libs/putchar.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+/* Some compilers will emit calls to this function, even though it's strictly
+ * a macro; so we have to have a real function version of it. */
+
+int (putchar)(int c)
+{
+	return putchar(c);
+}
+

--- a/Library/libs/setbuffer.c
+++ b/Library/libs/setbuffer.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void setbuffer(FILE * fp, char * buf, unsigned int size)
+void setbuffer(FILE * fp, char * buf, size_t size)
 {
    fflush(fp);
    if( fp->mode & __MODE_FREEBUF ) free(fp->bufstart);

--- a/Library/libs/strcat.c
+++ b/Library/libs/strcat.c
@@ -7,7 +7,7 @@
 #include <string.h>
     
 /********************** Function strcat ************************************/ 
-char *strcat(char *d, char *s) 
+char *strcat(char *d, const char *s) 
 {
 	strcpy(d + strlen(d), s);
 	return d;

--- a/Library/libs/strchr.c
+++ b/Library/libs/strchr.c
@@ -8,7 +8,7 @@
 
 /* FIXME: asm version ?? */    
 /********************** Function strchr ************************************/ 
-char *strchr(char *s, int c) 
+char *strchr(const char *s, int c) 
 {
 	register char ch;
 	

--- a/Library/libs/strcmp.c
+++ b/Library/libs/strcmp.c
@@ -7,7 +7,7 @@
 #include <string.h>
     
 /********************** Function strcmp ************************************/ 
-int strcmp(char *d, char *s) 
+int strcmp(const char *d, const char *s) 
 {
 	register char *s1 = (char *) d, *s2 = (char *) s, c1, c2;
 

--- a/Library/libs/strcpy.c
+++ b/Library/libs/strcpy.c
@@ -7,7 +7,7 @@
 #include <string.h>
     
 /********************** Function strcpy ************************************/ 
-char *strcpy(char *d, char *s) 
+char *strcpy(char *d, const char *s) 
 {
 	return memcpy(d, s, strlen(s) + 1);
 }

--- a/Library/libs/strcspn.c
+++ b/Library/libs/strcspn.c
@@ -4,7 +4,7 @@
 
 #include <string.h>
 
-size_t strcspn(char *string, char *set)
+size_t strcspn(const char *string, const char *set)
 /*
  *	Return the length of the sub-string of <string> that consists
  *	entirely of characters not found in <set>.  The terminating '\0'
@@ -12,7 +12,7 @@ size_t strcspn(char *string, char *set)
  *	character if <string> is in <set>, 0 is returned.
  */
 {
-    register char *setptr;
+    register const char *setptr;
     char *start;
 
     start = string;

--- a/Library/libs/strlen.c
+++ b/Library/libs/strlen.c
@@ -1,16 +1,17 @@
-/* string.c
- * Copyright (C) 1995,1996 Robert de Bath <rdebath@cix.compulink.co.uk>
- * This file is part of the Linux-8086 C library and is distributed
- * under the GNU Library General Public License.
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
  */
 
-#include <string.h>
+#include	<string.h>
 
-/********************** Function strlen ************************************/
-size_t strlen(const char *str)
+size_t
+strlen(const char *org)
 {
-	const char* start = str;
-	while (*str++)
-		;
-	return str - start;
+	register const char *s = org;
+
+	while (*s++)
+		/* EMPTY */ ;
+
+	return --s - org;
 }

--- a/Library/libs/strlen.c
+++ b/Library/libs/strlen.c
@@ -7,19 +7,10 @@
 #include <string.h>
 
 /********************** Function strlen ************************************/
-size_t strlen(char *str) __naked
+size_t strlen(const char *str)
 {
-__asm
-        pop     bc
-        pop     hl
-        push    hl
-        push    bc
-        xor     a, a
-        ld      b, a
-        ld      c, a
-        cpir
-        ld      hl, #-1
-        sbc     hl, bc  ; C flag still cleared from xor above.
-        ret
-__endasm;
+	const char* start = str;
+	while (*str++)
+		;
+	return str - start;
 }

--- a/Library/libs/strncat.c
+++ b/Library/libs/strncat.c
@@ -7,7 +7,7 @@
 #include <string.h>
     
 /********************** Function strncat ************************************/ 
-char *strncat(char *d, char *s, size_t l) 
+char *strncat(char *d, const char *s, size_t l) 
 {
 	register char *s1 = d + strlen(d), *s2 = memchr(s, 0, l);
 

--- a/Library/libs/strncmp.c
+++ b/Library/libs/strncmp.c
@@ -1,0 +1,25 @@
+/*
+ * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
+ * This file is licensed under the terms of the MIT open source license.
+ */
+
+#include	<string.h>
+
+int
+strncmp(register const char *s1, register const char *s2, register size_t n)
+{
+	if (n) {
+		do {
+			if (*s1 != *s2++)
+				break;
+			if (*s1++ == '\0')
+				return 0;
+		} while (--n > 0);
+		if (n > 0) {
+			if (*s1 == '\0') return -1;
+			if (*--s2 == '\0') return 1;
+			return (unsigned char) *s1 - (unsigned char) *s2;
+		}
+	}
+	return 0;
+}

--- a/Library/libs/strncmp.c
+++ b/Library/libs/strncmp.c
@@ -1,6 +1,7 @@
 /*
  * (c) copyright 1987 by the Vrije Universiteit, Amsterdam, The Netherlands.
- * This file is licensed under the terms of the MIT open source license.
+ * This file is licensed under the terms of the 3-clause BSD open source
+ * license.
  */
 
 #include	<string.h>

--- a/Library/libs/strncpy.c
+++ b/Library/libs/strncpy.c
@@ -7,9 +7,10 @@
 #include <string.h>
     
 /********************** Function strncpy ************************************/ 
-char *strncpy(char *d, char *s, size_t l) 
+char *strncpy(char *d, const char *s, size_t l) 
 {
-	register char *s1 = d, *s2 = s;
+	register char *s1 = d;
+	register const char *s2 = s;
 
 	while (l) {
 		l--;

--- a/Library/libs/strrchr.c
+++ b/Library/libs/strrchr.c
@@ -7,9 +7,9 @@
 #include <string.h>
     
 /********************** Function strrchr ************************************/ 
-char *strrchr(char *s, int c) 
+char *strrchr(const char *s, int c) 
 {
-	register char *p = s + strlen(s);
+	register const char *p = s + strlen(s);
 	 
 	/* For null it's just like strlen */ 
 	if (c == '\0')

--- a/Library/libs/vfprintf.c
+++ b/Library/libs/vfprintf.c
@@ -60,7 +60,7 @@ static int prtfld(FILE * op, size_t maxlen, size_t ct, unsigned char *buf, int l
 			--width;
 		}
 		if (ct++ < maxlen)
-                        putc(ch, op);
+                        fputc(ch, op);
 		if (ch == '\n' && buffer_mode == _IOLBF)
 			fflush(op);
 	}
@@ -253,7 +253,7 @@ int _vfnprintf(FILE * op, size_t maxlen, const char *fmt, va_list ap)
 		      charout:
 			/* normal char out */
 		        if (cnt < maxlen)
-		                putc(*fmt, op);
+		                fputc(*fmt, op);
 			++cnt;
 			if (*fmt == '\n' && buffer_mode == _IOLBF)
 				fflush(op);

--- a/Library/libs/vfscanf.c
+++ b/Library/libs/vfscanf.c
@@ -17,13 +17,14 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <ctype.h>
 #include <string.h>
 #include <stdarg.h>
 
 /* #define	skip()	do{c=getc(fp); if (c<1) goto done;}while(isspace(c))*/
 
-#define	skip()	while(isspace(c)) { if ((c=getc(fp))<1) goto done; }
+#define	skip()	while(isspace(c)) { if ((c=fgetc(fp))<1) goto done; }
 
 /* fp scan actions */
 #define F_NADA	0	/* just change state */
@@ -50,7 +51,7 @@
 #define FC_SIGN		3
 
 /* given transition,state do what action? */
-int fp_do[][NSTATE] = {
+static const uint8_t fp_do[][NSTATE] = {
 	{F_INT,F_INT,F_INT,
 	 F_FRAC,F_FRAC,
 	 F_EXP,F_EXP,F_EXP},	/* see digit */
@@ -63,7 +64,7 @@ int fp_do[][NSTATE] = {
 	 F_ESIGN,F_QUIT,F_QUIT},	/* see sign */
 };
 /* given transition,state what is new state? */
-int fp_ns[][NSTATE] = {
+static const uint8_t fp_ns[][NSTATE] = {
 	{FS_DIGS,FS_DIGS,FS_DIGS,
 	 FS_DD,FS_DD,
 	 FS_EDIGS,FS_EDIGS,FS_EDIGS},	/* see digit */
@@ -76,7 +77,7 @@ int fp_ns[][NSTATE] = {
 	 FS_ESIGN,0,0},	/* see sign */
 };
 /* which states are valid terminators? */
-int fp_sval[NSTATE] = {
+static const uint8_t fp_sval[NSTATE] = {
 	0,0,1,0,1,0,0,1
 };
 
@@ -124,7 +125,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
    if (!*fmt)
       return (0);
 
-   c = getc(fp);
+   c = fgetc(fp);
    while (c > 0)
    {
       store = 0;
@@ -207,7 +208,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
 	       }
 	       else if (c == '0')
 	       {
-		  c = getc(fp);
+		  c = fgetc(fp);
 		  if (c < 1)
 		     goto savnum;
 		  if ((c != 'x')
@@ -409,7 +410,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
 	    {
 	       if (store)
 		  *p++ = c;
-	       if (((c = getc(fp)) < 1) ||
+	       if (((c = fgetc(fp)) < 1) ||
 		   (--width == 0))
 		  break;
 
@@ -444,7 +445,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
        cmatch:
 	 if (c != *fmt)
 	    break;
-	 c = getc(fp);
+	 c = fgetc(fp);
       }
 
       if (!*++fmt)

--- a/Library/libs/vfscanf.c
+++ b/Library/libs/vfscanf.c
@@ -242,7 +242,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
 	    while (p && width-- && c)
 	    {
 	       n = (n * base) + (p - digits);
-	       c = getc(fp);
+	       c = fgetc(fp);
 	     zeroin:
 	       p = ((unsigned char *)
 		    strchr(digits, toupper(c)));
@@ -311,7 +311,7 @@ int vfscanf(FILE *fp, const char *fmt, va_list ap)
 		  goto fdone;
 	       }
 	       fstate = fp_ns[trans][fstate];
-	       c = getc(fp);
+	       c = fgetc(fp);
 	    }
 
 	  fdone:


### PR DESCRIPTION
This is a whole bunch of relatively minor libc changes:

- prototyping and function signature changes to be more consistent and standard
- replace the unused Z80 versions of the string functions with portable C versions (stolen from the ACK; 3-clause BSD licensed); Z80 platform use the copies from the compiler library anyway, and having C versions is required by platforms that don't have these in their compiler library
- some relatively minor changes to printf and scanf to reduce code size (by a few hundred bytes).