### PR TITLE
MSP430 overlay support

### DIFF
--- a/Build/platforms/msp430fr5969.ld.h
+++ b/Build/platforms/msp430fr5969.ld.h
@@ -1,8 +1,8 @@
 #ifndef MSP430FR5969_LD_H
 #define MSP430FR5969_LD_H
 
-/* Must be 0x0080 plus a multiple of 0x0200 */
-#define USER_BASE 0xa380
+/* Must be 0x0180 plus a multiple of 0x0200 */
+#define USER_BASE 0x9b80
 #define UDATA_BASE (USER_BASE - 0x0200)
 
 #endif

--- a/Kernel/platform-msp430fr5969/config.h
+++ b/Kernel/platform-msp430fr5969/config.h
@@ -74,5 +74,5 @@ extern int __swap_size_blocks;
 
 #define BOOTDEVICE 0x0001 /* hda1 */
 
-#define platform_discard() do {} while(0)
+extern void platform_discard(void);
 

--- a/Kernel/platform-msp430fr5969/config.h
+++ b/Kernel/platform-msp430fr5969/config.h
@@ -8,7 +8,7 @@
 #undef CONFIG_PROFIL
 /* Multiple processes in memory at once */
 #undef CONFIG_MULTI
-#define PTABSIZE 5
+#define PTABSIZE 6
 #define MAX_SWAPS PTABSIZE
 
 #define CONFIG_USERMEM_DIRECT

--- a/Kernel/platform-msp430fr5969/crt0.S
+++ b/Kernel/platform-msp430fr5969/crt0.S
@@ -18,11 +18,11 @@ trap_monitor:
 	dint
 
 	; Copy the startup code out of high rom and into its execution address.
-	mov.w #0, r15
+	mov #0, r15
 1:
-	movx.b __hirom_base(r15), __user_base(r15)
+	movx.b __load_start_boot_overlay(r15), __overlay_start_address(r15)
 	inc r15
-	cmp.w #__hirom_length, r15
+	cmp.w #__load_length_boot_overlay, r15
 	jnz 1b
 
 	; Go to the real startup code.

--- a/Kernel/platform-msp430fr5969/externs.h
+++ b/Kernel/platform-msp430fr5969/externs.h
@@ -7,6 +7,7 @@ extern void sd_rawinit(void);
 extern void tty_rawinit(void);
 extern void tty_interrupt(void);
 extern void fuzix_main(void);
+extern void load_overlay(uint16_t start, uint16_t stop);
 
 #endif
 

--- a/Kernel/platform-msp430fr5969/main.c
+++ b/Kernel/platform-msp430fr5969/main.c
@@ -8,6 +8,98 @@ uaddr_t ramtop;
 uint8_t need_resched;
 uint8_t last_interrupt;
 
+struct overlay
+{
+	uint16_t start;
+	uint16_t stop;
+};
+
+#define DECLARE_OVERLAY(n) \
+	extern char __load_start_##n##_overlay; \
+	extern char __load_stop_##n##_overlay
+
+#define DEFINE_OVERLAY(n) \
+	{ \
+		(uint16_t) &__load_start_##n##_overlay, \
+		(uint16_t) &__load_stop_##n##_overlay, \
+	}
+
+DECLARE_OVERLAY(syscall_exec16);
+DECLARE_OVERLAY(syscall_fs2);
+DECLARE_OVERLAY(syscall_other);
+
+const struct overlay overlays[] = {
+	DEFINE_OVERLAY(syscall_exec16),
+	DEFINE_OVERLAY(syscall_fs2),
+	DEFINE_OVERLAY(syscall_other)
+};
+
+const static char overlay_tab[FUZIX_SYSCALL_COUNT] = {
+	0, /* __exit */ 	/* FUZIX system call 0 */
+	2, /* _open */ 		/* FUZIX system call 1 */
+	0, /* _close */ 	/* FUZIX system call 2 */
+	3, /* _rename */ 	/* FUZIX system call 3 */
+	2, /* _mknod */ 	/* FUZIX system call 4 */
+	2, /* _link */ 		/* FUZIX system call 5 */
+	0, /* _unlink */ 	/* FUZIX system call 6 */
+	0, /* _read */ 		/* FUZIX system call 7 */
+	0, /* _write */ 	/* FUZIX system call 8 */
+	0, /* _lseek */ 	/* FUZIX system call 9 */
+	2, /* _chdir */ 	/* FUZIX system call 10 */
+	0, /* _sync */ 		/* FUZIX system call 11 */
+	2, /* _access */ 	/* FUZIX system call 12 */
+	2, /* _chmod */ 	/* FUZIX system call 13 */
+	2, /* _chown */ 	/* FUZIX system call 14 */
+	0, /* _stat */ 		/* FUZIX system call 15 */
+	0, /* _fstat */ 	/* FUZIX system call 16 */
+	0, /* _dup */ 		/* FUZIX system call 17 */
+	0, /* _getpid */ 	/* FUZIX system call 18 */
+	0, /* _getppid */ 	/* FUZIX system call 19 */
+	0, /* _getuid */ 	/* FUZIX system call 20 */
+	0, /* _umask */ 	/* FUZIX system call 21 */
+	2, /* _getfsys */ 	/* FUZIX system call 22 */
+	1, /* _execve */ 	/* FUZIX system call 23 */
+	0, /* _getdirent */ /* FUZIX system call 24 */
+	0, /* _setuid */ 	/* FUZIX system call 25 */
+	0, /* _setgid */ 	/* FUZIX system call 26 */
+	0, /* _time */ 		/* FUZIX system call 27 */
+	0, /* _stime */ 	/* FUZIX system call 28 */
+	0, /* _ioctl */ 	/* FUZIX system call 29 */
+	0, /* _brk */ 		/* FUZIX system call 30 */
+	0, /* _sbrk */ 		/* FUZIX system call 31 */
+	0, /* _fork */ 		/* FUZIX system call 32 */
+	3, /* _mount */ 	/* FUZIX system call 33 */
+	3, /* _umount */ 	/* FUZIX system call 34 */
+	0, /* _signal */ 	/* FUZIX system call 35 */
+	0, /* _dup2 */ 		/* FUZIX system call 36 */
+	0, /* _pause */ 	/* FUZIX system call 37 */
+	0, /* _alarm */ 	/* FUZIX system call 38 */
+	0, /* _kill */ 		/* FUZIX system call 39 */
+	0, /* _pipe */ 		/* FUZIX system call 40 */
+	0, /* _getgid */ 	/* FUZIX system call 41 */
+	0, /* _times */ 	/* FUZIX system call 42 */
+	2, /* _utime */ 	/* FUZIX system call 43 */
+	0, /* _geteuid */ 	/* FUZIX system call 44 */
+	0, /* _getegid */ 	/* FUZIX system call 45 */
+	2, /* _chroot */ 	/* FUZIX system call 46 */
+	2, /* _fcntl */ 	/* FUZIX system call 47 */
+	2, /* _fchdir */ 	/* FUZIX system call 48 */
+	2, /* _fchmod */ 	/* FUZIX system call 49 */
+	2, /* _fchown */ 	/* FUZIX system call 50 */
+	3, /* _mkdir */ 	/* FUZIX system call 51 */
+	3, /* _rmdir */ 	/* FUZIX system call 52 */
+	0, /* _setpgrp */ 	/* FUZIX system call 53 */
+	2, /* _uname */ 	/* FUZIX system call 54 */
+	0, /* _waitpid */ 	/* FUZIX system call 55 */
+	3, /* _profil */ 	/* FUZIX system call 56 */
+	3, /* _uadmin */ 	/* FUZIX systen call 57 */
+	3, /* _nice */ 		/* FUZIX system call 58 */
+	0, /* _sigdisp */ 	/* FUZIX system call 59 */
+	2, /* _flock */ 	/* FUZIX system call 60 */
+	0, /* _getpgrp */ 	/* FUZIX system call 61 */
+	0, /* _sched_yield */ /* FUZIX system call 62 */
+};
+
 void platform_idle(void)
 {
 }
@@ -22,3 +114,29 @@ void program_vectors(uint16_t* pageptr)
 	 * touch the interrupt vectors. Therefore we don't need to
 	 * reprogram them and this is a nop. Go us. */
 }
+
+static void maybe_load_overlay(char index)
+{
+	static char current_overlay = 0;
+	if ((index != 0) && (current_overlay != index))
+	{
+		const struct overlay* o = &overlays[index-1];
+		current_overlay = index;
+		load_overlay(o->start, o->stop);
+	}
+}
+
+void platform_discard(void)
+{
+	/* We're done with the start code, and the kernel's about to call
+	 * _execve. So we need to make sure it's in memory. */
+	maybe_load_overlay(1);
+}
+
+void load_overlay_for_syscall(void)
+{
+	if (udata.u_callno >= FUZIX_SYSCALL_COUNT)
+		return;
+	maybe_load_overlay(overlay_tab[udata.u_callno]);
+}
+

--- a/Kernel/platform-msp430fr5969/msp430fr5969.ld
+++ b/Kernel/platform-msp430fr5969/msp430fr5969.ld
@@ -212,22 +212,32 @@ SECTIONS
 	*(.text.*_trampoline);
   } > INFOMEM
 
-  .boottext : {
-    . = ALIGN(2);
-	*(.text.trap_reboot_high);
-	*(.text.blkdev_alloc);
-	*(.text.blkdev_scan);
-	"*/*_discard.o"(.text.* .rodata .rodata.*);
-	"*/mbr.o"(.text.* .rodata .rodata.*);
-	"*/start.o"(.text.* .rodata .rodata.*);
-  } > USER AT> HIROM
-  PROVIDE (__hirom_base = LOADADDR(.boottext));
-  PROVIDE (__hirom_length = SIZEOF(.boottext));
+  OVERLAY : NOCROSSREFS {
+    .boot_overlay {
+		*(.text.trap_reboot_high);
+		*(.text.blkdev_alloc);
+		*(.text.blkdev_scan);
+		"*/*_discard.o"(.text.* .rodata .rodata.*);
+		"*/mbr.o"(.text.* .rodata .rodata.*);
+		"*/start.o"(.text.* .rodata .rodata.*);
+    }
+	.syscall_exec16_overlay {
+		"*/syscall_exec16.o"(.text.* .rodata .rodata.*);
+	}
+	.syscall_fs2_overlay {
+		"*/syscall_fs2.o"(.text.* .rodata .rodata.*);
+	}
+	.syscall_other_overlay {
+		"*/syscall_other.o"(.text.* .rodata .rodata.*);
+	}
+  } > LOROM AT> HIROM
+  PROVIDE (__overlay_start_address = ADDR(.boot_overlay));
+  PROVIDE (__load_length_boot_overlay = SIZEOF(.boot_overlay));
 
   .rodata : {
     . = ALIGN(2);
     *(.rodata.* .rodata .const .const:*)
-  } > LOROM
+  } > LOROM AT> LOROM
 
   .text : {
   	. = ALIGN(2);

--- a/Kernel/platform-msp430fr5969/tricks.S
+++ b/Kernel/platform-msp430fr5969/tricks.S
@@ -8,6 +8,22 @@ SWAPSTACK_SIZE = 128
 swapstack:
 	.fill SWAPSTACK_SIZE
 
+; Loads an overlay from high memory to its destination in low memory.
+; The address provided in parameters are the *low 16 bits* of the high
+; memory addresses (for C compatibility).
+proc load_overlay
+	; r12 = overlay start
+	; r13 = overlay stop
+	mov.w #0, r14
+	sub.w r12, r13
+1:
+	movx.w 0x10000(r12), __overlay_start_address(r14)
+	incd r12
+	incd r14
+	cmp.w r14, r13
+	jnz 1b
+	ret
+
 ; Switchout switches out the current process, finds another that is READY,
 ; possibly the same process, and switches it in.  When a process is
 ; restarted after calling switchout, it thinks it has just returned
@@ -117,6 +133,7 @@ proc unix_syscall_entry
 	mov.w r15, &U_DATA__U_ARGN3
 	mov.b #1, &U_DATA__U_INSYS
 	eint
+	call #load_overlay_for_syscall
 	call #unix_syscall
 	dint
 	mov.b #0, &U_DATA__U_INSYS


### PR DESCRIPTION
As discussed. This gives me about 2kB of extra user space, as well as enough slack for another slot in the process table (because user space needs to change in 0x200 byte increments). Doesn't seem much, but that's 10% more user RAM.

Copying 2kB at one byte per 8 cycles on a 8MHz device takes 2ms. There are faster memcpys if necessary (it's got a rather nice DMA engine). But I don't think anyone will notice.

It's a shame syscall_fs has to be in common. That would give me another kilobyte...

I am, however, concerned it's rather brittle. If anyone moves a syscall, or adds a new one, my code will load the wrong overlay and Bad Things will happen. And because this will happen on an individual syscall level, nobody will notice until that syscall is exercised.