### PR TITLE
Have touch emit error message

### DIFF
--- a/Applications/util/touch.c
+++ b/Applications/util/touch.c
@@ -1,30 +1,52 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <utime.h>
+#include <errno.h>
+#include <sys/stat.h>
 
 static time_t settime;
 
 int main(int argc, const char *argv[])
 {
-    int er = 0, i, ncreate = 0;
+    int er = 0, res, i, ncreate = 0, fd;
     struct stat sbuf;
     struct utimbuf tbuf;
 
-    if ((argv[1][0] == '-') && (argv[1][1] == 'c'))
+    if ((argv[1][0] == '-') && (argv[1][1] == 'c')) {
 	ncreate = 1;
+    }
 
     for (i = ncreate + 1; i < argc; i++) {
 	if (argv[i][0] != '-') {
-	    if (stat(argv[i], &sbuf)) {
-		if (!ncreate)
-		    er = close(creat(argv[i], 0666));
+	    if (stat(argv[i], &sbuf) < 0) {
+		if (!ncreate) {
+		    fd = creat(argv[i], 0666);
+		    if (fd < 0) {
+			res = -1;
+		    } else {
+			close(fd);
+			res = 0;
+		    }
+		} else {
+		    /* -c: Quietly ignore missing files */
+		    res = 0;
+		}
 	    } else {
 	        settime = time(NULL);
                 tbuf.actime = settime;
 	        tbuf.modtime = settime;
-                er |= utime(argv[i], &tbuf);
+                res = utime(argv[i], &tbuf);
 	    }
+
+	    /* Complain on each failed touch */
+	    if (res) {
+		fprintf(stderr, "%s: cannot touch '%s': %s\n",
+		    argv[0], argv[i], strerror(errno));
+	    }
+
+	    /* Accumulate errors */
+	    er |= res;
 	}
     }
-    return er;
+    return (er ? 1 : 0);
 }


### PR DESCRIPTION
Following usual tool behavior, touch should emit an error when it can not
create a file (for instance, due to permissions).  Error message used mimics
touch as found on your typica *-ix system.

Shuffled error treatment, as close(create(...)) obscures the actual errno with
"invalid file descriptor" errno.