### PR TITLE
coredump: clear u_error for new batch of calls.

### DIFF
--- a/Kernel/syscall_exec16.c
+++ b/Kernel/syscall_exec16.c
@@ -361,6 +361,8 @@ uint8_t write_core_image(void)
 	inoptr parent = NULLINODE;
 	inoptr ino;
 
+	udata.u_error = 0;
+
 	ino = kn_open("core", &parent);
 	if (ino) {
 		i_deref(parent);


### PR DESCRIPTION
fixes bug in core-dumping that caused 0 length core files.  See issue #320.