### PR TITLE
zeta-v2: Fix boot from kernel in ROM

### DIFF
--- a/Kernel/platform-zeta-v2/Makefile
+++ b/Kernel/platform-zeta-v2/Makefile
@@ -51,6 +51,6 @@ diskboot.bin:	diskboot.s
 image:
 	sdasz80 -o bootrom.s
 	sdldz80 -m -i bootrom.rel
-	makebin -s 256 bootrom.ihx > bootrom.bin
-	cat bootrom.bin ../fuzix.bin > fuzix.rom
+	makebin -s 136 bootrom.ihx > bootrom.bin
+	cat bootrom.bin ../fuzix.bin | dd conv=sync bs=65536 count=1 of=fuzix.rom
 	../cpm-loader/makecpmloader ../cpm-loader/cpmload.bin ../fuzix.bin 0x88 fuzix.com

--- a/Kernel/platform-zeta-v2/bootrom.s
+++ b/Kernel/platform-zeta-v2/bootrom.s
@@ -53,6 +53,7 @@ ramdisk_copy:
 		out (MPGSEL_2),a
 		inc a			; map page 35 (RAM+48K) to bank 3
 		out (MPGSEL_3),a
-		jp 0x100		; jump to crt0.s
+
+		jp 0x8B                 ; jump to init_from_rom in crt0
 ; pad
 		.ds	(0x88-(.-start))

--- a/Kernel/platform-zeta-v2/config.h
+++ b/Kernel/platform-zeta-v2/config.h
@@ -110,7 +110,7 @@
 
 	/* UART0 as the console */
 	#define BOOT_TTY (512 + 1)
-	#define TTY_INIT_BAUD B115200
+	#define TTY_INIT_BAUD B38400
 #endif
 
 #define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */

--- a/Kernel/platform-zeta-v2/devtty.c
+++ b/Kernel/platform-zeta-v2/devtty.c
@@ -37,7 +37,7 @@ void tty_setup(uint8_t minor)
 	uint8_t lcr = 0;
 	if (minor == 1) {
 		b = ttydata[minor].termios.c_cflag & CBAUD;
-		if (b > 0 && b < 16) {
+		if (boot_from_rom && b > 0 && b < 16) {
 			UART0_LCR = 0x80;	/* LCR = DLAB ON */
 			UART0_DLL = divisor_table[b] & 0xFF;
 			UART0_DLH = divisor_table[b] >> 8;

--- a/Kernel/platform-zeta-v2/kernel.def
+++ b/Kernel/platform-zeta-v2/kernel.def
@@ -12,7 +12,7 @@ PROGLOAD		.equ	0x0100
 
 ; Zeta SBC V2 mnemonics for I/O ports etc
 
-CONSOLE_RATE		.equ	115200
+CONSOLE_RATE		.equ	38400
 
 CPU_CLOCK_KHZ		.equ	20000
 

--- a/Kernel/platform-zeta-v2/zeta-v2.h
+++ b/Kernel/platform-zeta-v2/zeta-v2.h
@@ -17,4 +17,6 @@ __sfr __at (UART0_BASE + 7) UART0_SCR;	/* Scratch register */
 __sfr __at (UART0_BASE + 0) UART0_DLL;	/* Divisor latch - low byte */
 __sfr __at (UART0_BASE + 1) UART0_DLH;	/* Divisor latch - high byte */
 
+extern bool boot_from_rom;
+
 #endif


### PR DESCRIPTION
We no longer change tty1 UART parameters unless booting from ROM, this means it is not necessary to keep the BIOS UART config in sync with the kernel UART config.