### PR TITLE
coco3: remove drivewire vwins: not worth memory usage in level 2

### DIFF
--- a/Kernel/platform-coco3/config.h
+++ b/Kernel/platform-coco3/config.h
@@ -70,7 +70,7 @@ extern unsigned char vt_map( unsigned char c );
 #define CMDLINE	0x88	  /* Location of root dev name */
 
 /* Device parameters */
-#define NUM_DEV_TTY 10
+#define NUM_DEV_TTY 6
 #define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */
 #define NBUFS    6       /* Number of block buffers */
 #define NMOUNTS	 4	  /* Number of mounts at a time - nothing mountable! */
@@ -81,7 +81,7 @@ extern unsigned char vt_map( unsigned char c );
 /* Drivewire Defines */
 
 #define DW_VSER_NUM 4     /* No of Virtual Serial Ports */
-#define DW_VWIN_NUM 4     /* No of Virtual Window Ports */
+#define DW_VWIN_NUM 0     /* No of Virtual Window Ports */
 #define DW_MIN_OFF  3     /* Minor number offset */
 
 /* Block device define */

--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -34,13 +34,14 @@ uint8_t tbuf3[TTYSIZ];   /* drivewire VSER 0 */
 uint8_t tbuf4[TTYSIZ];   /* drivewire VSER 1 */
 uint8_t tbuf5[TTYSIZ];   /* drivewire VSER 2 */
 uint8_t tbuf6[TTYSIZ];   /* drivewire VSER 3 */
-uint8_t tbuf7[TTYSIZ];   /* drivewire VWIN 0 */
-uint8_t tbuf8[TTYSIZ];   /* drivewire VWIN 1 */
-uint8_t tbuf9[TTYSIZ];   /* drivewire VWIN 2 */
-uint8_t tbufa[TTYSIZ];   /* drivewire VWIN 3 */
+/* these have a gee-whiz factor, but take a lot of RAM in level 2
+uint8_t tbuf7[TTYSIZ];   
+uint8_t tbuf8[TTYSIZ];   
+uint8_t tbuf9[TTYSIZ];   
+uint8_t tbufa[TTYSIZ];  
+*/
 
-
-struct s_queue ttyinq[NUM_DEV_TTY + 1] = {	
+struct s_queue ttyinq[NUM_DEV_TTY + 1] = {
 	/* ttyinq[0] is never used */
 	{NULL, NULL, NULL, 0, 0, 0},
 	/* GIME Consoles */
@@ -51,11 +52,12 @@ struct s_queue ttyinq[NUM_DEV_TTY + 1] = {
 	{tbuf4, tbuf4, tbuf4, TTYSIZ, 0, TTYSIZ / 2},
 	{tbuf5, tbuf5, tbuf5, TTYSIZ, 0, TTYSIZ / 2},
 	{tbuf6, tbuf6, tbuf6, TTYSIZ, 0, TTYSIZ / 2},
-	/* Drivewire Virtual Window Ports */
+	/* Drivewire Virtual Window Ports
 	{tbuf7, tbuf7, tbuf7, TTYSIZ, 0, TTYSIZ / 2},
 	{tbuf8, tbuf8, tbuf8, TTYSIZ, 0, TTYSIZ / 2},
 	{tbuf9, tbuf9, tbuf9, TTYSIZ, 0, TTYSIZ / 2},
 	{tbufa, tbufa, tbufa, TTYSIZ, 0, TTYSIZ / 2},
+	*/
 };
 
 


### PR DESCRIPTION
These use too much memory in Level2, and not worth their "gee-whiz" factor.