### PR TITLE
Making zx128 port compilable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ cscope.*
 *~
 # Statistics from builds
 size.report
+# Build system output
+.obj
+bin

--- a/Kernel/.gitignore
+++ b/Kernel/.gitignore
@@ -9,3 +9,11 @@ hogs.txt
 platform
 relocs.dat
 version.c
+
+# binmunge output
+bank[0-9].bin
+bank[0-9].ihx
+
+# target system images
+*.sna
+*.z80

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -183,7 +183,7 @@ font4x6.c: tools/make4x6
 	tools/make4x6 >font4x6.c
 
 clean:
-	rm -f $(OBJS) $(JUNK) fuzix.cdb fuzix.com fuzix.tmp platform fuzix.bin fuzix.map fuzix.noi fuzix.ihx common.ihx common.bin relocs.dat core *~ include/*~ version.c tools/make4x6 tools/analysemap tools/memhogs tools/binman tools/bihx tools/bintomdv tools/chkmdv tools/decbdragon tools/decb-image hogs.txt hogs.txt.old tools/*~
+	rm -f $(OBJS) $(JUNK) fuzix.cdb fuzix.com fuzix.tmp platform fuzix.bin fuzix.map fuzix.noi fuzix.ihx common.ihx common.bin relocs.dat core *~ include/*~ version.c tools/make4x6 tools/analysemap tools/memhogs tools/binman tools/bihx tools/binmunge tools/bintomdv tools/bin2sna tools/bin2z80 tools/chkmdv tools/decbdragon tools/decb-image hogs.txt hogs.txt.old tools/*~
 	+$(MAKE) -C platform-$(TARGET) clean
 	+$(MAKE) -C cpm-loader clean
 	+$(MAKE) -C tools/bankld clean

--- a/Kernel/cpu-z80/image.mk
+++ b/Kernel/cpu-z80/image.mk
@@ -26,7 +26,7 @@ tools/makejv3: tools/makejv3.c
 fuzix.ihx: target $(OBJS) platform-$(TARGET)/fuzix.lnk tools/bankld/sdldz80
 	$(CROSS_LD) -n -k $(LIBZ80) -f platform-$(TARGET)/fuzix.lnk
 
-fuzix.bin: fuzix.ihx tools/bihx tools/analysemap tools/memhogs tools/binman tools/bintomdv cpm-loader/cpmload.bin tools/bbc
+fuzix.bin: fuzix.ihx tools/bihx tools/analysemap tools/memhogs tools/binman tools/bintomdv tools/binmunge tools/bin2sna tools/bin2z80 cpm-loader/cpmload.bin
 	-cp hogs.txt hogs.txt.old
 	tools/memhogs <fuzix.map |sort -nr >hogs.txt
 	head -5 hogs.txt

--- a/Kernel/dev/net/net_z80pack.c
+++ b/Kernel/dev/net/net_z80pack.c
@@ -164,7 +164,7 @@ int net_listen(struct socket *s)
 int net_connect(struct socket *s)
 {
 	/* This is in host big endian order already */
-	uint8_t *p = &s->s_addr[SADDR_DST].addr;
+	uint8_t *p = (uint8_t*)&s->s_addr[SADDR_DST].addr;
 	uint8_t err;
 	irqflags_t irq = di();
 
@@ -175,7 +175,7 @@ int net_connect(struct socket *s)
 	netctrl = *p++;
 	netctrl = *p++;
 	netctrl = *p;
-	p = &s->s_addr[SADDR_DST].port;
+	p = (uint8_t*)&s->s_addr[SADDR_DST].port;
 	/* Write the port */
 	netctrl = *p++;
 	netctrl = *p;

--- a/Kernel/platform-zx128/bank128.c
+++ b/Kernel/platform-zx128/bank128.c
@@ -32,8 +32,10 @@ void pagemap_free(ptptr p)
 
 int pagemap_alloc(ptptr p)
 {
+#ifdef SWAPDEV
 	if (pfptr == 0)
 		swapneeded(p, 1);
+#endif
 	if (pfptr == 0)
 		return ENOMEM;
 	p->p_page = pfree[--pfptr];
@@ -59,6 +61,9 @@ uint16_t pagemap_mem_used(void)
  */
 int swapout(ptptr p)
 {
+#ifndef SWAPDEV
+	p; /* to shut the compiler */
+#else
 	uint16_t blk;
 	uint16_t map;
 
@@ -89,6 +94,7 @@ int swapout(ptptr p)
 #ifdef DEBUG
 	kprintf("%x: swapout done %d\n", p, p->p_page);
 #endif
+#endif
 	return 0;
 }
 
@@ -99,6 +105,9 @@ int swapout(ptptr p)
  */
 void swapin(ptptr p, uint16_t map)
 {
+#ifndef SWAPDEV
+	p;map; /* to shut the compiler */
+#else
 	uint16_t blk = map * SWAP_SIZE;
 
 #ifdef DEBUG
@@ -123,5 +132,6 @@ void swapin(ptptr p, uint16_t map)
 	low_bank = p;
 #ifdef DEBUG
 	kprintf("%x: swapin done %d\n", p, p->p_page);
+#endif
 #endif
 }

--- a/Kernel/platform-zx128/config.h
+++ b/Kernel/platform-zx128/config.h
@@ -52,7 +52,7 @@
 #define NUM_DEV_TTY 1
 
 #define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */
-#define SWAPDEV  2051	/* Microdrive 3 : FIXME - configure and probe */
+/* #define SWAPDEV  2051 */ /* Microdrive 3 : FIXME - configure and probe */
 #define NBUFS    9       /* Number of block buffers */
 #define NMOUNTS	 4	  /* Number of mounts at a time */
 #define MAX_BLKDEV 2	    /* 2 IDE drives, 1 SD drive */

--- a/Kernel/platform-zx128/devfd.c
+++ b/Kernel/platform-zx128/devfd.c
@@ -3,6 +3,8 @@
 #include <printf.h>
 #include <devfd.h>
 
+#include "disciple.h"
+
 #define MAX_FD	2
 
 #define OPDIR_NONE	0

--- a/Kernel/platform-zx128/devices.c
+++ b/Kernel/platform-zx128/devices.c
@@ -48,7 +48,10 @@ void device_init(void)
 #ifdef CONFIG_IDE
   devide_init();
 #endif
+
+#ifdef SWAPDEV
   /* Hack for now - we need to open the swap to get the map. Should
      we open swap nicely somewhere generic ? */
   d_open(SWAPDEV, 0);
+#endif
 }

--- a/Kernel/platform-zx128/devmdv.c
+++ b/Kernel/platform-zx128/devmdv.c
@@ -58,11 +58,16 @@ static int mdv_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
 		block = udata.u_offset >> 9;
 		mdv_page = udata.u_page;
 	} else {
+#ifdef SWAPDEV
 		/* Microdrive swap awesomeness */
 		mdv_buf = swapbase;
 		nblock = swapcnt >> 9;
 		block = swapblk;
 		mdv_page = swappage;
+#else
+		/* Attempt to swap when swapping is disabled */
+		goto bad;
+#endif
 	}
 
 	irq = di();

--- a/Kernel/platform-zx128/disciple.h
+++ b/Kernel/platform-zx128/disciple.h
@@ -1,0 +1,8 @@
+#ifndef __DISCIPLE_DOT_H__
+#define __DISCIPLE_DOT_H__
+
+/* low level interface */
+uint16_t fd_reset(uint8_t *driveptr);
+uint16_t fd_operation(uint8_t *driveptr);
+
+#endif /* __DISCIPLE_DOT_H__ */

--- a/Kernel/platform-zx128/fuzix.lnk
+++ b/Kernel/platform-zx128/fuzix.lnk
@@ -6,6 +6,7 @@
 -b _CODE2=0xC000
 -b _CODE3=0xDB00
 -b _DISCARD=0x8000
+-l z80
 platform-zx128/crt0.rel
 platform-zx128/commonmem.rel
 platform-zx128/zx128.rel

--- a/Kernel/platform-zx128/main.c
+++ b/Kernel/platform-zx128/main.c
@@ -9,10 +9,12 @@ uint16_t ramtop = PROGTOP;
 
 void pagemap_init(void)
 {
+#ifdef SWAPDEV
   /* Swap */
   swapmap_add(0);
   swapmap_add(1);
   swapmap_add(2);
+#endif
 }
 
 /* On idle we spin checking for the terminals. Gives us more responsiveness
@@ -42,3 +44,11 @@ void platform_interrupt(void)
 void map_init(void)
 {
 }
+
+#ifndef SWAPDEV
+/* Adding dummy swapper since it is referenced by tricks.s */
+void swapper(ptptr p)
+{
+  p;
+}
+#endif

--- a/Kernel/tools/.gitignore
+++ b/Kernel/tools/.gitignore
@@ -1,6 +1,10 @@
 analysemap
+bbc
 bihx
+bin2sna
+bin2z80
 binman
+binmunge
 bintomdv
 make4x6
 memhogs


### PR DESCRIPTION
Main change is isolation of the microdrive swap support inside the "ifdef SWAPDEV" blocks. zx128 use old swapping mechanism and so cannot be compiled now.

Also little changes in gitignores/makefiles and accidental fix for net_z80pack.c