### PR TITLE
coco3: reset vert scroll reg on boot.

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -142,6 +142,7 @@ b@	sta	,x+
 	decb
 	bne	b@
         ;; set temporary screen up
+	clr	$ff9c		; reset scroll register
 	ldb	#%01000100	; coco3 mode
 	stb	$ff90
 	;; detect PAL or NTSC ROM


### PR DESCRIPTION
The CoCo3 fpga doesn't init this reg to 0 like a real machine, force scroll reg to 0.