### PR TITLE
Add a schlocky ashrsi3 to 6809, fix devdw.

### DIFF
--- a/Kernel/dev/devdw.c
+++ b/Kernel/dev/devdw.c
@@ -49,7 +49,7 @@ static int dw_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
     cmd[6] = page >> 8;
     cmd[7] = page & 0xFF;
         
-    while (ct < udata.u_nblock) {
+    while (ct++ < udata.u_nblock) {
         for (tries = 0; tries < 4 ; tries++) {
             /* kprintf("dw_operation block %d left %d\n", block, nblock); */
             irq = di(); /* for now block interrupts for whole operation */

--- a/Kernel/lowlevel-6809.s
+++ b/Kernel/lowlevel-6809.s
@@ -17,6 +17,7 @@
 	.globl	_ashrhi3
 	.globl	_lshrhi3
 	.globl	___ashlsi3
+	.globl  ___ashrsi3
 	.globl	_swab
 
 	; debugging aids
@@ -572,6 +573,34 @@ _ashlhi3_1:
 _ashlhi3_2:
 	puls	x,pc
 
+
+
+___ashrsi3:
+	pshs	u
+	; FIXME temporary hack until we fix gcc-6809 or our use of it
+	; the argument passing doesn't match so we'll mangle it
+	ldu 4,s
+	stu ,x
+	ldu 6,s
+	stu 2,x
+	ldb 9,s
+	;; FIXME: insert 16 and 8 optimization here
+	;; remember to propigate top bit for signage
+try_rest@
+	tstb			; redunant until optimizations are added
+	beq	done@
+do_rest@
+	; Shift by 1
+	asr	,x
+	ror	1,x
+	ror	2,x
+	ror	3,x
+	decb
+	bne	do_rest@
+done@
+	puls	u,pc
+
+	
 ___ashlsi3:
 	pshs	u
 


### PR DESCRIPTION
This needs some optimization (what's the easiest way to propagate the sign bit when optimizing?).  ashrsi3 follows same calling convention as existing ashlsi3.  This makes new devio changes compile on 6809.  Plus simple bug fix for devdw.