### PR TITLE
Use precompiled sdcc for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,7 @@ cache:
 before_install:
     - sudo add-apt-repository ppa:david.given/ppa -y
     - sudo apt-get update -q
-    - sudo apt-get install cc65
-    - mkdir -p dependencies
-    - cd dependencies
-    - sudo apt-get --no-install-recommends install libboost-all-dev
-    - git clone --depth 1 --branch patched https://github.com/davidgiven/sdcc.git
-    - (cd sdcc/sdcc && ./configure --prefix=/usr/local --disable-pic14-port --disable-pic16-port)
-    - (cd sdcc/sdcc && make -j4 > /dev/null && sudo make install > /dev/null)
+    - sudo apt-get install cc65 sdcc
     - export PATH=$PATH:/usr/local/bin
     - cd ..
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
     - sudo apt-get update -q
     - sudo apt-get install cc65 sdcc
     - export PATH=$PATH:/usr/local/bin
-    - cd ..
 language: c
 script:
     - make PLATFORM=6502test -j4


### PR DESCRIPTION
Rather than downloading and building sdcc ourselves, use the precompiled version in my PPA. This reduces build time from about 8 minutes to about 5.