### PR TITLE
blkdev: increment data address and lba each time through read/write loop

### DIFF
--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -126,6 +126,8 @@ static int blkdev_transfer(uint8_t minor, uint8_t rawflag)
             goto xferfail;
         blk_op.nblock -= n;
         count += n;
+	blk_op.addr += n * BLKSIZE;
+	blk_op.lba += n;
     }
 
     return count; /* 10/10, would transfer sectors again */


### PR DESCRIPTION
The main sector transfer loop, was just sending the low-level driver the same address and lba every loop....