### PR TITLE
Minor MSP430 fixes

### DIFF
--- a/Kernel/cpu-msp430x/cpu.h
+++ b/Kernel/cpu-msp430x/cpu.h
@@ -122,3 +122,10 @@ typedef union {            /* this structure is endian dependent */
 #define EMAGIC   (*p)
 #define EMAGIC_2 (*p)
 
+/* To save space, queues go in high memory. */
+#define CONFIG_INDIRECT_QUEUES
+typedef uint16_t queueptr_t;
+#define GETQ(p) __read_hidata(p)
+#define PUTQ(p, v) __write_hidata((p), (v))
+
+

--- a/Kernel/cpu-msp430x/cpu.h
+++ b/Kernel/cpu-msp430x/cpu.h
@@ -121,10 +121,3 @@ typedef union {            /* this structure is endian dependent */
 #define EMAGIC   0x08
 #define EMAGIC_2 0x3c
 
-/* To save space, queues go in high memory. */
-#define CONFIG_INDIRECT_QUEUES
-typedef uint16_t queueptr_t;
-#define GETQ(p) __read_hidata(p)
-#define PUTQ(p, v) __write_hidata((p), (v))
-
-

--- a/Kernel/cpu-msp430x/cpu.h
+++ b/Kernel/cpu-msp430x/cpu.h
@@ -119,6 +119,6 @@ typedef union {            /* this structure is endian dependent */
 
 /* Really we should check for the jmp I imagine but gcc will figure the below
    out for us and keep this oddness out of the core code ! */
-#define EMAGIC	(*p)
-#define EMAGIC2 (*p)
+#define EMAGIC   (*p)
+#define EMAGIC_2 (*p)
 

--- a/Kernel/cpu-msp430x/cpu.h
+++ b/Kernel/cpu-msp430x/cpu.h
@@ -117,10 +117,9 @@ typedef union {            /* this structure is endian dependent */
 #define VIDEO
 #define DISCARD
 
-/* Really we should check for the jmp I imagine but gcc will figure the below
-   out for us and keep this oddness out of the core code ! */
-#define EMAGIC   (*p)
-#define EMAGIC_2 (*p)
+/* jmp over the Fuzix header. Will need updating if the header size changes */
+#define EMAGIC   0x08
+#define EMAGIC_2 0x3c
 
 /* To save space, queues go in high memory. */
 #define CONFIG_INDIRECT_QUEUES

--- a/Kernel/platform-msp430fr5969/config.h
+++ b/Kernel/platform-msp430fr5969/config.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 /* Enable to make ^Z dump the inode table for debug */
 #undef CONFIG_IDUMP
 /* Enable to make ^A drop back into the monitor */
@@ -27,6 +29,12 @@
 
 /* Video terminal, not a serial tty */
 #undef CONFIG_VT
+
+/* To save space, queues go in high memory. */
+#define CONFIG_INDIRECT_QUEUES
+typedef uint16_t queueptr_t;
+#define GETQ(p) __read_hidata(p)
+#define PUTQ(p, v) __write_hidata((p), (v))
 
 extern int __user_base;
 extern int __user_top;

--- a/Kernel/platform-msp430fr5969/config.h
+++ b/Kernel/platform-msp430fr5969/config.h
@@ -28,12 +28,6 @@
 /* Video terminal, not a serial tty */
 #undef CONFIG_VT
 
-/* To save space, queues go in high memory. */
-#define CONFIG_INDIRECT_QUEUES
-typedef uint16_t queueptr_t;
-#define GETQ(p) __read_hidata(p)
-#define PUTQ(p, v) __write_hidata((p), (v))
-
 extern int __user_base;
 extern int __user_top;
 


### PR DESCRIPTION
This fixes a couple of trivial bugs in your recent changes that were stopping the MSP430 from building.

I also figured out the proper magic numbers. Turns out the test costs 18 bytes of code space...