### PR TITLE
Allow DriveWire tty's to by ioctl'd by vt_ioctl().

### DIFF
--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -497,10 +497,10 @@ unsigned char vt_map(unsigned char c)
 
 int gfx_ioctl(uint8_t minor, uarg_t arg, char *ptr)
 {
-	if ( minor > 2 ) /* remove once DW get its own ioctl() */
-		goto notty;
 	if (arg >> 8 != 0x03)
 		return vt_ioctl(minor, arg, ptr);
+	if ( minor > 2 ) /* remove once DW get its own ioctl() */
+		goto notty;
 	if (arg == GFXIOC_GETINFO)
 		return uput( ptytab[minor-1].fdisp, ptr, sizeof( struct display));
 	if (arg == GFXIOC_GETMODE){


### PR DESCRIPTION
If we rearrange the order, then the DW tty's will still do tty_ioctl's.