### PR TITLE
coco3: color video debugging

### DIFF
--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -65,7 +65,7 @@ void clear_lines(int8_t y, int8_t ct)
 	map_for_video();
 	uint16_t *s = (uint16_t *)char_addr(y, 0);
 	uint16_t w = ' ' * 0x100 + curpty->attr;
-	for( ; wc ; wc-- )
+	while(  wc-- )
 		*s++=w;
 	map_for_kernel();
 }
@@ -75,7 +75,7 @@ void clear_across(int8_t y, int8_t x, int16_t l)
 	map_for_video();
 	uint16_t *s = (uint16_t *)char_addr(y, x);
 	uint16_t w=' ' * 0x100 + curpty->attr;
-	for( ; l ; l-- )
+	while( l-- )
 		*s++=w;
 	map_for_kernel();
 }

--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -61,11 +61,11 @@ void plot_char(int8_t y, int8_t x, uint16_t c)
 
 void clear_lines(int8_t y, int8_t ct)
 {
+	uint16_t wc= ct * VT_WIDTH;
 	map_for_video();
 	uint16_t *s = (uint16_t *)char_addr(y, 0);
-	ct *= VT_WIDTH;
 	uint16_t w = ' ' * 0x100 + curpty->attr;
-	for( ; ct ; ct-- )
+	for( ; wc ; wc-- )
 		*s++=w;
 	map_for_kernel();
 }

--- a/Kernel/vt.c
+++ b/Kernel/vt.c
@@ -243,7 +243,7 @@ void vtoutput(unsigned char *p, unsigned int len)
 				if (ncursorx >= 0 && ncursorx <= VT_RIGHT)
 					cursorx = ncursorx;
 					vtmode = 0;
-			} else if (vtmode == 4 {
+			} else if (vtmode == 4) {
 				vtattr = c;
 				vtmode = 0;
 				continue;


### PR DESCRIPTION
1. Fixes closing parens in vt.c.
2. Fixes coco3 platform's color code
