### PR TITLE
msx2: fix build dependency

### DIFF
--- a/Kernel/platform-msx2/image.mk
+++ b/Kernel/platform-msx2/image.mk
@@ -2,7 +2,7 @@ fuzix.ihx: target $(OBJS) platform-$(TARGET)/fuzix.lnk tools/bankld/sdldz80
 	$(CROSS_LD) -n -k $(LIBZ80) -f platform-$(TARGET)/fuzix.lnk
 	$(CROSS_LD) -n -k $(LIBZ80) -f platform-$(TARGET)/fuzix_boot.lnk
 
-fuzix.bin: fuzix.ihx bootrom.bin tools/bihx tools/analysemap tools/memhogs tools/binman tools/bintomdv cpm-loader/cpmload.bin
+fuzix.bin: fuzix.ihx tools/bihx tools/analysemap tools/memhogs tools/binman tools/bintomdv cpm-loader/cpmload.bin
 	-cp hogs.txt hogs.txt.old
 	tools/memhogs <fuzix.map |sort -nr >hogs.txt
 	head -5 hogs.txt


### PR DESCRIPTION
bootrom.bin is generated along with fuzix.ihx