### PR TITLE
bank16k:  bug fix pagemap_realloc

### DIFF
--- a/Kernel/bank16k.c
+++ b/Kernel/bank16k.c
@@ -124,10 +124,11 @@ int pagemap_realloc(usize_t size)
 	if (have > want) {
 		for (i = want; i < have; i++) {
 			pfree[pfptr++] = ptr[i];
-			ptr[i] = ptr[3];
+			ptr[i] = ptr[ want - 1 ];
 		}
 		udata.u_ptab->p_page = udata.u_page;
 		udata.u_ptab->p_page2 = udata.u_page2;
+		program_vectors(&udata.u_page);
 		return 0;
 	}
 


### PR DESCRIPTION
bug: released map pages in udata being filled in with simultaneously freed common page 3.  On context switch back to user-space, fuzix would explode because common has been moved (just like the case of want>have) Fix: fill in freed elements with our new "top" page, and proceed to copy our common code.  This also echos what pagemap_alloc() does.