### PR TITLE
coco3: define KEY_ROWS to compile vt ioctls

### DIFF
--- a/Kernel/platform-coco3/devtty.h
+++ b/Kernel/platform-coco3/devtty.h
@@ -1,6 +1,12 @@
 #ifndef __DEVTTY_DOT_H__
 #define __DEVTTY_DOT_H__
 
+#define KEY_ROWS 8
+#define KEY_COLS 7
+extern uint8_t keymap[8];
+extern uint8_t keyboard[8][7];
+extern uint8_t shiftkeyboard[8][7];
+
 #include <../include/vt.h>
 #include <../include/graphics.h>
 


### PR DESCRIPTION
Not sure how I missed this too...*sigh*