### PR TITLE
Fix dragon, coco3 graphics bounds checking

### DIFF
--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -165,7 +165,7 @@ int gfx_draw_op(uarg_t arg, char *ptr)
 			break;
 		}
 		l -= 8;
-		if (p[0] > 191 || p[1] > 31 || p[2] > 191 || p[3] > 31 ||
+		if (p[0] > 191 || p[1] > 31 || p[2] > 192 || p[3] > 32 ||
 		    p[0] + p[2] > 192 || p[1] + p[3] > 32 ||
 		    (p[2] * p[3]) > l) {
 			err = -EFAULT;

--- a/Kernel/platform-dragon-nx32/devtty.c
+++ b/Kernel/platform-dragon-nx32/devtty.c
@@ -396,7 +396,7 @@ static int gfx_draw_op(uarg_t arg, char *ptr, uint8_t *buf)
     if (l < 8)
       return EINVAL;
     l -= 8;
-    if (p[0] > 191 || p[1] > 31 || p[2] > 191 || p[3] > 31 ||
+    if (p[0] > 191 || p[1] > 31 || p[2] > 192 || p[3] > 32 ||
       p[0] + p[2] > 192 || p[1] + p[3] > 32 ||
       (p[2] * p[3]) > l)
       return -EFAULT;


### PR DESCRIPTION
we really can write 32 byte wide lines, 192 line columns