### PR TITLE
added missing operation letter

### DIFF
--- a/Library/libs/Makefile.6809
+++ b/Library/libs/Makefile.6809
@@ -92,7 +92,7 @@ syscall.l: fuzix$(PLATFORM)/syslib.l
 
 syslib$(PLATFORM).lib: syscall.l libc.l
 	cat libc.l syscall.l >syslib.l
-	$(AR) -c syslib$(PLATFORM).lib $$(cat syslib.l)
+	$(AR) rc syslib$(PLATFORM).lib $$(cat syslib.l)
 	ln -sf syslib$(PLATFORM).lib libc$(PLATFORM).a
 
 fuzix$(PLATFORM)/syslib.l: ../tools/syscall_$(PLATFORM)
@@ -109,15 +109,15 @@ liberror.txt: ../tools/liberror
 	make -C .. tools/liberror
 
 curses$(PLATFORM).lib: $(OBJ_CURS)
-	$(AR) -c curses$(PLATFORM).lib $(OBJ_CURS)
+	$(AR) rc curses$(PLATFORM).lib $(OBJ_CURS)
 	ln -sf curses$(PLATFORM).lib libcurses$(PLATFORM).a
 
 termcap$(PLATFORM).lib: $(OBJ_CT)
-	$(AR) -c termcap$(PLATFORM).lib $(OBJ_CT)
+	$(AR) rc termcap$(PLATFORM).lib $(OBJ_CT)
 	ln -sf termcap$(PLATFORM).lib libtermcap$(PLATFORM).a
 
 m$(PLATFORM).lib: $(OBJ_LM)
-	$(AR) -c m$(PLATFORM).lib $(OBJ_LM)
+	$(AR) rc m$(PLATFORM).lib $(OBJ_LM)
 	ln -sf m$(PLATFORM).lib libm$(PLATFORM).a
 
 $(OBJ_ASM):%.o: %.s


### PR DESCRIPTION
ar: missing operation letter, in this case 'r', must have one