### PR TITLE
CoCo3: use discard space for extra buffers

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -19,6 +19,8 @@
 	    .globl map_restore
 	    .globl _need_resched
 	    .globl _hz
+	    .globl _bufpool
+	    .globl _discard_size
 
             ; exported debugging tools
             .globl _trap_monitor
@@ -39,6 +41,16 @@
             include "kernel.def"
             include "../kernel09.def"
 
+
+	.area	.buffers
+
+_bufpool:
+	.ds	BUFSIZE*NBUFS
+
+	.area	.discard
+_discard_size:
+	.db	__sectionlen_.discard__/BUFSIZE
+	
 ; -----------------------------------------------------------------------------
 ; COMMON MEMORY BANK
 ; -----------------------------------------------------------------------------

--- a/Kernel/platform-coco3/config.h
+++ b/Kernel/platform-coco3/config.h
@@ -11,6 +11,9 @@
 /* Use C helpers for usermem */
 #undef CONFIG_USERMEM_C
 
+/* Reclaim discard space for buffers */
+#define CONFIG_DYNAMIC_BUFPOOL
+
 /* We use flexible 16K banks so use the helper */
 #define CONFIG_BANK16
 #define CONFIG_BANKS	4
@@ -85,4 +88,3 @@ extern unsigned char vt_map( unsigned char c );
 #define MAX_BLKDEV  4     /* 2 IDE + 2 SDC */
 #define DEVICE_IDE        /* enable if IDE interface present */
 
-#define platform_discard()

--- a/Kernel/platform-coco3/fuzix.link
+++ b/Kernel/platform-coco3/fuzix.link
@@ -8,8 +8,9 @@ section .text
 section .text.hot
 section .test.unlikely
 section .data
-section	.bss
+section .buffers
 section .discard
+section	.bss
 section .udata load 0xe000
 section .common
 section .cpage load 0xfe00

--- a/Kernel/platform-coco3/kernel.def
+++ b/Kernel/platform-coco3/kernel.def
@@ -25,4 +25,4 @@ IDEDATA			    equ 0xFF50
 IDEDATA_L		    equ 0xFF58
 
 
-NBUFS			    equ	5
+NBUFS			    equ	6

--- a/Kernel/platform-coco3/kernel.def
+++ b/Kernel/platform-coco3/kernel.def
@@ -23,3 +23,6 @@ SAM_RESTORE macro
 ;; asm/c shared IDE stuff
 IDEDATA			    equ 0xFF50
 IDEDATA_L		    equ 0xFF58
+
+
+NBUFS			    equ	5

--- a/Kernel/platform-coco3/main.c
+++ b/Kernel/platform-coco3/main.c
@@ -5,6 +5,26 @@
 #include <devtty.h>
 
 
+struct blkbuf *bufpool_end = bufpool + NBUFS;
+
+void platform_discard(void)
+{
+	extern uint8_t discard_size;
+	bufptr bp = bufpool_end;
+
+	kprintf("%d buffers reclaimed from discard\n", discard_size);
+	
+	bufpool_end += discard_size;
+
+	memset( bp, 0, discard_size * sizeof(struct blkbuf) );
+
+	for( bp = bufpool + NBUFS; bp < bufpool_end; ++bp ){
+		bp->bf_dev = NO_DEVICE;
+		bp->bf_busy = BF_FREE;
+	}
+}
+
+
 void platform_idle(void)
 {
 }


### PR DESCRIPTION
as lifted (again) from the dragon port.