### PR TITLE
Data corruption in waitpid()

### DIFF
--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -381,7 +381,8 @@ typedef struct p_tab {
 #ifdef udata
     struct u_data *p_udata;	/* Udata pointer for platforms using dynamic udata */
 #endif
-    /* Everything below here is overlaid by time info at exit */
+    /* Everything below here is overlaid by time info at exit.
+	 * Make sure it's 32-bit aligned. */
     uint16_t    p_priority;     /* Process priority */
     uint32_t    p_pending;      /* Bitmask of pending signals */
     uint32_t    p_ignored;      /* Bitmask of ignored signals */

--- a/Kernel/syscall_proc.c
+++ b/Kernel/syscall_proc.c
@@ -315,8 +315,8 @@ arg_t _waitpid(void)
 
 					/* Add in child's time info.  It was stored on top */
 					/* of p_priority in the childs process table entry. */
-					udata.u_cutime += ((clock_t *)p->p_priority)[0];
-					udata.u_cstime += ((clock_t *)p->p_priority)[1];
+					udata.u_cutime += ((clock_t *)&p->p_priority)[0];
+					udata.u_cstime += ((clock_t *)&p->p_priority)[1];
 					return retval;
 				}
 			}


### PR DESCRIPTION
I suspect I'm the only one to have noticed this because p_priority normally stores a small integer, which points at a memory location which is usually unused. I noticed this on the ARM because of unalignment traps. I should probably try and get zero page unmapped --- need to look into how to relocate the reset vectors...
