### PR TITLE
Tweaks to allow library to build on 6809

### DIFF
--- a/Library/include/sys/.gitignore
+++ b/Library/include/sys/.gitignore
@@ -1,2 +1,3 @@
 # not tracked here; copied from kernel tree by build process
 userstructs.h
+drivewire.h

--- a/Library/include/termcap.h
+++ b/Library/include/termcap.h
@@ -14,7 +14,7 @@ extern int tgetflag(char *__id);
 extern int tgetnum(char *__id);
 extern char *tgetstr(char *__id, char **__area);
 
-extern int tputs(const char *__str, int __affcnt, int (*__putc)(int)));
+extern int tputs(const char *__str, int __affcnt, int (*__putc)(int ch));
 extern char *tgoto(const char *__cap, int __col, int __row);
 
 #endif /* _TERMCAP_H */

--- a/Library/libs/tzset.c
+++ b/Library/libs/tzset.c
@@ -1,5 +1,5 @@
-/*************************** TZSET ************************************/  
-    
+/*************************** TZSET ************************************/
+
 #include <time.h>
 #include <string.h>
 #include <stdlib.h>
@@ -8,22 +8,22 @@ char *tzname[2] = { "GMT", "\0\0\0" };
 
 int daylight;
 long timezone;
- 
+
 /* tzset expects fo find a environment string of the form TZ=...
  * ??? need to correct!
- */ 
-void tzset(VOID)
+ */
+void tzset(void)
 {
-	char *tz = getenv("TZ");
+        char *tz = getenv("TZ");
 
-	if (tz == NULL) {
-		memcpy(tzname[1], "GMT", 3);
-		timezone = 0 * 60 * 60L;	/* London */
-	} else {
-		int v;
-		
-		memcpy(tzname[1], tz, 3);
-		v = atoi(tz + 3);
-		timezone = -((v / 100) * 60 + (v % 100)) * 60L;
-	}
-} 
+        if (tz == NULL) {
+                memcpy(tzname[1], "GMT", 3);
+                timezone = 0 * 60 * 60L;        /* London */
+        } else {
+                int v;
+
+                memcpy(tzname[1], tz, 3);
+                v = atoi(tz + 3);
+                timezone = -((v / 100) * 60 + (v % 100)) * 60L;
+        }
+}


### PR DESCRIPTION
In termcap.h there was an extra closing brace on tputs
In tzset.c there was a VOID that caused unhappiness; changed to void. Also expunged DOS line endings and trailing whitespace.
Now builds and apparently working on 6809.