### PR TITLE
coco3: better/conditional initialization of drivewire

### DIFF
--- a/Kernel/platform-coco3/devices.c
+++ b/Kernel/platform-coco3/devices.c
@@ -49,7 +49,8 @@ void device_init(void)
 #ifdef CONFIG_COCOSDC
 	devsdc_init( );
 #endif
-	dwtime_init( );
+	if ( ! dw_init() )
+		dwtime_init( );
 	inittod();
 	sock_init();
 }

--- a/Kernel/platform-coco3/dwtime.c
+++ b/Kernel/platform-coco3/dwtime.c
@@ -4,6 +4,7 @@
 #include <drivewire.h>
 #include <printf.h>
 #include <kdata.h>
+#include <ttydw.h>
 #include "config.h"
 
 #define DISC __attribute__((section(".discard")))
@@ -15,7 +16,9 @@ static const uint16_t mktime_moffset[12]= { 0, 31, 59, 90, 120, 151, 181, 212, 2
 static int get_time( uint8_t *tbuf )
 {
 	int ret;
-
+	
+	if ( dwtype == DWTYPE_NOTFOUND )
+		return -1;
 	tbuf[0]=0x23;
 	ret=dw_transaction( tbuf, 1, tbuf, 6, 0 );
 	if( ret ) return -1;

--- a/Kernel/platform-coco3/libc.c
+++ b/Kernel/platform-coco3/libc.c
@@ -1,5 +1,14 @@
 #include "cpu.h"
 
+int strcmp( char *a, char *b ){
+    int ret;
+    while (1){
+	ret = *a - *b++;
+	if( ! *a || ret )
+	    return ret;
+	a++;
+    }
+}
 
 size_t strlen(const char *p)
 {

--- a/Kernel/platform-coco3/main.c
+++ b/Kernel/platform-coco3/main.c
@@ -3,9 +3,13 @@
 #include <kdata.h>
 #include <printf.h>
 #include <devtty.h>
+#include <ttydw.h>
+
+#define DISC __attribute__((section(".discard")))
 
 
 struct blkbuf *bufpool_end = bufpool + NBUFS;
+
 
 void platform_discard(void)
 {
@@ -34,7 +38,7 @@ void do_beep(void)
 }
 
 /* Scan memory return number of 8k pages found */
-__attribute__((section(".discard")))
+DISC
 int scanmem(void)
 {
 	volatile uint8_t *mmu=(uint8_t *)0xffa8;
@@ -60,7 +64,7 @@ int scanmem(void)
  Map handling: We have flexible paging. Each map table consists
  of a set of pages with the last page repeated to fill any holes.
  */
-
+DISC
 void pagemap_init(void)
 {
     int i;
@@ -75,14 +79,18 @@ void pagemap_init(void)
     pagemap_add(6);
 }
 
-
+DISC
 void map_init(void)
 {
 }
 
-
+DISC
 uint8_t platform_param(char *p)
 {
+	if( !strcmp(p,"NODW") ){
+	    dwtype = DWTYPE_NOTFOUND;
+	    return -1;
+	}
 	return 0;
 }
 

--- a/Kernel/platform-coco3/ttydw.h
+++ b/Kernel/platform-coco3/ttydw.h
@@ -1,9 +1,21 @@
 #ifndef __TTYDW_DOT_H__
 #define __TTYDW_DOT_H__
 
+/* Stores drivewire server type on boot */
+extern uint8_t dwtype;
+#define DWTYPE_DW3          0xfc
+#define DWTYPE_UNKNOWN      0xfd
+#define DWTYPE_NOTFOUND     0xfe
+#define DWTYPE_PYDRIVEWIRE  0xff
+#define DWTYPE_DW4          0x04
+#define DWTYPE_LWWIRE       0x80
+
+
 void dw_putc( uint8_t minor, unsigned char c );
 void dw_vopen( uint8_t minor );
 void dw_vclose( uint8_t minor );
 int dw_carrier( uint8_t minor );
-void dw_vpoll( );
+void dw_vpoll( void );
+int dw_init( void );
+
 #endif


### PR DESCRIPTION
* Stores the probulated drivewire server type
* Adds platform param "NODW" to disable drivewire probing.
* found more stuff that should be in discard