### PR TITLE
Fix Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo add-apt-repository ppa:tormodvolden/m6809 -y
     - sudo apt-get update -q
     - sudo apt-get install cc65 sdcc lwtools:i386 libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386
-    - wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.x.x.run -O msp430.installer
+    - wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O msp430.installer
     - chmod a+rx msp430.installer
     - sudo ./msp430.installer --mode unattended --prefix $HOME/msp430
     - rm msp430.installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-cache:
-    directory:
-        - dependencies
+matrix:
+    include:
+        - env: PLATFORM=6502test
+        - env: PLATFORM=msp430fr5969
+        - env: PLATFORM=dragon-nx32
+        - env: PLATFORM=trs80
 before_install:
     - sudo add-apt-repository ppa:david.given/ppa -y
     - sudo add-apt-repository ppa:tormodvolden/m6809 -y
@@ -15,8 +18,5 @@ before_install:
     - sudo dpkg -i gcc-6809_4.6.4lw-1~precise_i386.deb
 language: c
 script:
-    - make PLATFORM=6502test -j4
-    - make PLATFORM=msp430fr5969 -j4
-    - make PLATFORM=dragon-nx32 -j4
-    - make PLATFORM=trs80 -j4
+    - make PLATFORM=$PLATFORM -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,22 @@ before_install:
     - sudo add-apt-repository ppa:david.given/ppa -y
     - sudo add-apt-repository ppa:tormodvolden/m6809 -y
     - sudo apt-get update -q
-    - sudo apt-get install cc65 sdcc lwtools:i386 libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386
-    - wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O msp430.installer
-    - chmod a+rx msp430.installer
-    - sudo ./msp430.installer --mode unattended --prefix $HOME/msp430
-    - rm msp430.installer
     - export PATH=$PATH:/usr/local/bin:$HOME/msp430/bin
-    - wget http://toolshed.sourceforge.net/gcc/gcc-6809_4.6.4lw-1~precise_i386.deb
-    - sudo dpkg -i gcc-6809_4.6.4lw-1~precise_i386.deb
+    - >
+        [ $PLATFORM = "6502test" ] && (sudo apt-get install cc65)
+    - >
+        [ $PLATFORM = "trs80" ] && (sudo apt-get install sdcc)
+    - >
+        [ $PLATFORM = "msp430fr5969" ] && (
+            wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O msp430.installer &&
+            chmod a+rx msp430.installer &&
+            sudo ./msp430.installer --mode unattended --prefix $HOME/msp430 &&
+            rm msp430.installer)
+    - >
+        [ $PLATFORM = "dragon-nx32" ] && (
+            sudo apt-get install lwtools:i386 libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386 &&
+            wget http://toolshed.sourceforge.net/gcc/gcc-6809_4.6.4lw-1~precise_i386.deb &&
+            sudo dpkg -i gcc-6809_4.6.4lw-1~precise_i386.deb)
 language: c
 script:
     - make PLATFORM=$PLATFORM -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,29 @@ before_install:
     - sudo add-apt-repository ppa:david.given/ppa -y
     - sudo add-apt-repository ppa:tormodvolden/m6809 -y
     - sudo apt-get update -q
+    - sudo apt-get install libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386
     - export PATH=$PATH:/usr/local/bin:$HOME/msp430/bin
-    - >
-        [ $PLATFORM = "6502test" ] && (sudo apt-get install cc65)
-    - >
-        [ $PLATFORM = "trs80" ] && (sudo apt-get install sdcc)
-    - >
-        [ $PLATFORM = "msp430fr5969" ] && (
-            wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O msp430.installer &&
-            chmod a+rx msp430.installer &&
-            sudo ./msp430.installer --mode unattended --prefix $HOME/msp430 &&
-            rm msp430.installer)
-    - >
-        [ $PLATFORM = "dragon-nx32" ] && (
-            sudo apt-get install lwtools:i386 libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386 &&
-            wget http://toolshed.sourceforge.net/gcc/gcc-6809_4.6.4lw-1~precise_i386.deb &&
-            sudo dpkg -i gcc-6809_4.6.4lw-1~precise_i386.deb)
+    - |
+        if [ $PLATFORM = "6502test" ]; then
+            sudo apt-get install cc65
+        fi
+    - |
+        if [ $PLATFORM = "trs80" ]; then
+            sudo apt-get install sdcc
+        fi
+    - |
+        if [ $PLATFORM = "msp430fr5969" ]; then
+            wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O /tmp/msp430.installer
+            chmod a+rx /tmp/msp430.installer
+            /tmp/msp430.installer --mode unattended --prefix $HOME/msp430
+            rm /tmp/msp430.installer
+        fi
+    - |
+        if [ $PLATFORM = "dragon-nx32" ]; then
+            sudo apt-get install lwtools:i386 
+            wget http://toolshed.sourceforge.net/gcc/gcc-6809_4.6.4lw-1~precise_i386.deb
+            sudo dpkg -i gcc-6809_4.6.4lw-1~precise_i386.deb
+        fi
 language: c
 script:
     - make PLATFORM=$PLATFORM -j4

--- a/Library/libs/strcpy.c
+++ b/Library/libs/strcpy.c
@@ -7,6 +7,7 @@
 #include <string.h>
     
 /********************** Function strcpy ************************************/ 
+#undef strcpy
 char *strcpy(char *d, const char *s) 
 {
 	return memcpy(d, s, strlen(s) + 1);


### PR DESCRIPTION
This fixes the Travis setup so that it builds again, at least for 6502test, trs80 and msp430. (dragon is still broken.) It also reworks it into a proper build matrix so that all platforms get built simultaneously --- this prevents embarrassment when, e.g., TI move the MSP430 toolchain and suddenly nothing works any more.