### PR TITLE
Dragon-nx32 graphics fixes

### DIFF
--- a/Kernel/platform-dragon-nx32/devtty.c
+++ b/Kernel/platform-dragon-nx32/devtty.c
@@ -370,8 +370,8 @@ static int gfx_draw_op(uarg_t arg, char *ptr, uint8_t *buf)
     if (l < 8)
       return EINVAL;
     l -= 8;
-    if (p[0] > 31 || p[1] > 191 || p[2] > 31 || p[3] > 191 ||
-      p[0] + p[2] > 32 || p[1] + p[3] > 192 ||
+    if (p[0] > 191 || p[1] > 31 || p[2] > 191 || p[3] > 31 ||
+      p[0] + p[2] > 192 || p[1] + p[3] > 32 ||
       (p[2] * p[3]) > l)
       return -EFAULT;
     if (arg == GFXIOC_READ) {

--- a/Kernel/platform-dragon-nx32/video.s
+++ b/Kernel/platform-dragon-nx32/video.s
@@ -344,7 +344,7 @@ _video_write:
 	tfr x,y			; So we can use y to get at the w/h
 	leax 4,x		; Move on to data space
 vwnext:
-	lda 2,y
+	lda 3,y
 	pshs u
 vwline:
 	ldb ,x+
@@ -353,7 +353,7 @@ vwline:
 	bne vwline
 	puls u
 	leau 32,u
-	dec ,y
+	dec 1,y
 	bne vwnext
 	puls u,pc
 ;
@@ -377,7 +377,7 @@ _video_read:
 	tfr x,y			; So we can use y to get at the w/h
 	leax 4,x		; Move on to data space
 vrnext:
-	lda 2,y			; a counts our copy along the scan line
+	lda 3,y			; a counts our copy along the scan line
 	pshs u
 vrline:
 	ldb ,u+			; b does our data
@@ -386,7 +386,7 @@ vrline:
 	bne vrline
 	puls u			; step down a line
 	leau 32,u
-	dec ,y			; use the buffer directly for line count
+	dec 1,y			; use the buffer directly for line count
 	bne vrnext
 	puls u,pc		; and done
 


### PR DESCRIPTION
A couple of bugs I noticed while porting this code to coco3.

The endian fix not only allows C structure to be define normally, but also allows the bounds checking code (the other submitted fix) to work (it treats the passed structure as an array of uint16's