### PR TITLE
opendir_r: bugfix: bad first iteration of readdir

### DIFF
--- a/Library/libs/opendir_r.c
+++ b/Library/libs/opendir_r.c
@@ -20,5 +20,7 @@ DIR *opendir_r(DIR *dir, char *path)
 	if ((dir->dd_fd = open(path, O_RDONLY | O_CLOEXEC)) < 0)
 		return NULL;
 	dir->dd_loc = 0;
+	dir->_priv.next = 0;
+	dir->_priv.last = 0;
 	return dir;
 }


### PR DESCRIPTION
On first call to readdir() after opendir_r(), readdir returns garbage, thinking it's internal directory file buffer is full and unprocessed.  If the DIR is user-allocated on stack, then there are no guarantees they are set to anything.  

https://github.com/EtchedPixels/FUZIX/blob/master/Library/libs/readdir.c#L14

dnext(), called by readdir(), tests next and last with nothing setting them.