### PR TITLE
V7 app fixes

### DIFF
--- a/Applications/V7/cmd/at.c
+++ b/Applications/V7/cmd/at.c
@@ -64,7 +64,7 @@ void onintr(int sig)
 	exit(1);
 }
 
-char *prefix(char *begin, char *full)
+const char *prefix(const char *begin, const char *full)
 {
 	int c;
 	while (c = *begin++) {
@@ -78,10 +78,10 @@ char *prefix(char *begin, char *full)
 	return (full);
 }
 
-int makeutime(char *pp)
+int makeutime(const char *pp)
 {
 	register int val;
-	register char *p;
+	register const char *p;
 
 	/* p points to a user time */
 	p = pp;
@@ -168,7 +168,7 @@ int makeuday(int argc, const char *argv[])
 	/* first of all, what's today */
 	time_t tm;
 	int found = -1;
-	char **ps;
+	const char **ps;
 	struct tm *detail;
 	struct monstr *pt;
 
@@ -244,7 +244,7 @@ void filename(char *dir, int y, int d, int t)
 	}
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	register int c;
 	char pwbuf[100];

--- a/Applications/V7/cmd/col.c
+++ b/Applications/V7/cmd/col.c
@@ -16,12 +16,13 @@
 
 char *page[PL];
 char lbuff[LINELN], *line;
+char fbuff[BUFSIZ];
 int bflag, xflag, fflag;
 int half;
 int cp, lp;
 int ll, llh, mustwr;
 int pcp = 0;
-char *pgmname;
+const char *pgmname;
 
 
 void outc(char c)
@@ -179,13 +180,12 @@ int main(int argc, const char *argv[])
 	int i;
 	int greek;
 	register int c;
-	char fbuff[BUFSIZ];
 
 	setbuf(stdout, fbuff);
 	pgmname = argv[0];
 
 	for (i = 1; i < argc; i++) {
-		register char *p;
+		register const char *p;
 		if (*argv[i] != '-') {
 			fprintf(stderr, "%s: bad option %s\n",
 				pgmname, argv[i]);

--- a/Applications/V7/cmd/comm.c
+++ b/Applications/V7/cmd/comm.c
@@ -15,6 +15,7 @@ char ldr[3][3] = { "", "\t", "\t\t" };
 
 FILE *ib1;
 FILE *ib2;
+char lb1[LB], lb2[LB];
 
 
 FILE *openfil(const char *s)
@@ -95,7 +96,6 @@ int compare(char *a, char *b)
 int main(int argc, const char *argv[])
 {
 	int l;
-	char lb1[LB], lb2[LB];
 
 	if (argc > 1) {
 		if (*argv[1] == '-' && argv[1][1] != 0) {

--- a/Applications/V7/cmd/cron.c
+++ b/Applications/V7/cmd/cron.c
@@ -106,7 +106,7 @@ void ex(char *s)
 
 void init(void)
 {
-	register i, c;
+	register int i, c;
 	register char *cp;
 	register char *ocp;
 	register int n;

--- a/Applications/V7/cmd/crypt.c
+++ b/Applications/V7/cmd/crypt.c
@@ -28,6 +28,8 @@ void setup(char *pw)
 	long seed;
 
 	strncpy(buf, pw, 8);
+	/* Overwrites the argv array so that the password doesn't show up in the
+	 * process listing. */
 	while (*pw)
 		*pw++ = '\0';
 	buf[8] = buf[0];
@@ -72,7 +74,7 @@ void setup(char *pw)
 		t2[t1[i]&MASK] = i;
 }
 
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 	int i, n1, n2;
 

--- a/Applications/V7/cmd/dd.c
+++ b/Applications/V7/cmd/dd.c
@@ -167,7 +167,7 @@ void sigterm(int sig)
 
 void flsh(void)
 {
-	register c;
+	register int c;
 
 	if(obc) {
 		if(obc == obs)
@@ -443,7 +443,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr,"bad arg: %s\n", string);
 		exit(0);
 	}
-	if(conv == null && cflag&(LCASE|UCASE))
+	/* BUG: (void*) cast here is for a cc65 bug */
+	if(conv == (void*)null && cflag&(LCASE|UCASE))
 		conv = cnull;
 	if (ifile)
 		ibf = open(ifile, 0);
@@ -463,7 +464,8 @@ int main(int argc, char *argv[])
 	}
 	if (bs) {
 		ibs = obs = bs;
-		if (conv == null)
+		/* BUG: (void*) cast here is for a cc65 bug */
+		if (conv == (void*)null)
 			fflag++;
 	}
 	if(ibs == 0 || obs == 0) {

--- a/Applications/V7/cmd/deroff.c
+++ b/Applications/V7/cmd/deroff.c
@@ -47,7 +47,7 @@ int rdelim = NOCHAR;
 
 
 int argc;
-char **argv;
+const char **argv;
 
 char fname[50];
 FILE *files[15];
@@ -422,7 +422,7 @@ void work(void)
 int main(int ac, const char *av[])
 {
 	register int i;
-	register char *p;
+	register const char *p;
 	static char onechar[2] = "X";
 
 	argc = ac - 1;

--- a/Applications/V7/cmd/diff.c
+++ b/Applications/V7/cmd/diff.c
@@ -1,4 +1,4 @@
-/* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
+const /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* ANSIfied for FUZIX */
 
 /*	diff - differential file comparison
@@ -106,6 +106,7 @@ int status = 2;
 int anychange = 0;
 char *empty = "";
 int bflag;
+char buf[512];
 
 char *tempfile;			/*used when comparing against std input */
 char *dummy;			/*used in resetting storage search ptr */
@@ -121,7 +122,7 @@ void sdone(int sig)
 	done();
 }
 
-void mesg(char *s, char *t)
+void mesg(const char *s, const char *t)
 {
 	fprintf(stderr, "diff: %s%s\n", s, t);
 }
@@ -194,7 +195,7 @@ void unsort(struct line *f, int l, int *b)
 
 int skipline(int f)
 {
-	register i;
+	register int i;
 	for (i = 1; getc(input[f]) != '\n'; i++);
 	return (i);
 }
@@ -202,7 +203,6 @@ int skipline(int f)
 void filename(char **pa1, char **pa2)
 {
 	register char *a1, *b1, *a2;
-	char buf[512];
 	struct stat stbuf;
 	int i, f;
 	a1 = *pa1;
@@ -243,8 +243,8 @@ int readhash(FILE * f)
 {
 	long sum;
 	register unsigned shift;
-	register space;
-	register t;
+	register int space;
+	register int t;
 	sum = 1;
 	space = 0;
 	if (!bflag)
@@ -278,10 +278,10 @@ int readhash(FILE * f)
 	return ((short) low(sum) + (short) high(sum));
 }
 
-void prepare(int i, char *arg)
+void prepare(int i, const char *arg)
 {
 	register struct line *p;
-	register j, h;
+	register int j, h;
 	if ((input[i] = fopen(arg, "r")) == NULL) {
 		mesg("cannot open ", arg);
 		done();
@@ -299,7 +299,7 @@ void prepare(int i, char *arg)
 
 void prune(void)
 {
-	register i, j;
+	register int i, j;
 	for (pref = 0; pref < len[0] && pref < len[1] &&
 	     file[0][pref + 1].value == file[1][pref + 1].value; pref++);
 	for (suff = 0; suff < len[0] - pref && suff < len[1] - pref &&
@@ -426,7 +426,7 @@ int stone(int *a, int n, int *b, int *c)
 to confounding by hashing (which result in "jackpot")
 2.  collect random access indexes to the two files */
 
-void check(const char *argv[])
+void check(char *argv[])
 {
 	register int i, j;
 	int jackpot;
@@ -537,7 +537,7 @@ void change(int a, int b, int c, int d)
 		prints(".\n");
 }
 
-void output(const char *argv[])
+void output(char *argv[])
 {
 	int m;
 	register int i0, i1, j1;
@@ -575,10 +575,10 @@ void output(const char *argv[])
 		change(1, 0, 1, len[1]);
 }
 
-int main(int argc, const char *argv[])
+int main(int argc,  char *argv[])
 {
 	register int k;
-	const char **args;
+	char **args;
 
 	args = argv;
 	if (argc > 3 && *argv[1] == '-') {
@@ -596,7 +596,7 @@ int main(int argc, const char *argv[])
 				bflag = 1;
 				break;
 			case 'h':
-				execv("/usr/lib/diffh", args);
+				execv("/usr/lib/diffh", (const char**)args);
 				mesg("cannot find diffh", empty);
 				done();
 			}

--- a/Applications/V7/cmd/diff3.c
+++ b/Applications/V7/cmd/diff3.c
@@ -38,6 +38,7 @@ struct diff d13[NC];
 struct diff d23[NC];
 struct diff de[NC];
 char line[256];
+char block[512];
 FILE *fp[3];
 int linct[3] = { 0, 0, 0 };
 
@@ -54,7 +55,7 @@ int debug = 0;
 
 void repos(int nchar)
 {
-	register i;
+	register int i;
 	for (i = 0; i < 2; i++)
 		fseek(fp[i], (long) -nchar, 1);
 }
@@ -82,7 +83,7 @@ int number(char **lc)
 
 int getline(FILE * b)
 {
-	register i, c;
+	register int i, c;
 	for (i = 0; i < sizeof(line) - 1; i++) {
 		c = getc(b);
 		if (c == EOF)
@@ -278,8 +279,7 @@ int edit(struct diff *diff, int dup, int j)
 /*		regurgitate */
 void edscript(int n)
 {
-	register j, k;
-	char block[512];
+	register int j, k;
 	for (n = n; n > 0; n--) {
 		prange(&de[n].old);
 		fseek(fp[2], (long) de[n].new.from, 0);

--- a/Applications/V7/cmd/diffh.c
+++ b/Applications/V7/cmd/diffh.c
@@ -166,7 +166,7 @@ int cmp(const char *s, const char *t)
 int easysynch(void)
 {
 	int i, j;
-	register k, m;
+	register int k, m;
 	char *s0, *s1;
 	for (i = j = 1; i < RANGE && j < RANGE; i++, j++) {
 		s0 = getl(0, n0 + i);

--- a/Applications/V7/cmd/join.c
+++ b/Applications/V7/cmd/join.c
@@ -12,14 +12,14 @@
 #define F1 0
 #define F2 1
 #define	NFLD	20	/* max field per line */
-#define comp() cmp(ppi[F1][j1],ppi[F2][j2])
+#define comp() cmp(ppi[F1][jf1],ppi[F2][jf2])
 
 FILE *f[2];
 char buf[2][BUFSIZ];	/*input lines */
 char *ppi[2][NFLD];	/* pointers to fields in lines */
 char *s1,*s2;
-int	j1	= 1;	/* join of this field of file 1 */
-int	j2	= 1;	/* join of this field of file 2 */
+int	jf1	= 1;	/* join of this field of file 1 */
+int	jf2	= 1;	/* join of this field of file 2 */
 int	olist[2*NFLD];	/* output these fields */
 int	olistf[2*NFLD];	/* from these files */
 int	no;	/* number of entries in olist */
@@ -69,12 +69,12 @@ int output(int on1, int on2)	/* print items from olist */
 	const char *temp;
 
 	if (no <= 0) {	/* default case */
-		printf("%s", on1? ppi[F1][j1]: ppi[F2][j2]);
+		printf("%s", on1? ppi[F1][jf1]: ppi[F2][jf2]);
 		for (i = 0; i < on1; i++)
-			if (i != j1)
+			if (i != jf1)
 				printf("%c%s", sep1, ppi[F1][i]);
 		for (i = 0; i < on2; i++)
-			if (i != j2)
+			if (i != jf2)
 				printf("%c%s", sep1, ppi[F2][i]);
 		printf("\n");
 	} else {
@@ -139,11 +139,11 @@ int main(int argc, const char *argv[])
 			break;
 		case 'j':
 			if (argv[1][2] == '1')
-				j1 = atoi(argv[2]);
+				jf1 = atoi(argv[2]);
 			else if (argv[1][2] == '2')
-				j2 = atoi(argv[2]);
+				jf2 = atoi(argv[2]);
 			else
-				j1 = j2 = atoi(argv[2]);
+				jf1 = jf2 = atoi(argv[2]);
 			argc--;
 			argv++;
 			break;
@@ -154,11 +154,11 @@ int main(int argc, const char *argv[])
 	for (i = 0; i < no; i++)
 		olist[i]--;	/* 0 origin */
 	if (argc != 3)
-		errx(1, "usage: join [-j1 x -j2 y] [-o list] file1 file2");
-	j1--;
-	j2--;	/* everyone else believes in 0 origin */
-	s1 = ppi[F1][j1];
-	s2 = ppi[F2][j2];
+		errx(1, "usage: join [-jf1 x -jf2 y] [-o list] file1 file2");
+	jf1--;
+	jf2--;	/* everyone else believes in 0 origin */
+	s1 = ppi[F1][jf1];
+	s2 = ppi[F2][jf2];
 	if (argv[1][0] == '-')
 		f[F1] = stdin;
 	else if ((f[F1] = fopen(argv[1], "r")) == NULL)

--- a/Applications/V7/cmd/pr.c
+++ b/Applications/V7/cmd/pr.c
@@ -134,7 +134,7 @@ loop:
 	return(c);
 }
 
-pgetc(int i)
+int pgetc(int i)
 {
 	register int c;
 
@@ -286,7 +286,7 @@ void mopen(char **ap)
 void print(char *fp, char **argp)
 {
 	struct stat sbuf;
-	register sncol;
+	register int sncol;
 	register const char *sheader;
 	register char *cbuf;
 	char linebuf[150], *cp;

--- a/Applications/V7/cmd/ptx.c
+++ b/Applications/V7/cmd/ptx.c
@@ -86,7 +86,7 @@ void diag(const char *s, const char *arg)
 char *getline(void)
 {
 
-	register c;
+	register int c;
 	register char *linep;
 	char *endlinep;
 
@@ -260,7 +260,7 @@ void putout(char *strt, char *end)
 
 void getsort(void)
 {
-	register c;
+	register int c;
 	register char *tilde, *linep, *ref;
 	char *p1a, *p1b, *p2a, *p2b, *p3a, *p3b, *p4a, *p4b;
 	int w;

--- a/Applications/V7/cmd/rev.c
+++ b/Applications/V7/cmd/rev.c
@@ -12,7 +12,7 @@ FILE *input;
 
 int main(int argc, char *argv[])
 {
-	register i, c;
+	register int i, c;
 	input = stdin;
 	do {
 		if (argc > 1) {

--- a/Applications/V7/cmd/split.c
+++ b/Applications/V7/cmd/split.c
@@ -13,7 +13,7 @@ FILE	*os;
 
 int main(int argc, const char *argv[])
 {
-	register i, c, f;
+	register int i, c, f;
 	int iflg = 0;
 
 	for(i=1; i<argc; i++)

--- a/Applications/V7/cmd/su.c
+++ b/Applications/V7/cmd/su.c
@@ -12,9 +12,9 @@ struct passwd *pwd;
 
 /* FIXME: su - and other semantics of later su versions */
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
-	register const char **p;
+	register char **p;
 	const char *nptr;
 	char *password;
 	int badsw = 0;

--- a/Applications/V7/cmd/sum.c
+++ b/Applications/V7/cmd/sum.c
@@ -10,7 +10,7 @@
 int main(int argc, const char *argv[])
 {
 	register unsigned sum;
-	register i, c;
+	register int i, c;
 	register FILE *f;
 	register long nbytes;
 	int errflg = 0;
@@ -39,8 +39,9 @@ int main(int argc, const char *argv[])
 		}
 		if (ferror(f)) {
 			errflg++;
+			/* BUG: cast here is to work around a cc65 bug */
 			fprintf(stderr, "sum: read error on %s\n",
-				argc > 1 ? argv[i] : "-");
+				argc > 1 ? argv[i] : (const char*)"-");
 		}
 		printf("%05u%6ld", sum, (nbytes + BUFSIZ - 1) / BUFSIZ);
 		if (argc > 2)

--- a/Applications/V7/cmd/test.c
+++ b/Applications/V7/cmd/test.c
@@ -30,14 +30,7 @@ void synbad(const char *s1, const char *s2)
 	exit(255);
 }
 
-int length(char *s)
-{
-	char *es = s;
-	while (*es++);
-	return (es - s - 1);
-}
-
-char *nxtarg(int mt)
+const char *nxtarg(int mt)
 {
 	if (ap >= ac) {
 		if (mt) {
@@ -49,7 +42,7 @@ char *nxtarg(int mt)
 	return (av[ap++]);
 }
 
-int tio(char *a, int f)
+int tio(const char *a, int f)
 {
 	/* FIXME: should use stat and parse permissions */
 	f = open(a, f);
@@ -60,7 +53,7 @@ int tio(char *a, int f)
 	return (0);
 }
 
-int ftype(char *f)
+int ftype(const char *f)
 {
 	struct stat statb;
 
@@ -71,7 +64,7 @@ int ftype(char *f)
 	return (FIL);
 }
 
-int fsizep(char *f)
+int fsizep(const char *f)
 {
 	struct stat statb;
 	if (stat(f, &statb) < 0)
@@ -83,15 +76,15 @@ int fsizep(char *f)
 int e3(void)
 {
 	int p1;
-	register char *a;
-	char *p2;
+	register const char *a;
+	const char *p2;
 	int int1, int2;
 
-	extern int exp(void);
+	extern int expr(void);
 
 	a = nxtarg(0);
 	if (EQ(a, "(")) {
-		p1 = exp();
+		p1 = expr();
 		if (!EQ(nxtarg(0), ")"))
 			synbad(") expected", "");
 		return (p1);
@@ -133,7 +126,7 @@ int e3(void)
 		return (!EQ(nxtarg(0), a));
 
 	if (EQ(a, "-l")) {
-		int1 = length(p2);
+		int1 = strlen(p2);
 		p2 = nxtarg(0);
 	} else {
 		int1 = atoi(a);
@@ -174,13 +167,13 @@ int e1(void)
 	return (p1);
 }
 
-int exp(void)
+int expr(void)
 {
 	int p1;
 
 	p1 = e1();
 	if (EQ(nxtarg(1), "-o"))
-		return (p1 | exp());
+		return (p1 | expr());
 	ap--;
 	return (p1);
 }
@@ -199,5 +192,5 @@ int main(int argc, const char *argv[])
 	argv[ac] = 0;
 	if (ac <= 1)
 		exit(1);
-	exit(exp()? 0 : 1);
+	exit(expr()? 0 : 1);
 }

--- a/Applications/V7/cmd/time.c
+++ b/Applications/V7/cmd/time.c
@@ -21,7 +21,7 @@ const char *nsep = "\0\0.\0 \0 \0\0";
 void printt(const char *s, long a)
 {
 	char digit[9];
-	register i;
+	register int i;
 	char c;
 	int nonzero;
 
@@ -46,7 +46,7 @@ int main(int argc, const char *argv[])
 {
 	struct tms buffer, obuffer;
 	int status;
-	register p;
+	register int p;
 	time_t before, after;
 
 	if (argc <= 1)

--- a/Applications/V7/cmd/tsort.c
+++ b/Applications/V7/cmd/tsort.c
@@ -79,7 +79,7 @@ int cmp(const char *s, const char *t)
 
 /*	turn a string into a node pointer
 */
-struct nodelist *index(const char *s)
+struct nodelist *stringindex(const char *s)
 {
 	register struct nodelist *i;
 	register const char *t;
@@ -163,8 +163,8 @@ int main(int argc, const char *argv[])
 			break;
 		if (x != 2)
 			error("odd data", empty);
-		i = index(precedes);
-		j = index(follows);
+		i = stringindex(precedes);
+		j = stringindex(follows);
 		if (i == j || present(i, j))
 			continue;
 		t = (struct predlist *) malloc(sizeof(struct predlist));

--- a/Applications/V7/cmd/wall.c
+++ b/Applications/V7/cmd/wall.c
@@ -8,13 +8,14 @@
 #define	USERS	50
 
 char mesg[3000];
+char buf[BUFSIZ];
 int msize;
 struct utmp utmp[USERS];
 
 void sendmes(char *tty)
 {
-	register i;
-	char t[50], buf[BUFSIZ];
+	register int i;
+	char t[50];
 	FILE *f;
 
 	i = fork();
@@ -40,7 +41,7 @@ void sendmes(char *tty)
 
 int main(int argc, const char *argv[])
 {
-	register i;
+	register int i;
 	register struct utmp *p;
 	FILE *f;
 

--- a/Applications/V7/games/arithmetic.c
+++ b/Applications/V7/games/arithmetic.c
@@ -89,7 +89,7 @@ void score(void)
 
 void delete(int sig)
 {
-	if (rights + wrongs == 0.) {
+	if (rights + wrongs == 0) {
 		printf("\n");
 		exit(0);
 	}

--- a/Applications/V7/games/fish.c
+++ b/Applications/V7/games/fish.c
@@ -39,7 +39,7 @@ int choose(char a[], int n)
 {
 	/* pick and return one at random from the n choices in a */
 	/* The last one is moved to replace the one chosen */
-	register j, t;
+	register int j, t;
 
 	if (n <= 0)
 		error("null choice");
@@ -57,7 +57,7 @@ void shuffle(void)
 	/* uses the random number generator `rand' in the C library */
 	/* assumes that `srand' has already been called */
 
-	register i;
+	register int i;
 
 	for (i = 0; i < DECK; ++i)
 		deck[i] = (i % 13) + 1;	/* seed the deck */
@@ -78,7 +78,7 @@ int draw(void)
 
 int empty(HAND h)
 {
-	register i;
+	register int i;
 
 	for (i = 1; i <= CTYPE; ++i) {
 		if (h[i] != 0 && h[i] != 4)
@@ -125,7 +125,7 @@ char *cname[] = {
 
 void stats(void)
 {
-	register i, ct, b;
+	register int i, ct, b;
 
 	if (proflag)
 		printf("Pro level\n");
@@ -153,7 +153,7 @@ void stats(void)
 
 void phand(HAND h)
 {
-	register i, j;
+	register int i, j;
 
 	j = 0;
 
@@ -163,7 +163,7 @@ void phand(HAND h)
 			continue;
 		}
 		if (h[i]) {
-			register k;
+			register int k;
 			k = h[i];
 			while (k--)
 				printf("%s ", cname[i]);
@@ -214,7 +214,7 @@ const char *inst[] = {
 
 void instruct(void)
 {
-	register char **cpp;
+	register const char **cpp;
 
 	printf("\n");
 
@@ -231,7 +231,7 @@ void madebook(int x)
 
 void score(void)
 {
-	register my, your, i;
+	register int my, your, i;
 
 	my = your = 0;
 
@@ -264,7 +264,7 @@ void score(void)
 int guess(void)
 {
 	/* get the guess from the tty and return it... */
-	register g, go;
+	register int g, go;
 
 	go = 0;
 
@@ -365,7 +365,7 @@ void heguessed(int d)
 int myguess(void)
 {
 
-	register i, lg, t;
+	register int i, lg, t;
 
 	if (empty(myhand))
 		return (NOMORE);
@@ -432,7 +432,7 @@ int move(HAND hs, HAND ht, int g, int v)
 {
 	/* hand hs has made a guess, g, directed towards ht */
 	/* v on indicates that the guess was made by the machine */
-	register d;
+	register int d;
 	const char *sp, *tp;
 
 	sp = tp = "I";
@@ -511,7 +511,7 @@ void game(void)
 
 	for (;;) {
 
-		register g;
+		register int g;
 
 
 		/* you make repeated guesses */

--- a/Applications/V7/games/wump.c
+++ b/Applications/V7/games/wump.c
@@ -120,12 +120,12 @@ int rnum(int n)
 		first[1] = ((uint32_t) t) >> 16;
 		srand((first[1] * first[0]) ^ first[1]);
 	}
-	return ((rand() / 32768.0) * n);
+	return (((long)rand() / 32768L) * n);
 }
 
 int rin(void)
 {
-	register n, c;
+	register int n, c;
 
 	n = 0;
 	c = getchar();
@@ -144,10 +144,10 @@ int rin(void)
 	return (n);
 }
 
-int near(struct room *ap, int ahaz)
+int isnear(struct room *ap, int ahaz)
 {
 	register struct room *p;
-	register haz, i;
+	register int haz, i;
 
 	p = ap;
 	haz = ahaz;
@@ -168,7 +168,7 @@ int icomp(const void *v1, const void *v2)
 int tunnel(int i)
 {
 	register struct room *p;
-	register n, j;
+	register int n, j;
 	int c;
 
 	c = 20;
@@ -295,15 +295,15 @@ int main(int argc, char *argv[])
 		goto loop;
 	}
 	for (i = 0; i < NTUNN; i++)
-		if (near(&room[p->tunn[i]], WUMP))
+		if (isnear(&room[p->tunn[i]], WUMP))
 			goto nearwump;
-	if (near(p, WUMP)) {
+	if (isnear(p, WUMP)) {
 	      nearwump:
 		printf("I smell a wumpus\n");
 	}
-	if (near(p, BAT))
+	if (isnear(p, BAT))
 		printf("Bats nearby\n");
-	if (near(p, PIT))
+	if (isnear(p, PIT))
 		printf("I feel a draft\n");
 	printf("There are tunnels to");
 	for (i = 0; i < NTUNN; i++)

--- a/Library/libs/execl.c
+++ b/Library/libs/execl.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <errno.h>
     
 /* Find file in pathes:
  * 1. /name or ./name or ../name is already qualified names
@@ -62,5 +63,19 @@ int execl(const char *pathP, const char *arg0, ...)
 int execlp(const char *pathP, const char *arg0, ...) 
 {
 	return execve(_findPath(pathP), &arg0, environ);
+}
+#else
+int execl(const char *pathP, const char *arg0, ...) 
+{
+	/* BUG: this should be ENOSYS, but Fuzix doesn't have that yet */
+	errno = EINVAL;
+	return -1;
+}
+
+int execlp(const char *pathP, const char *arg0, ...) 
+{
+	/* BUG: this should be ENOSYS, but Fuzix doesn't have that yet */
+	errno = EINVAL;
+	return -1;
 }
 #endif


### PR DESCRIPTION
Ansification, constification and smallifying pass --- now builds on 6502 and Z80 (and without warnings on gcc5). Added dummy execl and execlp implementations for cc65 as at requires them.

The biggest 6502 app is still levee, at 48309 bytes, but dc is close behind at 47716 bytes. I haven't been able to run anything, though.