### PR TITLE
found this issue when trying to ranlib libm6809.a

### DIFF
--- a/Library/libs/Makefile.6809
+++ b/Library/libs/Makefile.6809
@@ -138,7 +138,7 @@ $(OBJ_CURS):%.o: %.c
 vfscanf-libm.o: vfscanf.c
 	$(CC) $(CC_OPT) -DBUILD_LIBM $< -o $@
 
-vfprintf-libm.o: vfscanf.c
+vfprintf-libm.o: vfprintf.c
 	$(CC) $(CC_OPT) -DBUILD_LIBM $< -o $@
 
 $(OBJ_HARD):%.o: %.c


### PR DESCRIPTION
found this issue when trying to ranlib libm6809.a: 'error: multiple defined label _fp_scan'