### PR TITLE
bugfix: umount

### DIFF
--- a/Applications/util/umount.c
+++ b/Applications/util/umount.c
@@ -53,7 +53,6 @@ int rm_mtab(char *devname)
     }
     while (fgets(tmp, sizeof(tmp), inpf)) {
 		dev = strtok(tmp, " ");
-		mntpt = strtok(NULL, " ");
         if (strcmp(dev, devname) == 0) {
             continue;
         } else {

--- a/Applications/util/umount.c
+++ b/Applications/util/umount.c
@@ -7,90 +7,89 @@
 
 char *getdev(char *arg)
 {
-    FILE *f;
+	FILE *f;
 	char tmp[MTAB_LINE];
 	char* dev;
 	char* mntpt;
-    
-    f = fopen("/etc/mtab", "r");
-    if (f) {
-        while (fgets(tmp, sizeof(tmp), f)) {
+
+	f = fopen("/etc/mtab", "r");
+	if (f) {
+		while (fgets(tmp, sizeof(tmp), f)) {
 			dev = strtok(tmp, " ");
 			mntpt = strtok(NULL, " ");
-            if ((strcmp(dev, arg) == 0) || (strcmp(mntpt, arg) == 0)) {
-                fclose(f);
-                return strdup(dev);
-            }
-        }
-        fclose(f);
-    }
-
-    return NULL;
+			if ((strcmp(dev, arg) == 0) || (strcmp(mntpt, arg) == 0)) {
+				fclose(f);
+				return strdup(dev);
+			}
+		}
+		fclose(f);
+	}
+	return NULL;
 }
 
 
 int rm_mtab(char *devname)
 {
-    FILE *inpf, *outf;
-    char *tmp_fname;
+	FILE *inpf, *outf;
+	char *tmp_fname;
 	char tmp[MTAB_LINE];
 	char tmp2[MTAB_LINE];
 	char* dev;
 	char* mntpt;
 
-    if ((tmp_fname = tmpnam(NULL)) == NULL) {
-        perror("Error getting temporary file name");
-        exit(1);
-    }
-    inpf = fopen("/etc/mtab", "r");
-    if (!inpf) {
-        perror("Can't open /etc/mtab");
-        exit(1);
-    }
-    outf = fopen(tmp_fname, "w");
-    if (!outf) {
-        perror("Can't create temporary file");
-        exit(1);
-    }
-    while (fgets(tmp, sizeof(tmp), inpf)) {
-	    strncpy( tmp2, tmp, MTAB_LINE );
+	if ((tmp_fname = tmpnam(NULL)) == NULL) {
+		perror("Error getting temporary file name");
+		exit(1);
+	}
+	inpf = fopen("/etc/mtab", "r");
+	if (!inpf) {
+		perror("Can't open /etc/mtab");
+		exit(1);
+	}
+	outf = fopen(tmp_fname, "w");
+	if (!outf) {
+		perror("Can't create temporary file");
+		exit(1);
+	}
+	while (fgets(tmp, sizeof(tmp), inpf)) {
+		strncpy( tmp2, tmp, MTAB_LINE );
 		dev = strtok(tmp, " ");
-        if (strcmp(dev, devname) == 0) {
-            continue;
-        } else {
-            fprintf(outf, "%s", tmp2);
-        }
-    }
-    fclose(inpf);
-    fclose(outf);
-    if (unlink("/etc/mtab") < 0) {
-        perror("Can't delete old /etc/mtab file");
-        exit(1);
-    }
-    if (rename(tmp_fname, "/etc/mtab") < 0) {
-        perror("Error installing /etc/mtab");
-        exit(1);
-    }
-    return 0;
+		if (strcmp(dev, devname) == 0) {
+			continue;
+		} else {
+			fprintf(outf, "%s", tmp2);
+		}
+	}
+	fclose(inpf);
+	fclose(outf);
+	if (unlink("/etc/mtab") < 0) {
+		perror("Can't delete old /etc/mtab file");
+		exit(1);
+	}
+	if (rename(tmp_fname, "/etc/mtab") < 0) {
+		perror("Error installing /etc/mtab");
+		exit(1);
+	}
+	return 0;
 }
 
 int main(int argc, char *argv[])
 {
-    char *dev;
+	char *dev;
+	
+	if (argc != 2) {
+		printf("usage: umount device\n");
+		return 1;
+	}
 
-    if (argc != 2) {
-        printf("usage: umount device\n");
-        return 1;
-    }
-
-    dev = getdev(argv[1]);
-    if (!dev) dev = argv[1];
-
-    if (umount(dev) == 0) {
-        rm_mtab(dev);
-    } else {
-        perror("umount");
-        return 1;
-    }
-    return 0;
+	dev = getdev(argv[1]);
+	if (!dev) dev = argv[1];
+	
+	if (umount(dev) == 0) {
+		rm_mtab(dev);
+	} else {
+		perror("umount");
+		return 1;
+	}
+	return 0;
 }

--- a/Applications/util/umount.c
+++ b/Applications/util/umount.c
@@ -34,6 +34,7 @@ int rm_mtab(char *devname)
     FILE *inpf, *outf;
     char *tmp_fname;
 	char tmp[MTAB_LINE];
+	char tmp2[MTAB_LINE];
 	char* dev;
 	char* mntpt;
 
@@ -52,11 +53,12 @@ int rm_mtab(char *devname)
         exit(1);
     }
     while (fgets(tmp, sizeof(tmp), inpf)) {
+	    strncpy( tmp2, tmp, MTAB_LINE );
 		dev = strtok(tmp, " ");
         if (strcmp(dev, devname) == 0) {
             continue;
         } else {
-            fprintf(outf, "%s", tmp);
+            fprintf(outf, "%s", tmp2);
         }
     }
     fclose(inpf);


### PR DESCRIPTION
bug: umount not re-writing /etc/mtab correctly.  In rm_mtab():  strtok is used to find the umounted device line, but strtok modifies it's input string, so non matching entries where being truncated (by strtok).  Cleaned up formatting.