### PR TITLE
Fix alignment and sizing issues

### DIFF
--- a/Applications/V7/games/wump.c
+++ b/Applications/V7/games/wump.c
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 				if (p->tunn[j] == p->tunn[k])
 					goto init;
 		}
-		qsort(&p->tunn[0], NTUNN, 2, icomp);
+		qsort(&p->tunn[0], NTUNN, sizeof(int), icomp);
 		p++;
 	}
 

--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <pwd.h>
@@ -328,10 +329,10 @@ static void parse_inittab(void)
 	while (sdata < sdata_end)
 		parse_initline();
 	/* Allocate space for the control arrays */
-	initpid = (uint16_t *) idata;
-	idata += 2 * initcount;
 	initptr = (uint8_t **) idata;
 	idata += sizeof(void *) * initcount;
+	initpid = (uint16_t *) idata;
+	idata += 2 * initcount;
 	if (brk(idata) == -1)
 		putstr("unable to return space\n");
 	memset(initpid, 0, 2 * initcount);

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -174,21 +174,6 @@ typedef struct dinode {
     blkno_t  i_addr[20];
 } dinode;               /* Exactly 64 bytes long! */
 
-struct  stat    /* Really only used by libc */
-{
-	int16_t   st_dev;
-	uint16_t  st_ino;
-	uint16_t  st_mode;
-	uint16_t  st_nlink;
-	uint16_t  st_uid;
-	uint16_t  st_gid;
-	uint16_t  st_rdev;
-	off_t   st_size;
-	uint32_t  st_atime;	/* Break in 2038 */
-	uint32_t  st_mtime;
-	uint32_t  st_ctime;
-};
-
 /* We use the Linux one for compatibility. There's no real Unix 'standard'
    for such things */
 

--- a/Kernel/include/userstructs.h
+++ b/Kernel/include/userstructs.h
@@ -19,7 +19,7 @@ struct _uzistat
 	uint16_t st_gid;
 	uint16_t st_rdev;
 	uint32_t st_size;
-	uint32_t st_atime;  /* Breaks in 2038 */
+	uint32_t st_atime;
 	uint32_t st_mtime;
 	uint32_t st_ctime;
 	uint32_t st_timeh;	/* Time high bytes */

--- a/Kernel/include/userstructs.h
+++ b/Kernel/include/userstructs.h
@@ -1,0 +1,29 @@
+#ifndef _USERSTRUCTURES_H
+#define _USERSTRUCTURES_H
+
+/* Structures shared between kernel and user space.
+ *
+ * Only use explicitly sized types here --- otherwise differing compiler
+ * flags between kernel code and user code can pack them differently.
+ */
+
+struct _uzistat
+{
+	/* Do not change this without also changing stcpy() in syscall_fs.c. */
+
+	int16_t  st_dev;
+	uint16_t st_ino;
+	uint16_t st_mode;
+	uint16_t st_nlink;
+	uint16_t st_uid;
+	uint16_t st_gid;
+	uint16_t st_rdev;
+	uint32_t st_size;
+	uint32_t st_atime;  /* Breaks in 2038 */
+	uint32_t st_mtime;
+	uint32_t st_ctime;
+	uint32_t st_timeh;	/* Time high bytes */
+};
+
+#endif
+

--- a/Kernel/syscall_fs.c
+++ b/Kernel/syscall_fs.c
@@ -134,9 +134,10 @@ arg_t _fstat(void)
 /* Utility for stat and fstat */
 int stcpy(inoptr ino, char *buf)
 {
-	int err = uput((char *) &(ino->c_dev), buf, 12);
-	err |= uput((char *) &(ino->c_node.i_addr[0]), buf + 12, 2);
-	err |= uput((char *) &(ino->c_node.i_size), buf + 14, 16);
+	int err = uput((char *) &(ino->c_node.i_size),    buf + 0,         5*4);
+	err |=    uput((char *) &(ino->c_dev),            buf + 5*4,       2*2);
+	err |=    uput((char *) &(ino->c_node.i_mode),    buf + 5*4 + 2*2, 4*2);
+	err |=    uput((char *) &(ino->c_node.i_addr[0]), buf + 5*4 + 6*2, 1*2);
 	return err;
 }
 

--- a/Kernel/syscall_fs.c
+++ b/Kernel/syscall_fs.c
@@ -134,10 +134,9 @@ arg_t _fstat(void)
 /* Utility for stat and fstat */
 int stcpy(inoptr ino, char *buf)
 {
-	int err = uput((char *) &(ino->c_node.i_size),    buf + 0,         5*4);
-	err |=    uput((char *) &(ino->c_dev),            buf + 5*4,       2*2);
-	err |=    uput((char *) &(ino->c_node.i_mode),    buf + 5*4 + 2*2, 4*2);
-	err |=    uput((char *) &(ino->c_node.i_addr[0]), buf + 5*4 + 6*2, 1*2);
+	int err = uput((char *) &(ino->c_dev), buf, 12);
+	err |= uput((char *) &(ino->c_node.i_addr[0]), buf + 12, 2);
+	err |= uput((char *) &(ino->c_node.i_size), buf + 14, 16);
 	return err;
 }
 

--- a/Library/include/sys/types.h
+++ b/Library/include/sys/types.h
@@ -28,12 +28,12 @@ typedef unsigned char uchar;
 typedef unsigned int uint;
 #endif
 
-#ifndef __SIZE_T_DEFINED
+#if !defined(__SIZE_T_DEFINED) && !defined(_SIZE_T_DEFINED)
 #define __SIZE_T_DEFINED
 typedef uint16_t size_t;
 #endif
 
-#ifndef __SSIZE_T_DEFINED
+#if !defined(__SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED)
 #define __SSIZE_T_DEFINED
 typedef int16_t ssize_t;
 #endif

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -15,6 +15,13 @@ extern int syscall(int callno, ...);
 
 struct  _uzistat
 {
+	/* For alignment reasons, arrange this structure with largest objects
+	 * first. */
+	uint32_t   st_size;
+	uint32_t   st_atime;
+	uint32_t   st_mtime;
+	uint32_t   st_ctime;
+	uint32_t   st_timeh;	/* Time high bytes */
 	int16_t    st_dev;
 	uint16_t   st_ino;
 	uint16_t   st_mode;
@@ -22,11 +29,6 @@ struct  _uzistat
 	uint16_t   st_uid;
 	uint16_t   st_gid;
 	uint16_t   st_rdev;
-	uint32_t   st_size;
-	uint32_t   st_atime;
-	uint32_t   st_mtime;
-	uint32_t   st_ctime;
-	uint32_t   st_timeh;	/* Time high bytes */
 };
 
 struct _uzisysinfoblk {

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -10,24 +10,11 @@
 #endif
 #include <sys/stat.h>
 
+/* TODO: make this less nasty. */
+#include "../../Kernel/include/userstructs.h"
+
 extern int errno;
 extern int syscall(int callno, ...);
-
-struct  _uzistat
-{
-	int16_t    st_dev;
-	uint16_t   st_ino;
-	uint16_t   st_mode;
-	uint16_t   st_nlink;
-	uint16_t   st_uid;
-	uint16_t   st_gid;
-	uint16_t   st_rdev;
-	uint32_t   st_size;
-	uint32_t   st_atime;
-	uint32_t   st_mtime;
-	uint32_t   st_ctime;
-	uint32_t   st_timeh;	/* Time high bytes */
-};
 
 struct _uzisysinfoblk {
   uint8_t infosize;		/* For expandability */

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -15,13 +15,6 @@ extern int syscall(int callno, ...);
 
 struct  _uzistat
 {
-	/* For alignment reasons, arrange this structure with largest objects
-	 * first. */
-	uint32_t   st_size;
-	uint32_t   st_atime;
-	uint32_t   st_mtime;
-	uint32_t   st_ctime;
-	uint32_t   st_timeh;	/* Time high bytes */
 	int16_t    st_dev;
 	uint16_t   st_ino;
 	uint16_t   st_mode;
@@ -29,6 +22,11 @@ struct  _uzistat
 	uint16_t   st_uid;
 	uint16_t   st_gid;
 	uint16_t   st_rdev;
+	uint32_t   st_size;
+	uint32_t   st_atime;
+	uint32_t   st_mtime;
+	uint32_t   st_ctime;
+	uint32_t   st_timeh;	/* Time high bytes */
 };
 
 struct _uzisysinfoblk {

--- a/Library/libs/error.c
+++ b/Library/libs/error.c
@@ -11,6 +11,7 @@
 #include <paths.h>
 #include <errno.h>
 #include <fcntl.h>
+#include "malloc-l.h"
 
 static uint8_t *__sys_errlist;
 static uint16_t *__sys_errptr;
@@ -25,7 +26,7 @@ static void _load_errlist(void)
 		return;
 	if (fstat(fd, &st) < 0 || !S_ISREG(st.st_mode))
 		goto bad;
-	__sys_errlist = sbrk((st.st_size + 3)&~3);
+	__sys_errlist = sbrk(ALIGNUP(st.st_size));
 	if (__sys_errlist == (void *) -1)
 		goto bad;
 	if (read(fd,__sys_errlist, st.st_size) == st.st_size) {

--- a/Library/libs/free.c
+++ b/Library/libs/free.c
@@ -135,8 +135,13 @@ void *__mini_malloc(size_t size)
 	if (size == 0)
 		return 0;
 
+	/* Ensure size is aligned, otherwise our memory nodes become unaligned
+	 * and we get hard-to-debug errors on platforms which require
+	 * aligned accesses. */
+	size = ALIGNUP(size + sizeof(struct mem_cell));
+
 	/* Minor oops here, sbrk has a signed argument */
-	if (size > (((unsigned) -1) >> 1) - sizeof(struct mem_cell) * 3) {
+	if (size > (((unsigned) -1) >> 1) - sizeof(struct mem_cell) * 2) {
 	      nomem:errno = ENOMEM;
 		return 0;
 	}

--- a/Library/libs/malloc-l.h
+++ b/Library/libs/malloc-l.h
@@ -14,6 +14,26 @@
 
 #define __MINI_MALLOC__
 
+union maximally_aligned {
+	uint8_t b;
+	uint16_t s;
+	uint32_t i;
+	#if !defined(NO_64BIT)
+		uint64_t l;
+	#endif
+	float f;
+	double d;
+};
+
+struct malloc_alignment_tester
+{
+	char b;
+	union maximally_aligned u;
+};
+
+#define ALIGNMENT ((int)&(((struct malloc_alignment_tester*)NULL)->u))
+#define ALIGNUP(s) (((s) + ALIGNMENT - 1) & ~(ALIGNMENT - 1))
+
 #define MCHUNK		512	/* Allocation unit in 'mem' elements */
 #undef LAZY_FREE		/* If set frees can be infinitly defered */
 #undef MINALLOC	/* 32 */	/* Smallest chunk to alloc in 'mem's */
@@ -29,9 +49,10 @@
 #endif
 
 typedef struct mem_cell {
-	struct mem_cell *next;	/* A pointer to the next mem */
-	unsigned int size;	/* An int >= sizeof pointer */
-	char *depth;		/* For the alloca hack */
+	struct mem_cell *next;              /* A pointer to the next mem */
+	unsigned int size;                  /* An int >= sizeof pointer */
+	char *depth;                        /* For the alloca hack */
+	union maximally_aligned padding[0]; /* Ensures alignment of payload */
 } mem;
 
 #define m_size(p)  ((p)[0].size)		/* For malloc */

--- a/Library/libs/malloc.c
+++ b/Library/libs/malloc.c
@@ -24,12 +24,10 @@ void *malloc(size_t size)
 	if (size == 0)
 		return 0;	/* ANSI STD */
 
-	/* Ensure size is aligned, otherwise our memory nodes become unaligned
-	 * and we get hard-to-debug errors on platforms which require
-	 * aligned accesses. */
-	size = (size + sizeof(void*) - 1) & ~(sizeof(void*) - 1);
-
-	sz = size + sizeof(struct mem_cell);
+	/* Ensure the size is aligned, otherwise our memory nodes become unaligned
+	 * and we get hard-to-debug errors on platforms which require aligned
+	 * accesses. */
+	sz = ALIGNUP(size + sizeof(struct mem_cell));
 
 #ifdef MINALLOC
 	if (sz < MINALLOC)


### PR DESCRIPTION
The only bit of any great interest is the stcpy(), which writes to the user's struct _uzistat structure. I've rearranged it to avoid random member padding upsetting it due to alignment, but I'm not really a fan --- it's very fragile, and any changes would probably fail. I'd much rather import struct _uzistat into the kernel and copy the members one by one, but on small architectures that's probably very expensive.

I suspect the other structures will fail in the same way, but I haven't been bitten by those yet.