### PR TITLE
6809: syscall number is 8 bit

### DIFF
--- a/Kernel/lowlevel-6809.s
+++ b/Kernel/lowlevel-6809.s
@@ -93,7 +93,7 @@ unix_syscall_entry:
 	SAM_KERNEL
 	std ,y++
 	SAM_USER
-	ldd 1,s		; stacked D register -> syscall number
+	ldb 2,s		; stacked B register -> syscall number
 	SAM_KERNEL
 	stb U_DATA__U_CALLNO
         ; save process stack pointer (in user page)

--- a/Library/tools/syscall_6809.c
+++ b/Library/tools/syscall_6809.c
@@ -29,10 +29,10 @@ static void write_call(int n)
 	/* then put return address back */
 	fprintf(fp, "\tpuls d,x\n"
 		    "\tpshs d\n"
-		    "\tldd #%d\n"
+		    "\tldb #%d\n"
 		    "\tjmp __syscall_mangled\n", n);
   } else {
-	fprintf(fp, "\tldd #%d\n"
+	fprintf(fp, "\tldb #%d\n"
 		    "\tjmp __syscall\n", n);
   }
   fclose(fp);


### PR DESCRIPTION
Syscall number are 8 bit, so the high byte (A reg) is always zero.
Saves one byte of memory by syscall.
ABI compatibility with previous code is preserved.