### PR TITLE
util: patchcpm no longer exists to install

### DIFF
--- a/Applications/util/fuzix-util.pkg
+++ b/Applications/util/fuzix-util.pkg
@@ -105,9 +105,4 @@ f 0755 /bin/write       write
 f 0755 /bin/xargs       xargs
 f 0755 /bin/yes         yes
 
-########################################################################
-package  util-z80
 
-if-cpu  z80
-
-f 0755 /bin/patchcpm    patchcpm


### PR DESCRIPTION
This was reported by Ron Klein while compiling for a CoCo.  Maybe if-cpu is broken?