### PR TITLE
Some cc65 fixes

### DIFF
--- a/Applications/V7/cmd/diff.c
+++ b/Applications/V7/cmd/diff.c
@@ -596,7 +596,7 @@ int main(int argc,  char *argv[])
 				bflag = 1;
 				break;
 			case 'h':
-				execv("/usr/lib/diffh", (const char**)args);
+				execv("/usr/lib/diffh", (char**)args);
 				mesg("cannot find diffh", empty);
 				done();
 			}

--- a/Applications/V7/cmd/time.c
+++ b/Applications/V7/cmd/time.c
@@ -58,7 +58,7 @@ int main(int argc, const char *argv[])
 		exit(1);
 	}
 	if (p == 0) {
-		execvp(argv[1], &argv[1]);
+		execvp(argv[1], (char**) &argv[1]);
 		perror(argv[1]);
 		_exit(1);
 	}

--- a/Applications/util/cal.c
+++ b/Applications/util/cal.c
@@ -50,7 +50,7 @@ static char sccsid[] = "@(#)cal.c	8.4 (Berkeley) 4/2/94";
 int time_zone = 0;
 long timezone = 0;
 
-int errx(int exv, char *str)
+void errx(int exv, char *str)
 {
     fprintf(stderr, "cal: %s\n", str);
     exit(exv);
@@ -104,6 +104,9 @@ char *full_month[12] = {
     "May",       "June",     "July",     "August",
     "September", "October",  "November", "December"
 };
+
+static int days[12][MAXDAYS];
+static char lineout[80];
 
 /* leap year -- account for gregorian reformation in 1752 */
 #define	leap_year(yr) \
@@ -192,7 +195,7 @@ int main(int argc, char *argv[])
 	j_yearly(year);
     else
 	yearly(year);
-    exit(0);
+    return(0);
 }
 
 #define	DAY_LEN		3	/* 3 spaces per day */
@@ -226,8 +229,6 @@ void j_yearly(int year)
 {
     char *p;
     int col, *dp, i, month, row, which_cal;
-    int days[12][MAXDAYS];
-    char lineout[80];
 
     sprintf(lineout, "%d", year);
     center(lineout, J_WEEK_LEN * 2 + J_HEAD_SEP, 0);
@@ -263,8 +264,6 @@ void yearly(int year)
 {
     char *p;
     int col, *dp, i, month, row, which_cal;
-    int days[12][MAXDAYS];
-    char lineout[80];
 
     sprintf(lineout, "%d", year);
     center(lineout, WEEK_LEN * 3 + HEAD_SEP * 2, 0);

--- a/Applications/util/cat.c
+++ b/Applications/util/cat.c
@@ -29,6 +29,7 @@
 
 #define BUFFER_SIZE    512
 
+static char buff[BUFFER_SIZE];
 
 /* The name of the file currently being displayed, "-" indicates stdin. */
 
@@ -61,7 +62,6 @@ int open_file(char *new_filename)
 int output_file(int fd)
 {
     int bytes_read;
-    char buff[BUFFER_SIZE];
 
     while ((bytes_read = read(fd, buff, BUFFER_SIZE)) > 0)
 	write(STDOUT_FILENO, buff, bytes_read);

--- a/Applications/util/chmod.c
+++ b/Applications/util/chmod.c
@@ -37,7 +37,7 @@ int  rflag, errors;
 struct stat st;
 char path[PATH_MAX + 1];
 
-int main(int argc, char **argv);
+int main(int argc, char *argv[]);
 mode_t parsemode(char *symbolic, mode_t oldmode);
 int do_change(char *name);
 void usage(void);

--- a/Applications/util/cksum.c
+++ b/Applications/util/cksum.c
@@ -72,7 +72,7 @@ static const unsigned long crctab[] = {
 };
 
 
-
+static unsigned char buffer[1024];
 static int aux;
 
 /* Routine straight out of 4.9.10 */
@@ -103,7 +103,6 @@ static void crc(int fd, char *name)
   off_t f_size;
   unsigned long crc;
   int nb;
-  unsigned char buffer[1024];
 
   if (fd < 0) {
 	perror(name);

--- a/Applications/util/cmp.c
+++ b/Applications/util/cmp.c
@@ -18,6 +18,9 @@
 #define putstr(x)	write(1, x, strlen(x))
 #define eputstr(x)	write(2, x, strlen(x))
 
+static char buf1[512];
+static char buf2[512];
+
 void main(int argc, char *argv[])
 {
 	int		fd1;
@@ -27,8 +30,6 @@ void main(int argc, char *argv[])
 	long		pos;
 	char		*bp1;
 	char		*bp2;
-	char		buf1[512];
-	char		buf2[512];
 	struct	stat	statbuf1;
 	struct	stat	statbuf2;
 

--- a/Applications/util/df.c
+++ b/Applications/util/df.c
@@ -113,7 +113,7 @@ void df_dev(dev_t dev)
 
     printf("%-16s %6u %6u %6u %5u%% %s\n",
             dn, Total, Used, Free, Percent,
-            fsys.s_mntpt ? mntpoint(dn) : "/");
+            fsys.s_mntpt ? mntpoint(dn) : (const char*) "/");
 }
 
 void df_all(void)

--- a/Applications/util/dosread.c
+++ b/Applications/util/dosread.c
@@ -154,7 +154,7 @@ void usage(const char *prog_name);
 unsigned c2u2(const unsigned char *ucarray);
 unsigned long c4u4(const unsigned char *ucarray);
 void determine(void);
-int main(int argc, const char *argv []);
+int main(int argc, char *argv []);
 DIRECTORY *directory(DIRECTORY *dir, int entries, BOOL function, char *pathname);
 void extract(DIRECTORY *entry);
 void delete(DIRECTORY *entry);
@@ -331,7 +331,7 @@ void determine(void)
   }
 }
 
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
   register char *arg_ptr = slash(argv[0]);
   DIRECTORY *entry;

--- a/Applications/util/du.c
+++ b/Applications/util/du.c
@@ -52,7 +52,7 @@ typedef struct already {
     nlink_t al_nlink;
 } ALREADY;
 
-int  main(int argc, char **argv);
+int  main(int argc, char *argv[]);
 int  makedname(char *d, char *f, char *out, int outlen);
 int  done(dev_t dev, ino_t inum, nlink_t nlink);
 long dodir(char *d, int thislev, dev_t dev);
@@ -131,7 +131,7 @@ long dodir(char *d, int thislev, dev_t dev)
     long total;
     DIR  *dp;
     struct dirent *entry;
-    char dent[LINELEN];
+    static char dent[LINELEN];
 
     if (lstat(d, &s) < 0) {
 	fprintf(stderr, "%s: %s: %s\n", prog, d, strerror(errno));

--- a/Applications/util/ed.c
+++ b/Applications/util/ed.c
@@ -48,6 +48,7 @@ static BOOL dirty;
 static char *filename;
 static char searchstring[USERSIZE];
 
+static char buf[USERSIZE+1];
 static char *bufbase;
 static char *bufp;
 static LEN bufused;
@@ -110,7 +111,6 @@ static void docommands(void)
     NUM num2;
     BOOL have1;
     BOOL have2;
-    char buf[USERSIZE];
 
     while (TRUE) {
 	intflag = FALSE;
@@ -569,7 +569,6 @@ static LEN findstring(LINE *lp, char *str, LEN len, LEN offset)
 static void addlines(NUM num)
 {
     int len;
-    char buf[USERSIZE + 1];
 
     while (fgets(buf, sizeof(buf), stdin)) {
 	if ((buf[0] == '.') && (buf[1] == '\n') && (buf[2] == '\0'))

--- a/Applications/util/fsck.c
+++ b/Applications/util/fsck.c
@@ -514,7 +514,7 @@ void ckdir(uint16_t inum, uint16_t pnum, char *name)
     uint16_t j;
     int c;
     int nentries;
-    char ename[150];
+    static char ename[150];
 
     iread(inum, &ino);
     if ((ino.i_mode & S_IFMT) != S_IFDIR)

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -132,10 +132,10 @@ static pid_t spawn_process(uint8_t * p, uint8_t wait)
 			/* Don't leak utmp into the child */
 			endutent();
 			/* Run the child */
-			execv(args[2], args + 2);
+			execv(args[2], (char**) (args + 2));
 			/* If it didn't look binary run it via the shell */
 			if (errno == ENOEXEC)
-				execv("/bin/sh", args);
+				execv("/bin/sh", (char**) args);
 			/* Oh bugger */
 			perror(args[2]);
 			exit(1);
@@ -547,7 +547,7 @@ static pid_t getty(const char *ttyname, const char *id)
 
 			/* here we are inside child's context of execution */
 			envset("PATH", "/bin:/usr/bin");
-			envset("CTTY", ttyname);
+			envset("CTTY", (char*) ttyname);
 
 			/* make stdin, stdout and stderr point to fdtty */
 

--- a/Applications/util/ll.c
+++ b/Applications/util/ll.c
@@ -39,7 +39,7 @@ int ls(char *path)
     int    d, st;
     struct _uzidirent buf;
     struct stat statbuf;
-    char   dname[512];
+    static char dname[512];
 
     if (stat(path, &statbuf) != 0 || !S_ISDIR(statbuf.st_mode)) {
         printf("ls: can't stat %s\n", path);

--- a/Applications/util/ls.c
+++ b/Applications/util/ls.c
@@ -152,7 +152,8 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
 
     struct passwd *pwd;
     struct group *grp;
-    char buf[PATHLEN], *cp = buf;
+    static char buf[PATHLEN];
+	char *cp = buf;
     int len;
 
     *cp = '\0';
@@ -217,7 +218,8 @@ void main(int argc, char *argv[])
     BOOL endslash;
     DIR *dirp;
     int i;
-    char *cp, *name, **newlist, fullname[PATHLEN];
+    char *cp, *name, **newlist;
+	static char fullname[PATHLEN];
 
     if ((list = (char **) malloc(LISTSIZE * sizeof(char *))) == NULL) {
 	fprintf(stderr, "No memory for ls buffer\n");

--- a/Applications/util/man.c
+++ b/Applications/util/man.c
@@ -64,7 +64,7 @@ int searchwhatis(FILE *wf, char *title, char **ppage, char **psection)
  */
 {
 	static char page[256], section[32];
-	char alias[256];
+	static char alias[256];
 	int found= 0;
 	int c;
 
@@ -478,7 +478,8 @@ int trymandir(char *mandir, char *title, char *section)
  */
 {
 	FILE *wf;
-	char whatis[1024], pagename[1024], *wpage, *wsection;
+	static char whatis[1024], pagename[1024];
+	char *wpage, *wsection;
 	int rsw, rsp;
 	int ntries;
 	int (*searchidx)(FILE *, char *, char **, char **);
@@ -559,7 +560,7 @@ int trysubmandir(char *mandir, char *title, char *section)
  * may have manual pages that override the ones in the major directory.
  */
 {
-	char submandir[1024];
+	static char submandir[1024];
 	DIR *md;
 	struct dirent *entry;
 
@@ -590,7 +591,7 @@ int trysubmandir(char *mandir, char *title, char *section)
 void searchmanpath(char *title, char *section)
 /* Search the manual path for a manual page describing "title." */
 {
-	char mandir[1024];
+	static char mandir[1024];
 	char *pp= manpath, *pd;
 
 	for (;;) {

--- a/Applications/util/mkdir.c
+++ b/Applications/util/mkdir.c
@@ -12,7 +12,7 @@ void writes(const char *p)
 int make_dir(const char *name, int f)
 {
     char *line;
-    char iname[256];
+    static char iname[256];
 
     int l = strlen(name) - 1;
 

--- a/Applications/util/od.c
+++ b/Applications/util/od.c
@@ -14,7 +14,7 @@ int  next;
 int  bytespresent;
 
 
-int  main(int argc, char **argv);
+int  main(int argc, char *argv[]);
 long offset(int argc, char *argv[], int k);
 void dumpfile(void);
 void wdump(short *words, int k, int radix);

--- a/Applications/util/ps.c
+++ b/Applications/util/ps.c
@@ -33,8 +33,8 @@ int do_ps(void)
     int i, j, uid, pfd, ptsize;
     struct passwd *pwd;
     struct p_tab *pp;
-    struct p_tab ptab[PTABSIZE];
-    char name[10], uname[20];
+    static struct p_tab ptab[PTABSIZE];
+    static char name[10], uname[20];
 
     uid = getuid();
 

--- a/Applications/util/ssh.c
+++ b/Applications/util/ssh.c
@@ -184,7 +184,7 @@ int main(int argc, char *argval[])
                             *tp++ = '/';
                         for (i = 0; (*tp++ = cmd[i++]) != '\0'; )
                             ;
-                        execve(eline, argv, (const char**) environ);
+                        execve(eline, (char**) argv, (char**) environ);
                     }
                     write(2, "ssh: ", 5);
                     write(2, cmd, strlen(cmd));

--- a/Applications/util/stty.c
+++ b/Applications/util/stty.c
@@ -91,7 +91,7 @@ char *prog_name;
 struct termios termios;
 int column= 0, max_column=80;		/* Assume 80 character terminals. */
 
-void main(int argc, char **argv);
+void main(int argc, char *argv[]);
 void report(int flags);
 int option(char *opt, char *next);
 int match(const char *s1, const char *s2);

--- a/Applications/util/sum.c
+++ b/Applications/util/sum.c
@@ -62,7 +62,7 @@ void error(const char *s, const char *f)
 
 void sum(int fd, const char *fname)
 {
-  char buf[BUFFER_SIZE];
+  static char buf[BUFFER_SIZE];
   register int i, n;
   long size = 0;
   unsigned crc = 0;

--- a/Applications/util/tee.c
+++ b/Applications/util/tee.c
@@ -57,7 +57,7 @@ void writes(const char *p)
 int main(int argc, char *argv[])
 {
   char iflag = 0, aflag = 0;
-  char buf[CHUNK_SIZE];
+  static char buf[CHUNK_SIZE];
   int i, s, n;
 
   argv++;

--- a/Applications/util/tr.c
+++ b/Applications/util/tr.c
@@ -26,7 +26,7 @@ BOOL invec[ASCII + 1], outvec[ASCII + 1];
 
 short in_index, out_index;
 
-int  main(int argc, char **argv);
+int  main(int argc, char *argv[]);
 void convert(void);
 void map(unsigned char *string1, unsigned char *string2);
 void expand(char *arg, unsigned char *buffer);
@@ -159,7 +159,7 @@ void complement(unsigned char *buffer)
 {
     register unsigned char *ptr;
     register short i, index;
-    unsigned char conv[ASCII + 2];
+    static unsigned char conv[ASCII + 2];
 
     index = 0;
     for (i = 1; i <= ASCII; i++) {

--- a/Applications/util/uue.c
+++ b/Applications/util/uue.c
@@ -31,7 +31,7 @@ char seqc = SEQMAX;
 int split = 0;
 int fileln = 32000;
 
-int  main(int argc, char **argv);
+int  main(int argc, char *argv[]);
 void maketable(void);
 void makename(void);
 void encode(void);

--- a/Applications/util/which.c
+++ b/Applications/util/which.c
@@ -7,8 +7,8 @@ int main(int argc, char *argv[])
     int  quit, found;
     char *envpath;
     char *path, *cp;
-    char buf[512];
-    char patbuf[512];
+    static char buf[512];
+    static char patbuf[512];
 
     if (argc < 2) {
 	fprintf(stderr, "Usage: which cmd [cmd, ..]\n");

--- a/Applications/util/write.c
+++ b/Applications/util/write.c
@@ -33,10 +33,10 @@ void usage(char ** argv)
 
 int main(int argc, char ** argv)
 {
-	char ttyname[12];
+	static char ttyname[12];
 	struct passwd * pwdent;
 	int ofd = -1;
-	char buf[255];
+	static char buf[255];
 	int n;
 
 	if ((argc > 3) || (argc < 2)) {

--- a/Library/libs/strstr.c
+++ b/Library/libs/strstr.c
@@ -10,7 +10,7 @@
 char *strstr(const char *s1, const char *s2)
 {
    int l = strlen(s2);
-   char * p = s1;
+   char * p = (char *) s1;
 
    if( l==0 ) return p;
 


### PR DESCRIPTION
This is a set of simple changes intended to make the apps build with cc65. It pulls out some stack-allocated buffers into global variables, to keep the stack size down, and also adds explicit casts to work around some of cc65's type comparison bugs.