### PR TITLE
Better MSP430 overlay support

### DIFF
--- a/Build/platforms/msp430fr5969.ld.h
+++ b/Build/platforms/msp430fr5969.ld.h
@@ -2,8 +2,8 @@
 #define MSP430FR5969_LD_H
 
 /* Must be 0x0180 plus a multiple of 0x0200 */
-#define USER_BASE 0x9b80
-#define UDATA_BASE (USER_BASE - 0x0200)
+#define UDATA_BASE 0x8f80
+#define USER_BASE (UDATA_BASE + 0x0200)
 
 #endif
 

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -742,6 +742,7 @@ extern struct mount *fs_tab_get(uint16_t dev);
 /* returns true on failure, false on success */
 extern bool fmount(uint16_t dev, inoptr ino, uint16_t flags);
 extern void magic(inoptr ino);
+extern arg_t unlinki(inoptr ino, inoptr pino, char *fname);
 
 /* inode.c */
 extern void readi(inoptr ino, uint8_t flag);
@@ -749,6 +750,7 @@ extern void writei(inoptr ino, uint8_t flag);
 extern int16_t doclose (uint8_t uindex);
 extern inoptr rwsetup (bool is_read, uint8_t *flag);
 extern int dev_openi(inoptr *ino, uint8_t flag);
+extern void sync(void);
 
 /* mm.c */
 extern unsigned int uputsys(unsigned char *from, usize_t size);

--- a/Kernel/inode.c
+++ b/Kernel/inode.c
@@ -319,3 +319,21 @@ int dev_openi(inoptr *ino, uint8_t flag)
         tty_post(*ino, da & 0xFF, flag);
         return 0;
 }
+
+void sync(void)
+{
+	inoptr ino;
+
+	/* Write out modified inodes */
+
+	for (ino = i_tab; ino < i_tab + ITABSIZE; ++ino)
+		if (ino->c_refs > 0 && (ino->c_flags & CDIRTY)) {
+			wr_inode(ino);
+			ino->c_flags &= ~CDIRTY;
+			/* WRS: also call d_flush(ino->c_dev) here? */
+		}
+
+        /* This now also indirectly does the superblocks as they
+           are buffers that are pinned */
+	bufsync();		/* Clear buffer pool */
+}

--- a/Kernel/platform-msp430fr5969/build.mk
+++ b/Kernel/platform-msp430fr5969/build.mk
@@ -9,6 +9,23 @@ $(kernelversion.result):
 	$(hide) (cd $(dir $@) && $(kernelversion.abssrcs) $(VERSION) $(SUBVERSION))
 	$(hide) mv $(dir $@)/version.c $@
 
+syscallmap.ext = h
+# Do not change the order below without updating main.c.
+syscallmap.srcs = \
+	../syscall_exec16.c \
+	../syscall_fs.c \
+	../syscall_fs2.c \
+	../syscall_fs3.c \
+	../syscall_other.c \
+	../syscall_proc.c
+$(call build, syscallmap, nop)
+$(syscallmap.result): $(map_syscall.result)
+	@echo SYSCALLMAP $@
+	$(hide) mkdir -p $(dir $@)
+	$(hide) $(map_syscall.result) $(syscallmap.abssrcs) > $@
+	
+$(TOP)/Kernel/platform-msp430fr5969/main.c: $(syscallmap.result)
+
 kernel.srcs = \
 	../dev/blkdev.c \
 	../dev/devsd.c \
@@ -28,6 +45,7 @@ kernel.srcs = \
 	../syscall_exec16.c \
 	../syscall_fs.c \
 	../syscall_fs2.c \
+	../syscall_fs3.c \
 	../syscall_other.c \
 	../syscall_proc.c \
 	../timer.c \
@@ -45,6 +63,9 @@ kernel.srcs = \
 	main_discard.c \
 	tricks.S \
 	$(kernelversion.result)
+
+kernel.includes += \
+	-I$(dir $(syscallmap.result)) \
 
 kernel.cflags += \
 	-Wno-int-to-pointer-cast \

--- a/Kernel/platform-msp430fr5969/externs.h
+++ b/Kernel/platform-msp430fr5969/externs.h
@@ -8,6 +8,7 @@ extern void tty_rawinit(void);
 extern void tty_interrupt(void);
 extern void fuzix_main(void);
 extern void load_overlay(uint16_t start, uint16_t stop);
+extern void load_overlay_for_syscall(void);
 
 #endif
 

--- a/Kernel/platform-msp430fr5969/main.c
+++ b/Kernel/platform-msp430fr5969/main.c
@@ -25,80 +25,29 @@ struct overlay
 	}
 
 DECLARE_OVERLAY(syscall_exec16);
+DECLARE_OVERLAY(syscall_fs);
 DECLARE_OVERLAY(syscall_fs2);
+DECLARE_OVERLAY(syscall_fs3);
 DECLARE_OVERLAY(syscall_other);
+DECLARE_OVERLAY(syscall_proc);
+
+/* Do not change the order here without also changing the list in
+ * build.mk. */
 
 const struct overlay overlays[] = {
 	DEFINE_OVERLAY(syscall_exec16),
+	DEFINE_OVERLAY(syscall_fs),
 	DEFINE_OVERLAY(syscall_fs2),
-	DEFINE_OVERLAY(syscall_other)
+	DEFINE_OVERLAY(syscall_fs3),
+	DEFINE_OVERLAY(syscall_other),
+	DEFINE_OVERLAY(syscall_proc),
 };
 
 const static char overlay_tab[FUZIX_SYSCALL_COUNT] = {
-	0, /* __exit */ 	/* FUZIX system call 0 */
-	2, /* _open */ 		/* FUZIX system call 1 */
-	0, /* _close */ 	/* FUZIX system call 2 */
-	3, /* _rename */ 	/* FUZIX system call 3 */
-	2, /* _mknod */ 	/* FUZIX system call 4 */
-	2, /* _link */ 		/* FUZIX system call 5 */
-	0, /* _unlink */ 	/* FUZIX system call 6 */
-	0, /* _read */ 		/* FUZIX system call 7 */
-	0, /* _write */ 	/* FUZIX system call 8 */
-	0, /* _lseek */ 	/* FUZIX system call 9 */
-	2, /* _chdir */ 	/* FUZIX system call 10 */
-	0, /* _sync */ 		/* FUZIX system call 11 */
-	2, /* _access */ 	/* FUZIX system call 12 */
-	2, /* _chmod */ 	/* FUZIX system call 13 */
-	2, /* _chown */ 	/* FUZIX system call 14 */
-	0, /* _stat */ 		/* FUZIX system call 15 */
-	0, /* _fstat */ 	/* FUZIX system call 16 */
-	0, /* _dup */ 		/* FUZIX system call 17 */
-	0, /* _getpid */ 	/* FUZIX system call 18 */
-	0, /* _getppid */ 	/* FUZIX system call 19 */
-	0, /* _getuid */ 	/* FUZIX system call 20 */
-	0, /* _umask */ 	/* FUZIX system call 21 */
-	2, /* _getfsys */ 	/* FUZIX system call 22 */
-	1, /* _execve */ 	/* FUZIX system call 23 */
-	0, /* _getdirent */ /* FUZIX system call 24 */
-	0, /* _setuid */ 	/* FUZIX system call 25 */
-	0, /* _setgid */ 	/* FUZIX system call 26 */
-	0, /* _time */ 		/* FUZIX system call 27 */
-	0, /* _stime */ 	/* FUZIX system call 28 */
-	0, /* _ioctl */ 	/* FUZIX system call 29 */
-	0, /* _brk */ 		/* FUZIX system call 30 */
-	0, /* _sbrk */ 		/* FUZIX system call 31 */
-	0, /* _fork */ 		/* FUZIX system call 32 */
-	3, /* _mount */ 	/* FUZIX system call 33 */
-	3, /* _umount */ 	/* FUZIX system call 34 */
-	0, /* _signal */ 	/* FUZIX system call 35 */
-	0, /* _dup2 */ 		/* FUZIX system call 36 */
-	0, /* _pause */ 	/* FUZIX system call 37 */
-	0, /* _alarm */ 	/* FUZIX system call 38 */
-	0, /* _kill */ 		/* FUZIX system call 39 */
-	0, /* _pipe */ 		/* FUZIX system call 40 */
-	0, /* _getgid */ 	/* FUZIX system call 41 */
-	0, /* _times */ 	/* FUZIX system call 42 */
-	2, /* _utime */ 	/* FUZIX system call 43 */
-	0, /* _geteuid */ 	/* FUZIX system call 44 */
-	0, /* _getegid */ 	/* FUZIX system call 45 */
-	2, /* _chroot */ 	/* FUZIX system call 46 */
-	2, /* _fcntl */ 	/* FUZIX system call 47 */
-	2, /* _fchdir */ 	/* FUZIX system call 48 */
-	2, /* _fchmod */ 	/* FUZIX system call 49 */
-	2, /* _fchown */ 	/* FUZIX system call 50 */
-	3, /* _mkdir */ 	/* FUZIX system call 51 */
-	3, /* _rmdir */ 	/* FUZIX system call 52 */
-	0, /* _setpgrp */ 	/* FUZIX system call 53 */
-	2, /* _uname */ 	/* FUZIX system call 54 */
-	0, /* _waitpid */ 	/* FUZIX system call 55 */
-	3, /* _profil */ 	/* FUZIX system call 56 */
-	3, /* _uadmin */ 	/* FUZIX systen call 57 */
-	3, /* _nice */ 		/* FUZIX system call 58 */
-	0, /* _sigdisp */ 	/* FUZIX system call 59 */
-	2, /* _flock */ 	/* FUZIX system call 60 */
-	0, /* _getpgrp */ 	/* FUZIX system call 61 */
-	0, /* _sched_yield */ /* FUZIX system call 62 */
+#include "syscallmap.h"
 };
+
+char current_overlay = 0;
 
 void platform_idle(void)
 {
@@ -115,28 +64,28 @@ void program_vectors(uint16_t* pageptr)
 	 * reprogram them and this is a nop. Go us. */
 }
 
-static void maybe_load_overlay(char index)
-{
-	static char current_overlay = 0;
-	if ((index != 0) && (current_overlay != index))
-	{
-		const struct overlay* o = &overlays[index-1];
-		current_overlay = index;
-		load_overlay(o->start, o->stop);
-	}
-}
-
 void platform_discard(void)
 {
 	/* We're done with the start code, and the kernel's about to call
 	 * _execve. So we need to make sure it's in memory. */
-	maybe_load_overlay(1);
+	udata.u_callno = 23; // execve
+	load_overlay_for_syscall();
 }
 
 void load_overlay_for_syscall(void)
 {
 	if (udata.u_callno >= FUZIX_SYSCALL_COUNT)
 		return;
-	maybe_load_overlay(overlay_tab[udata.u_callno]);
+
+	int index = overlay_tab[udata.u_callno];
+	if ((index != 0) && (current_overlay != index))
+	{
+		const struct overlay* o = &overlays[index-1];
+		if (o->start)
+		{
+			current_overlay = index;
+			load_overlay(o->start, o->stop);
+		}
+	}
 }
 

--- a/Kernel/platform-msp430fr5969/msp430fr5969.ld
+++ b/Kernel/platform-msp430fr5969/msp430fr5969.ld
@@ -224,11 +224,20 @@ SECTIONS
 	.syscall_exec16_overlay {
 		"*/syscall_exec16.o"(.text.* .rodata .rodata.*);
 	}
+	.syscall_fs_overlay {
+		"*/syscall_fs.o"(.text.* .rodata .rodata.*);
+	}
 	.syscall_fs2_overlay {
 		"*/syscall_fs2.o"(.text.* .rodata .rodata.*);
 	}
+	.syscall_fs3_overlay {
+		"*/syscall_fs3.o"(.text.* .rodata .rodata.*);
+	}
 	.syscall_other_overlay {
 		"*/syscall_other.o"(.text.* .rodata .rodata.*);
+	}
+	.syscall_proc_overlay {
+		"*/syscall_proc.o"(.text.* .rodata .rodata.*);
 	}
   } > LOROM AT> HIROM
   PROVIDE (__overlay_start_address = ADDR(.boot_overlay));

--- a/Kernel/platform-msp430fr5969/tricks.S
+++ b/Kernel/platform-msp430fr5969/tricks.S
@@ -71,6 +71,7 @@ not_swapped:
 	mov.b #P_RUNNING, P_TAB__P_STATUS_OFFSET(r12) ; mark process as running
 
 	dint
+	call #load_overlay_for_syscall    // ensure right overlay is loaded
 	mov &U_DATA__U_SP, SP             // restore stack pointer
     clr &runticks                     // reset process run count
 	pop SR                            // restore status register

--- a/Kernel/process.c
+++ b/Kernel/process.c
@@ -557,7 +557,7 @@ void doexit(int16_t val, int16_t val2)
 	if (udata.u_ptab->p_pid == 1)
 		panic(PANIC_KILLED_INIT);
 
-	_sync();		/* Not necessary, but a good idea. */
+	sync();		/* Not necessary, but a good idea. */
 
 	irq = di();
 

--- a/Kernel/syscall_other.c
+++ b/Kernel/syscall_other.c
@@ -83,7 +83,7 @@ arg_t _rename(void)
 	/* get it onto disk - probably overkill */
 	wr_inode(dstp);
 	wr_inode(srcp);
-	_sync();
+	sync();
 	ret = 0;
       nogood2:
 	i_deref(dstp);
@@ -289,7 +289,7 @@ arg_t _mount(void)
 		goto nogood;
 	}
 
-	_sync();
+	sync();
 
 	if (fmount(dev, dino, flags)) {
 		udata.u_error = EBUSY;
@@ -353,7 +353,7 @@ arg_t _umount(void)
 			goto nogood;
 		}
 
-	_sync();
+	sync();
 
 	i_deref(mnt->m_fs->s_mntpt);
 	/* Give back the buffer we pinned at mount time */
@@ -431,7 +431,7 @@ arg_t _uadmin(void)
 {
 	if (esuper())
 		return -1;
-	_sync();
+	sync();
 	/* Wants moving into machine specific files */
 	if (cmd == A_SHUTDOWN || cmd == A_DUMP)
 		trap_monitor();

--- a/Kernel/tools/build.mk
+++ b/Kernel/tools/build.mk
@@ -1,0 +1,5 @@
+$(call find-makefile)
+
+map_syscall.srcs = map_syscall.c
+$(call build, map_syscall, host-exe)
+

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ filesystem.result = filesystem-$(PLATFORM).img
 include $(BUILD)/bake.mk
 include $(BUILD)/platforms/$(PLATFORM).mk
 include $(BUILD)/rules/standard.rules.mk
+include $(TOP)/Kernel/tools/build.mk
 include $(TOP)/Standalone/build.mk
 include $(TOP)/Library/build.mk
 include $(TOP)/Library/tests/build.mk


### PR DESCRIPTION
This uses your new tool to figure out which syscalls are in which file; thanks!

All syscall banks can now be used as overlays. Turns out that caching a process' current overlay in udata.u_page2 is unnecessary --- I can figure out which overlay was loaded after switchin by looking at the syscall in udata.u_callno, and I already have code to do that. Total amount of extra code: one subroutine call in switchin. I now have a 27kB userland, which is actually getting quite respectable. (That's about the same amount free as a BBC Micro with tape filesystem and mode 7.)

However, I did have to move unlinki and the guts of _sync into common code, as these functions are called from multiple syscall banks and we don't support cross-bank function calls. (How did this work on hardware banked platforms?)