### PR TITLE
coco3: shuffle memory to let us actually use kernel memory past 0xc000

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -168,7 +168,7 @@ b@	sta	,x+
 	ldu	#$c000		; src
 c@	ldd	,u++		; copy 2 at a time
 	std	,x++		;
-	cmpx	#$e000		; are we done?
+	cmpx	#$2000		; are we done?
 	bne	c@		; loop if not done
         ;; set temporary screen up
 	clr	$ff9c		; reset scroll register

--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -170,6 +170,7 @@ c@	ldd	,u++		; copy 2 at a time
 	std	,x++		;
 	cmpx	#$2000		; are we done?
 	bne	c@		; loop if not done
+	clr	$ffa8		; reset cpu $0000
         ;; set temporary screen up
 	clr	$ff9c		; reset scroll register
 	ldb	#%01000100	; coco3 mode

--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -161,15 +161,24 @@ b@	sta	,x+
 	inca
 	decb
 	bne	b@
+	;; move mmu bank 0x6 to 0xB
+	lda	#$0b		; map mmu bank 0xB to cpu $0000
+	sta	$ffa8		;
+	ldx	#$0000		; dest
+	ldu	#$c000		; src
+c@	ldd	,u++		; copy 2 at a time
+	std	,x++		;
+	cmpx	#$e000		; are we done?
+	bne	c@		; loop if not done
         ;; set temporary screen up
 	clr	$ff9c		; reset scroll register
 	ldb	#%01000100	; coco3 mode
 	stb	$ff90
 	;; detect PAL or NTSC ROM
 	ldb	#$3f		; put Super BASIC in mmu
-	stb	$ffae		; 
+	stb	$ffae		;
 	lda	$c033		; get BASIC's "mirror" of Video Reg
-	ldb	#$06		; put Fuzix Kernel back in mmu
+	ldb	#$0b		; put Fuzix Kernel back in mmu
 	stb	$ffae		;
 	anda	#$8		; mask off 50 hz bit
 	sta	_hz		; save for future use


### PR DESCRIPTION
This seems to be much simpler than actual banking.  This is a work-around to let us use kernel cpu space 0xc000-0xe000,  which was donated by kernel to help in pseduo-forking init.