### PR TITLE
kill.c: bugfix: inverted test of strcmp

### DIFF
--- a/Applications/util/kill.c
+++ b/Applications/util/kill.c
@@ -29,9 +29,9 @@ int main(int argc, char *argv[])
 	    sig = SIGINT;
 	else if (!strcmp(cp, "QUIT"))
 	    sig = SIGQUIT;
-	else if (strcmp(cp, "KILL"))
+	else if (!strcmp(cp, "KILL"))
 	    sig = SIGKILL;
-	else if (strcmp(cp, "TERM"))
+	else if (!strcmp(cp, "TERM"))
 	    sig = SIGTERM;
 	else {
 	    sig = 0;


### PR DESCRIPTION
This bug made every signal number into SIGKILL, disallowing TERM or numbered sigs.