### PR TITLE
coco3: bank in vt code

### DIFF
--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -1,5 +1,5 @@
 
-CSRCS = ttydw.c mbr.c dwtime.c bank0.c
+CSRCS = ttydw.c mbr.c dwtime.c
 CSRCS += devices.c main.c libc.c devsdc.c
 
 CDSRCS = ../dev/devide_discard.c
@@ -41,17 +41,17 @@ $(AOBJS): %$(BINEXT): %.s
 
 
 clean:
-	rm -f $(OBJS) $(JUNK)  core *~
+	rm -f $(OBJS) $(JUNK) bank0.img core *~
 
 image:	kernel bank0.img
+	cat fuzix.bin0 bank0.bin bank_end.img > ../fuzix.bin
 
 kernel:
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o ../bank16k.o ../bank16k.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o devtty.o devtty.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o ../timer.o ../timer.c
-	$(CROSS_CC) $(CROSS_CC_VIDEO) $(CROSS_CCOPTS) -O0 -c -o video.o video.c
-	$(CROSS_CC) $(CROSS_CC_VIDEO) $(CROSS_CCOPTS) -O0 -c -o ../usermem.o ../usermem.c
-	$(CROSS_LD) -o ../fuzix.bin --map=../fuzix.map --script=fuzix.link \
+	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o ../usermem.o ../usermem.c
+	$(CROSS_LD) -o fuzix.bin0 --map=../fuzix.map --script=fuzix.link \
 	crt0.o commonmem.o \
 	coco3.o ../start.o ../version.o ../lowlevel-6809.o \
 	tricks.o main.o ../timer.o ../kdata.o devices.o \
@@ -69,8 +69,9 @@ kernel:
 bank0.img:
 	m4 bank0.si > bank0.s
 	lwasm -obank0.o --obj bank0.s
+	lwasm -obank_end.img -r bank_end.s
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o video.o video.c
-	$(CROSS_LD) -r -o bank0.img --map=bank0.map --script=bank.link \
+	$(CROSS_LD) -r -o bank0.bin --map=bank0.map --script=bank.link \
 	../vt.o video.o videoll.o bank0.o
 
 boot.bin: boot/boot.s

--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -1,5 +1,5 @@
 
-CSRCS = ttydw.c mbr.c dwtime.c
+CSRCS = ttydw.c mbr.c dwtime.c bank0.c
 CSRCS += devices.c main.c libc.c devsdc.c
 
 CDSRCS = ../dev/devide_discard.c
@@ -9,6 +9,7 @@ NSRCS = ../dev/net/net_native.c
 
 ASRCS = coco3.s crt0.s ../platform-dragon-nx32/ide.s
 ASRCS += tricks.s commonmem.s usermem_gime.s drivewire.s sdc.s videoll.s
+ASRCS += video_link.s
 
 COBJS = $(CSRCS:.c=$(BINEXT))
 AOBJS = $(ASRCS:.s=$(BINEXT))
@@ -42,7 +43,9 @@ $(AOBJS): %$(BINEXT): %.s
 clean:
 	rm -f $(OBJS) $(JUNK)  core *~
 
-image:
+image:	kernel bank0.img
+
+kernel:
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o ../bank16k.o ../bank16k.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o devtty.o devtty.c
 	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o ../timer.o ../timer.c
@@ -58,10 +61,17 @@ image:
 	../syscall_proc.o ../syscall_other.o ../mm.o ../bank16k.o ../swap.o \
 	../tty.o ../devsys.o ../usermem.o ../syscall_fs2.o ../syscall_exec16.o \
 	../syscall_fs3.o \
-	../usermem_std-6809.o devtty.o libc.o ../vt.o usermem_gime.o video.o \
-	videoll.o dwtime.o \
+	../usermem_std-6809.o devtty.o libc.o usermem_gime.o \
+	video_link.o dwtime.o \
 	../level2.o ../syscall_level2.o ../select.o ../syscall_net.o \
 	net_native.o
+
+bank0.img:
+	m4 bank0.si > bank0.s
+	lwasm -obank0.o --obj bank0.s
+	$(CROSS_CC) $(CROSS_CCOPTS) -O0 -c -o video.o video.c
+	$(CROSS_LD) -r -o bank0.img --map=bank0.map --script=bank.link \
+	../vt.o video.o videoll.o bank0.o
 
 boot.bin: boot/boot.s
 	lwasm -lboot.list -oboot.bin boot/boot.s

--- a/Kernel/platform-coco3/bank.link
+++ b/Kernel/platform-coco3/bank.link
@@ -1,15 +1,13 @@
 define basesympat __sectionbase_%s__
 define lensympat __sectionlen_%s__
+section .bankstart
 section .link load 0x2000
 section .video
-section .videodata
 section .text2
 section .text
 section .text.hot
 section .test.unlikely
 section .data
-section .buffers
-section .discard
 section	.bss
-
+section .bankend
 

--- a/Kernel/platform-coco3/bank.link
+++ b/Kernel/platform-coco3/bank.link
@@ -1,0 +1,15 @@
+define basesympat __sectionbase_%s__
+define lensympat __sectionlen_%s__
+section .link load 0x2000
+section .video
+section .videodata
+section .text2
+section .text
+section .text.hot
+section .test.unlikely
+section .data
+section .buffers
+section .discard
+section	.bss
+
+

--- a/Kernel/platform-coco3/bank0.si
+++ b/Kernel/platform-coco3/bank0.si
@@ -1,5 +1,4 @@
 
-	.area	.text
 
 	.globl	_curpty
 	.globl	_di
@@ -22,6 +21,8 @@
 	import	_video_init	; e
 
 changequote(`[', `]')
+
+	.area	.external,constant		 
 
 _curpty		equ	$esyscmd([awk '/curpty/ {print $5}' ../fuzix.map])
 _di		equ	$esyscmd([awk '/_di\ / {print $5}' ../fuzix.map])

--- a/Kernel/platform-coco3/bank0.si
+++ b/Kernel/platform-coco3/bank0.si
@@ -1,0 +1,51 @@
+
+	.area	.text
+
+	.globl	_curpty
+	.globl	_di
+	.globl 	_irqrestore
+	.globl	_mulhi3
+	.globl	_uget
+	.globl  _ugetw
+	.globl 	_uput
+	.globl  _tty_inproc
+	.globl  _tty_ioctl
+
+
+	import	_vtoutput	; 0
+	import	_vt_ioctl	; 2
+	import	_vt_inproc	; 4
+	import	_vtinit		; 6
+	import	_vt_save	; 8
+	import	_vt_load	; a
+	import	_gfx_draw_op	; c
+	import	_video_init	; e
+
+changequote(`[', `]')
+
+_curpty		equ	$esyscmd([awk '/curpty/ {print $5}' ../fuzix.map])
+_di		equ	$esyscmd([awk '/_di\ / {print $5}' ../fuzix.map])
+_irqrestore	equ	$esyscmd([awk '/_irqrestore/ {print $5}' ../fuzix.map])
+_mulhi3		equ	$esyscmd([awk '/_mulhi3/ {print $5}' ../fuzix.map])
+_uget		equ	$esyscmd([awk '/\ _uget\ / {print $5}' ../fuzix.map])
+_ugetw		equ	$esyscmd([awk '/\ _ugetw\ / {print $5}' ../fuzix.map])
+_uput		equ	$esyscmd([awk '/\ _uput\ / {print $5}' ../fuzix.map])	
+_tty_inproc	equ	$esyscmd([awk '/\ _tty_inproc\ / {print $5}' ../fuzix.map])	
+_tty_ioctl	equ	$esyscmd([awk '/\ _tty_ioctl\ / {print $5}' ../fuzix.map])	
+
+;;; 
+;;; This is a table of pointers to exported symbols
+;;; that the kernel will use to call into this bank
+;;; 
+	
+	.area	.link
+
+	.dw	_vtoutput	; 0
+	.dw	_vt_ioctl	; 2
+	.dw	_vt_inproc	; 4
+	.dw	_vtinit		; 6
+	.dw	_vt_save	; 8
+	.dw	_vt_load	; a
+	.dw	_gfx_draw_op	; c
+	.dw	_video_init	; e
+

--- a/Kernel/platform-coco3/bank0.si
+++ b/Kernel/platform-coco3/bank0.si
@@ -19,7 +19,7 @@
 	import	_vt_load	; a
 	import	_gfx_draw_op	; c
 	import	_video_init	; e
-	import  videoll_init
+
 
 changequote(`[', `]')
 
@@ -49,5 +49,18 @@ _tty_ioctl	equ	$esyscmd([awk '/\ _tty_ioctl\ / {print $5}' ../fuzix.map])
 	.dw	_vt_save	; 8
 	.dw	_vt_load	; a
 	.dw	_gfx_draw_op	; c
-	.dw	videoll_init	; e
+	.dw	_video_init	; e
 
+;;; This is a hand-build DECB BIN header with banking extension
+
+	.area	.bankstart
+	.db	$a		; Bank extension MMU 11
+	.db	0		; preamble byte
+	.dw	bankend-$2000	; length
+	.dw	$2000		; load address
+
+	.area	.bankend
+bankend				; end of bank
+	.db	$ff		; postamble
+	.dw	0		; exec address (junk for banking)
+	.dw	0		; junk (must be zero or loader will fail)

--- a/Kernel/platform-coco3/bank0.si
+++ b/Kernel/platform-coco3/bank0.si
@@ -19,6 +19,7 @@
 	import	_vt_load	; a
 	import	_gfx_draw_op	; c
 	import	_video_init	; e
+	import  videoll_init
 
 changequote(`[', `]')
 
@@ -48,5 +49,5 @@ _tty_ioctl	equ	$esyscmd([awk '/\ _tty_ioctl\ / {print $5}' ../fuzix.map])
 	.dw	_vt_save	; 8
 	.dw	_vt_load	; a
 	.dw	_gfx_draw_op	; c
-	.dw	_video_init	; e
+	.dw	videoll_init	; e
 

--- a/Kernel/platform-coco3/bank_end.s
+++ b/Kernel/platform-coco3/bank_end.s
@@ -1,0 +1,6 @@
+;;;
+;;; Test video bank
+;;;
+
+	
+	.db	0		; bank end

--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -474,10 +474,6 @@ void platform_interrupt(void)
 	dw_vpoll();
 }
 
-void vtattr_notify(void)
-{
-	curpty->attr = ((vtink&7)<<3) + (vtpaper&7);
-}
 
 int gfx_ioctl(uint8_t minor, uarg_t arg, char *ptr)
 {

--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -154,10 +154,10 @@ static struct mode_s mode[5] = {
 
 static struct pty ptytab[] VSECTD = {
 	{
-		(unsigned char *) 0x2000, 
-		NULL, 
-		0, 
-		{0, 0, 0, 0}, 
+		(unsigned char *) 0x4000, 
+		NULL,
+		0,
+		{0, 0, 0, 0},
 		0x10000 / 8,
 		0x04,
 		0x74,              /* 80 column */
@@ -169,10 +169,10 @@ static struct pty ptytab[] VSECTD = {
 		050
 	},
 	{
-		(unsigned char *) 0x3000, 
-		NULL, 
-		0, 
-		{0, 0, 0, 0}, 
+		(unsigned char *) 0x5000, 
+		NULL,
+		0,
+		{0, 0, 0, 0},
 		0x11000 / 8,
 		0x04,
 		0x6c,              /* 40 column */

--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -13,6 +13,20 @@ extern void video_cmd( char *rlt_data);
 
 */
 
+
+void do_beep( void )
+{
+}
+
+uint8_t vtattr_cap;
+
+
+void vtattr_notify(void)
+{
+        curpty->attr = ((vtink&7)<<3) + (vtpaper&7);
+}
+
+
 static int irq;
 
 static void map_for_video()

--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -32,14 +32,14 @@ static int irq;
 static void map_for_video()
 {
 	irq=di();
-	*( uint8_t *)0xffa9 = 8;
-	*( uint8_t *)0xffaa = 9;
+	*( uint8_t *)0xffaa = 8;
+	*( uint8_t *)0xffab = 9;
 }
 
 static void map_for_kernel()
 {
-	*( uint8_t *)0xffa9 = 1;
 	*( uint8_t *)0xffaa = 2;
+	*( uint8_t *)0xffab = 3;
 	irqrestore(irq);
 }
 
@@ -131,10 +131,10 @@ unsigned char vt_map(unsigned char c)
 }
 
 // Get copy user buffer to video mem
-// 
+//
 static void video_get( char *usrptr ){
 	map_for_video();
-	uget( usrptr, (char *)0x2000, 512);
+	uget( usrptr, (char *)0x4000, 512);
 	map_for_kernel();
 }
 
@@ -142,7 +142,7 @@ __attribute__((section(".discard")))
 void video_init( )
 {
 	map_for_video();
-	memset( (char *)0x2000, ' ', 0x4000 );
+	memset( (char *)0x4000, ' ', 0x4000 );
 	map_for_kernel();
 }
 
@@ -151,7 +151,7 @@ int gfx_draw_op(uarg_t arg, char *ptr)
 	int err=0;
 	int l;
 	int c = 8;	/* 4 x uint16_t */
-	uint16_t *p = (uint16_t *)(char *)0x5e00;
+	uint16_t *p = (uint16_t *)(char *)0x7e00;
 
 	map_for_video();
 	l = ugetw(ptr);
@@ -161,7 +161,7 @@ int gfx_draw_op(uarg_t arg, char *ptr)
 	}
 	if (arg != GFXIOC_READ)
 		c = l;
-	if (uget(ptr + 2, (char *)0x5e00, c)){
+	if (uget(ptr + 2, (char *)0x7e00, c)){
 		err = EFAULT;
 		goto ret;
 	}
@@ -170,7 +170,7 @@ int gfx_draw_op(uarg_t arg, char *ptr)
 		/* TODO
 		   if (draw_validate(ptr, l, 256, 192))  - or 128!
 		   return EINVAL */
-		video_cmd( ( char *)0x5e00 );
+		video_cmd( ( char *)0x7e00 );
 		break;
 	case GFXIOC_WRITE:
 	case GFXIOC_READ:
@@ -186,12 +186,12 @@ int gfx_draw_op(uarg_t arg, char *ptr)
 			break;
 		}
 		if (arg == GFXIOC_READ) {
-			video_read( (unsigned char *)0x5e00 );
-			if (uput( (char *)0x5e00 + 8, ptr+10, l-2))
+			video_read( (unsigned char *)0x7e00 );
+			if (uput( (char *)0x7e00 + 8, ptr+10, l-2))
 				err = EFAULT;
 			break;
 		}
-		video_write( (unsigned char *)0x5e00 );
+		video_write( (unsigned char *)0x7e00 );
 	}
  ret:
 	map_for_kernel();

--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -7,10 +7,6 @@ extern void video_cmd( char *rlt_data);
 /* These are routines stolen from the stock vt.c's VT_SIMPLE code, and modified
    to suite multiple vts
 
-   These routines are called by vt.c.   They play with Kernel banking, so this
-   module should be compiled into the .video section.  These routines should 
-   only reference/call things that are in .video or .videodata
-
 */
 
 
@@ -138,7 +134,6 @@ static void video_get( char *usrptr ){
 	map_for_kernel();
 }
 
-__attribute__((section(".discard")))
 void video_init( )
 {
 	map_for_video();

--- a/Kernel/platform-coco3/video_link.s
+++ b/Kernel/platform-coco3/video_link.s
@@ -1,0 +1,98 @@
+;;;
+;;;  This file contains stubs to bank in the video code, call it,
+;;;  and return.  This is not thread safe.
+;;;
+
+	.globl	_vtoutput
+	.globl	_vt_ioctl
+	.globl	_vt_inproc
+	.globl	_vt_save
+	.globl	_vt_load
+	.globl  _gfx_draw_op
+	.globl  _video_init
+	
+	.area	.video
+
+ret	.dw	0
+
+
+_vtoutput
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$2000]
+
+_vt_ioctl
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$2002]
+
+_vt_inproc
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$2004]
+	
+_vt_save
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$2008]
+
+_vt_load
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$200a]
+
+_gfx_draw_op
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$200c]
+	
+_video_init
+	pshs	y
+	lda	#11
+	sta	$ffa9
+	ldy	2,s
+	sty	ret
+	ldy	#return
+	sty	2,s
+	puls	y
+	jmp	[$200e]
+	
+return
+	jmp	[ret]
+	

--- a/Kernel/platform-coco3/video_link.s
+++ b/Kernel/platform-coco3/video_link.s
@@ -10,8 +10,8 @@
 	.globl	_vt_load
 	.globl  _gfx_draw_op
 	.globl  _video_init
-	
-	.area	.video
+
+	.area	.text
 
 ret	.dw	0
 

--- a/Kernel/platform-coco3/video_link.s
+++ b/Kernel/platform-coco3/video_link.s
@@ -48,7 +48,7 @@ _vt_inproc
 	sty	2,s
 	puls	y
 	jmp	[$2004]
-	
+
 _vt_save
 	pshs	y
 	lda	#11
@@ -81,8 +81,17 @@ _gfx_draw_op
 	sty	2,s
 	puls	y
 	jmp	[$200c]
-	
+
 _video_init
+	;; clear bss section
+	pshs	x,y
+	ldx	#__sectionbase_.bss__
+	ldy	#__sectionlen_.bss__
+a@	clr	,x+
+	leay	-1,y
+	bne	a@
+	puls	x,y
+	;; normal call
 	pshs	y
 	lda	#11
 	sta	$ffa9
@@ -92,7 +101,8 @@ _video_init
 	sty	2,s
 	puls	y
 	jmp	[$200e]
-	
+
 return
+	lda	#1
+	sta	$ffa9
 	jmp	[ret]
-	

--- a/Kernel/platform-coco3/video_link.s
+++ b/Kernel/platform-coco3/video_link.s
@@ -83,15 +83,6 @@ _gfx_draw_op
 	jmp	[$200c]
 
 _video_init
-	;; clear bss section
-	pshs	x,y
-	ldx	#__sectionbase_.bss__
-	ldy	#__sectionlen_.bss__
-a@	clr	,x+
-	leay	-1,y
-	bne	a@
-	puls	x,y
-	;; normal call
 	pshs	y
 	lda	#11
 	sta	$ffa9

--- a/Kernel/platform-coco3/videoll.s
+++ b/Kernel/platform-coco3/videoll.s
@@ -17,12 +17,12 @@
 
 	include "kernel.def"
 	include "../kernel09.def"
-	
-	.area .video
 
-VIDEO_BASE  equ	 $4000
+	.area .text
 
-	
+VIDEO_BASE  equ	 $6000
+
+
 ;;;   void *memset(void *d, int c, size_t sz)
 _memset:
 	pshs	x,y
@@ -165,11 +165,3 @@ _getq
 	puls	cc,pc		; restore interrupts, return
 
 
-;;; Init this bank's bss data
-videoll_init
-	ldx 	#__sectionbase_.bss__
-	ldy 	#__sectionlen_.bss__
-a@	clr 	,x+
-	leay 	-1,y
-	bne 	a@
-	jmp	_video_init

--- a/Kernel/platform-coco3/videoll.s
+++ b/Kernel/platform-coco3/videoll.s
@@ -13,6 +13,7 @@
 	.globl _video_cmd
 	.globl _putq
 	.globl _getq
+	.globl videoll_init
 
 	include "kernel.def"
 	include "../kernel09.def"
@@ -162,3 +163,13 @@ _getq
 	lda	#1		; restore kernel map
 	sta	0xffa9		;
 	puls	cc,pc		; restore interrupts, return
+
+
+;;; Init this bank's bss data
+videoll_init
+	ldx 	#__sectionbase_.bss__
+	ldy 	#__sectionlen_.bss__
+a@	clr 	,x+
+	leay 	-1,y
+	bne 	a@
+	jmp	_video_init


### PR DESCRIPTION
This creates a banking system for the vt.c (and lower) code.  Special note of interest:  from the bank code's pov: external linkages are awked from main kernel map file, and exported linkages are set up as a table of pointers.  And nothing shows you how poorly you've factored your code quite link banking it :)