### PR TITLE
Couple of tty.c fixes?

### DIFF
--- a/Kernel/tty.c
+++ b/Kernel/tty.c
@@ -159,7 +159,7 @@ int tty_open(uint8_t minor, uint16_t flag)
         }
 	tty_setup(minor);
 	if ((t->termios.c_cflag & CLOCAL) || (flag & O_NDELAY))
-	        return 0;
+		goto out;
 
         /* FIXME: racy - need to handle IRQ driven carrier events safely */
         if (!tty_carrier(minor)) {
@@ -172,7 +172,7 @@ int tty_open(uint8_t minor, uint16_t flag)
                 t->flag &= ~TTYF_DEAD;
                 return -1;
         }
-        t->users++;
+ out:   t->users++;
         return 0;
 }
 

--- a/Kernel/tty.c
+++ b/Kernel/tty.c
@@ -46,7 +46,7 @@ int tty_read(uint8_t minor, uint8_t rawflag, uint8_t flag)
 	nread = 0;
 	while (nread < udata.u_count) {
 		for (;;) {
-		        if (t->flag & TTYF_DEAD) {
+		        if ((t->flag & TTYF_DEAD)&&(!q->q_count)) {
 		                udata.u_error = ENXIO;
 		                return -1;
                         }


### PR DESCRIPTION
A couple of bugs fixes found in tty.c?

- the DEAD flag gets checked so early, that any data still in the buffer after a carrier drop cannot be retreived.

- Opening a tty with NBLOCK wasn't keeping the number of users updated... causing weirdness when closing the port - the t->users count would wrap to -1 on close, and the low-level driver closer (actually needed for drivewire) wasn't being called.