### PR TITLE
net_native: add async event for remote shutdown.

### DIFF
--- a/Kernel/dev/net/net_native.c
+++ b/Kernel/dev/net/net_native.c
@@ -81,6 +81,12 @@ int netdev_write(void)
 		s->s_iflag |= SI_DATA;
 		wakeup(&s->s_iflag);
 		break;
+		/* Remote closed connection */
+	case NE_SHUTR:
+		s->s_iflag |= SI_SHUTR;
+		sd->err = ne.ret;
+		wakeup_all(s);
+		break;
 	default:
 		kprintf("netbad %d\n", ne.event);
 		udata.u_error = EOPNOTSUPP;

--- a/Kernel/include/net_native.h
+++ b/Kernel/include/net_native.h
@@ -50,6 +50,7 @@ struct sockmsg {
 #define NE_INIT		4
 #define NE_ROOM		5
 #define NE_DATA		6
+#define NE_SHUTR        7
 
 struct netevent {
 	uint8_t socket;
@@ -63,5 +64,11 @@ struct netevent {
 };
 
 #define NET_INIT	0x4401
+
+int netdev_write(void);
+int netdev_read(uint8_t flag);
+int netdev_ioctl(uarg_t request, char *data);
+int netdev_close(void);
+
 
 #endif


### PR DESCRIPTION
also adds some prototypes so syscall_net.c can find 'em. 