### PR TITLE
sh now builds and runs on modern computers.

### DIFF
--- a/Applications/V7/cmd/sh/args.c
+++ b/Applications/V7/cmd/sh/args.c
@@ -10,8 +10,7 @@
  *
  */
 
-#include <stdlib.h>
-#include	"defs.h"
+#include "defs.h"
 
 static const char **copyargs(const char *from[], int n);
 static DOLPTR dolh;

--- a/Applications/V7/cmd/sh/defs.h
+++ b/Applications/V7/cmd/sh/defs.h
@@ -1,11 +1,15 @@
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 
+#define _GNU_SOURCE
 #include <stdint.h>
 #include <stddef.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <signal.h>
 #include <sys/times.h>
+#include <errno.h>
+
 /*
  *	UNIX shell
  */
@@ -176,7 +180,7 @@ extern const char ps2name[];
 
 /* transput */
 extern CHAR tmpout[];
-extern char * tmpnam;
+extern char *tempfile;
 extern int serial;
 #define		TMPNAM 7
 extern FILE standin;

--- a/Applications/V7/cmd/sh/fault.c
+++ b/Applications/V7/cmd/sh/fault.c
@@ -9,7 +9,6 @@
  *
  */
 
-#include	<stdlib.h>
 #include	"defs.h"
 
 

--- a/Applications/V7/cmd/sh/io.c
+++ b/Applications/V7/cmd/sh/io.c
@@ -101,7 +101,7 @@ int create(const char *s)
 int tmpfil(void)
 {
 	itos(serial++);
-	movstr(numbuf, tmpnam);
+	movstr(numbuf, tempfile);
 	return create(tmpout);
 }
 

--- a/Applications/V7/cmd/sh/main.c
+++ b/Applications/V7/cmd/sh/main.c
@@ -10,10 +10,10 @@
  *
  */
 
+#include	"defs.h"
 #include	<stdlib.h>
 #include	<unistd.h>
 #include	<fcntl.h>
-#include	"defs.h"
 #include	"sym.h"
 #include	"timeout.h"
 #include	<sys/types.h>
@@ -25,6 +25,7 @@ static BOOL beenhere = FALSE;
 CHAR tmpout[20] = "/tmp/sh-";
 FILEBLK stdfile;
 FILE standin = &stdfile;
+char* tempfile;
 
 static void exfile(BOOL);
 
@@ -183,7 +184,7 @@ void settmp(void)
 {
 	itos(getpid());
 	serial = 0;
-	tmpnam = movstr(numbuf, &tmpout[TMPNAM]);
+	tempfile = movstr(numbuf, &tmpout[TMPNAM]);
 }
 
 void Ldup(register int fa, register int fb)

--- a/Applications/V7/cmd/sh/service.c
+++ b/Applications/V7/cmd/sh/service.c
@@ -19,8 +19,6 @@ static int split(const char *s);
 
 #define ARGMK	01
 
-/* FIXME: errno from header */
-extern int errno;
 /* FIXME: put into a header */
 extern const char *sysmsg[];
 


### PR DESCRIPTION
This allows sh to build and run on Linux.

(I was debugging a horrible issue elsewhere and found myself needing to step through the sh memory allocation code in gdb. The sh innards are rather scary. And, it turned out, completely correct AFAICT.)