### PR TITLE
refactored which utility

### DIFF
--- a/Applications/util/which.c
+++ b/Applications/util/which.c
@@ -4,45 +4,45 @@
 
 int main(int argc, char *argv[])
 {
-    int  quit, found;
-    char *envpath;
-    char *path, *cp;
-    static char buf[512];
-    static char patbuf[512];
+	int quit, found;
+	char *envpath;
+	char *path, *cp;
+	static char buf[512];
+	static char patbuf[512];
 
-    if (argc < 2) {
-	fprintf(stderr, "Usage: which cmd [cmd, ..]\n");
-	return 1;
-    }
-    if ((envpath = getenv("PATH")) == 0) {
-	envpath = ".";
-    }
-    argv[argc] = 0;
-    for (argv++; *argv; argv++) {
-
-	strcpy(patbuf, envpath);
-	cp = path = patbuf;
-	quit = found = 0;
-
-	while (!quit) {
-	    cp = index(path, ':');
-	    if (cp == NULL) {
-		quit++;
-	    } else {
-		*cp = '\0';
-	    }
-	    snprintf(buf, 512, "%s/%s", (*path ? path : "."), *argv);
-	    path = ++cp;
-
-	    if (access(buf, 1) == 0) {
-		printf("%s\n", buf);
-		found++;
-	    }
+	if (argc < 2) {
+		fprintf(stderr, "Usage: which cmd [cmd, ..]\n");
+		return 1;
 	}
-	if (!found) {
-	    printf("No %s in %s\n", *argv, envpath);
+	if ((envpath = getenv("PATH")) == 0) {
+		envpath = ".";
 	}
-    }
+	argv[argc] = 0;
+	for (argv++; *argv; argv++) {
 
-    return 0;
+		strcpy(patbuf, envpath);
+		cp = path = patbuf;
+		quit = found = 0;
+
+		while (!quit) {
+			cp = index(path, ':');
+			if (cp == NULL) {
+				quit++;
+			} else {
+				*cp = '\0';
+			}
+			snprintf(buf, 512, "%s/%s", (*path ? path : "."), *argv);
+			path = ++cp;
+
+			if (access(buf, 1) == 0) {
+				printf("%s\n", buf);
+				found++;
+			}
+		}
+		if (!found) {
+			printf("No %s in %s\n", *argv, envpath);
+		}
+	}
+
+	return 0;
 }


### PR DESCRIPTION
re-idented/formatted
defaults to "/bin" instead of "." if PATH is not set
use snprintf instead of strcpy, safer
stop spewing error message to stdout
returns success only if all the executables have been found