### PR TITLE
V7 man pages (all platforms)

### DIFF
--- a/Applications/V7/cmd/ac.1m
+++ b/Applications/V7/cmd/ac.1m
@@ -1,0 +1,59 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH AC 1M 
+.SH NAME
+ac \- login accounting
+.SH SYNOPSIS
+.B ac
+[
+.B \-w
+wtmp ] [
+.B \-p
+] [
+.B \-d
+] [ people ] ...
+.SH DESCRIPTION
+.I Ac
+produces a printout giving
+connect time
+for each user who has logged in
+during the life of the current
+.I wtmp
+file.
+A total is also produced.
+.B \-w
+is used to specify an alternate
+.IR wtmp ""
+file.
+.B \-p
+prints individual totals; without this option,
+only totals are printed.
+.B \-d
+causes a printout for each midnight to midnight
+period.
+Any
+.I people
+will limit the
+printout to only the specified login names.
+If no
+.IR wtmp ""
+file is given,
+.I /usr/adm/wtmp
+is used.
+.PP
+The accounting file
+.I /usr/adm/wtmp
+is maintained by
+.I init
+and
+.I login.
+Neither of these programs creates the file,
+so if it does not exist
+no connect-time accounting is done.
+To start accounting, it should be created with length 0.
+On the other hand if the file is left undisturbed it will
+grow without bound, so periodically any information
+desired should be collected and the file truncated.
+.SH FILES
+/usr/adm/wtmp
+.SH "SEE ALSO"
+init(8), login(1), utmp(5).

--- a/Applications/V7/cmd/at.1
+++ b/Applications/V7/cmd/at.1
@@ -1,0 +1,97 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH AT 1 
+.SH NAME
+at \- execute commands at a later time
+.SH SYNOPSIS
+.B at
+time
+[
+day
+]
+[
+file
+]
+.SH DESCRIPTION
+.I At
+squirrels away a copy of the named
+.I file
+(standard input default)
+to be used as input to
+.IR sh (1)
+at a specified later time.
+A
+.IR cd (1)
+command to the current directory is inserted
+at the beginning,
+followed by assignments to all environment variables.
+When the script is run, it uses the user and group ID
+of the creator of the copy file.
+.PP
+The
+.I time
+is 1 to 4 digits, with an optional following
+`A', `P', `N' or `M' for
+AM, PM, noon or midnight.
+One and two digit numbers are taken to be hours, three and four digits
+to be hours and minutes.
+If no letters follow the digits, a 24 hour clock time is understood.
+.PP
+The optional
+.I day
+is either
+(1) a month name followed by a day number,
+or
+(2) a day of the week; if the word `week' follows
+invocation is moved seven days further off.
+Names of months and days may be recognizably truncated.
+Examples of legitimate commands are
+.IP
+at 8am jan 24
+.br
+at 1530 fr week
+.PP
+.I At
+programs are executed by periodic execution
+of the command
+.I /usr/lib/atrun
+from
+.IR cron (8).
+The granularity of
+.I at
+depends upon how often
+.I atrun
+is executed.
+.PP
+Standard output or error output is lost unless redirected.
+.SH FILES
+/usr/spool/at/yy.ddd.hhhh.uu
+.br
+activity to be performed at hour
+.I hhhh
+of year day
+.I ddd
+of year
+.IR yy .
+.I uu
+is a unique number.
+.br
+/usr/spool/at/lasttimedone contains
+.I hhhh
+for last hour of activity.
+.br
+/usr/spool/at/past directory of activities now in progress
+.br
+/usr/lib/atrun program that executes activities that
+are due
+.br
+pwd(1)
+.SH "SEE ALSO"
+calendar(1),
+cron(8)
+.SH DIAGNOSTICS
+Complains about various syntax errors and times out of range.
+.SH BUGS
+Due to the granularity of the execution of
+.I /usr/lib/atrun,
+there may be bugs in scheduling things almost
+exactly 24 hours into the future.

--- a/Applications/V7/cmd/col.1
+++ b/Applications/V7/cmd/col.1
@@ -1,0 +1,68 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH COL 1
+.SH NAME
+col \- filter reverse line feeds
+.SH SYNOPSIS
+.B col [\|\-bfx\|]
+.SH DESCRIPTION
+.I Col
+reads the standard input and writes the standard output.
+It performs the line overlays implied by reverse line
+feeds (ESC-7 in ASCII)
+and by forward and reverse half line feeds (ESC-9 and ESC-8).
+.I Col
+is particularly useful for filtering multicolumn
+output made with the `.rt' command of
+.I nroff
+and output resulting from use of the
+.IR tbl (1)
+preprocessor.
+.PP
+Although
+.I col
+accepts half line motions in its input, it normally does not
+emit them on output.
+Instead, text that would appear between lines is moved to the next lower
+full line boundary.
+This treatment can be suppressed by the
+.B \-f
+(fine) option; in this case
+the output from
+.I col
+may contain forward half line feeds (ESC-9), but will still never contain
+either kind of reverse line motion.
+.PP
+If the
+.B \-b
+option is given,
+.I col
+assumes that the output device in use is not capable of backspacing.
+In this case, if several characters are to appear in the same place,
+only the last one read will be taken.
+.PP
+The control characters SO (ASCII code 017),
+and SI (016) are assumed
+to start and end text in an alternate character set.
+The character set (primary or alternate) associated with each printing
+character read is remembered; on output, SO and SI characters are generated
+where necessary to maintain the correct treatment of each character.
+.PP
+.I Col
+normally converts white space to tabs to shorten printing time.
+If the
+.B \-x
+option is given, this conversion is suppressed.
+.PP
+All control characters are removed from the input except space,
+backspace,
+tab, return, newline, ESC (033) followed by one of 789, SI, SO, and VT
+(013).
+This last character is an alternate form of full reverse line feed, for
+compatibility with some other hardware conventions.
+All other non-printing characters are ignored.
+.SH "SEE ALSO"
+troff(1), tbl(1), greek(1)
+.SH BUGS
+Can't back up more than 128 lines.
+.br
+No more than 800 characters, including backspaces, on a line.

--- a/Applications/V7/cmd/comm.1
+++ b/Applications/V7/cmd/comm.1
@@ -1,0 +1,41 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH COMM 1 
+.SH NAME
+comm \- select or reject lines common to two sorted files
+.SH SYNOPSIS
+.B comm
+[
+.B \-
+[
+.B 123
+]
+] file1 file2
+.SH DESCRIPTION
+.I Comm
+reads
+.I file1
+and
+.I file2,
+which should be ordered in ASCII collating sequence,
+and produces a three column output: lines only in
+.I file1;
+lines only in
+.I file2;
+and lines in both files.
+The filename `\-' means the standard input.
+.PP
+Flags 1, 2, or 3 suppress printing of the corresponding
+column.
+Thus
+.B comm
+.B \-12
+prints only the lines common to the two files;
+.B comm
+.B \-23
+prints only lines in the first file but not in the second;
+.B comm
+.B \-123
+is a no-op.
+.PP
+.SH "SEE ALSO"
+cmp(1), diff(1), uniq(1)

--- a/Applications/V7/cmd/cron.8
+++ b/Applications/V7/cmd/cron.8
@@ -1,0 +1,57 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH CRON 8 
+.SH NAME
+cron \- clock daemon
+.SH SYNOPSIS
+.B /etc/cron
+.SH DESCRIPTION
+.I Cron
+executes commands at specified dates and times
+according to the instructions in the file
+/usr/lib/crontab.
+Since
+.I cron
+never exits,
+it should only be executed once.
+This is best done by running
+.I cron
+from the initialization
+process through the file
+/etc/rc;
+see
+.IR init (8).
+.PP
+Crontab
+consists of lines of six fields each.
+The fields are separated by spaces or tabs.
+The first five are integer patterns to
+specify the
+minute (0-59),
+hour (0-23),
+day of the month (1-31),
+month of the year (1-12),
+and day of the week (1-7 with 1=monday).
+Each of these patterns may
+contain a number in the range above;
+two numbers separated by
+a minus
+meaning a range inclusive;
+a list of numbers separated by
+commas meaning any of the numbers;
+or an asterisk meaning all legal values.
+The sixth field is a string
+that is executed by the Shell at the
+specified times.
+A percent character
+in this field is translated to a new-line
+character.
+Only the first line (up to a % or end of line)
+of the command field is executed by the Shell.
+The other lines are made available to the
+command as standard input.
+.PP
+Crontab is examined by
+.I cron
+every minute.
+.SH FILES
+/usr/lib/crontab

--- a/Applications/V7/cmd/crypt.1
+++ b/Applications/V7/cmd/crypt.1
@@ -1,0 +1,86 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH CRYPT 1 
+.SH NAME
+crypt \- encode/decode
+.SH SYNOPSIS
+.B crypt
+[ password ]
+.SH DESCRIPTION
+.I Crypt
+reads from the standard input and writes
+on the standard output.
+The
+.I password
+is a key that selects a particular transformation.
+If no
+.I password 
+is given,
+.I crypt
+demands a key from the terminal and turns
+off printing while the key is being typed in.
+.I Crypt
+encrypts and decrypts with the same key:
+.PP
+	crypt key <clear >cypher
+.br
+	crypt key <cypher | pr
+.PP
+will print the clear.
+.PP
+Files encrypted by
+.I crypt
+are compatible with those treated by the editor
+.I ed
+in encryption mode.
+.PP
+The security of encrypted files depends on three factors:
+the fundamental method must be hard to solve;
+direct search of the key space must be infeasible;
+`sneak paths' by which keys or cleartext can become
+visible must be minimized.
+.PP
+.I Crypt
+implements a one-rotor machine designed along the lines
+of the German Enigma, but with a 256-element rotor.
+Methods of attack on such machines are known, but not widely;
+moreover the amount of work required is likely to be large.
+.PP
+The transformation of a key into the internal
+settings of the machine is deliberately designed to
+be expensive, i.e. to take a substantial fraction of
+a second to compute.
+However,
+if keys are restricted to (say)
+three lower-case letters,
+then encrypted files can be read by expending only
+a substantial fraction of
+five minutes of machine time.
+.PP
+Since the key is an argument to the
+.I crypt
+command,
+it is potentially visible to users executing
+.IR ps (1)
+or a derivative.
+To minimize this possibility,
+.I crypt
+takes care to destroy any record of the key
+immediately upon entry.
+No doubt the choice of keys and key security
+are the most vulnerable aspect of
+.I crypt.
+.SH FILES
+/dev/tty for typed key
+.SH "SEE ALSO"
+ed(1),
+makekey(8)
+.SH BUGS
+There is no warranty of merchantability nor any warranty
+of fitness for a particular purpose nor any other warranty,
+either express or implied, as to the accuracy of the
+enclosed materials or as to their suitability for any
+particular purpose.  Accordingly, Bell Telephone
+Laboratories assumes no responsibility for their use by the
+recipient.   Further, Bell Laboratories assumes no obligation
+to furnish any assistance of any kind whatsoever, or to
+furnish any additional information or documentation.

--- a/Applications/V7/cmd/dc.1
+++ b/Applications/V7/cmd/dc.1
@@ -1,0 +1,199 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH DC 1 
+.SH NAME
+dc \- desk calculator
+.SH SYNOPSIS
+.B dc
+[ file ]
+.SH DESCRIPTION
+.I Dc
+is an arbitrary precision arithmetic package.
+Ordinarily it operates on decimal integers,
+but one may specify an input base, output base,
+and a number of fractional digits to be maintained.
+The overall structure of
+.I dc
+is
+a stacking (reverse Polish) calculator.
+If an argument is given,
+input is taken from that file until its end,
+then from the standard input.
+The following constructions are recognized:
+.HP 6
+number
+.br
+The value of the number is pushed on the stack.
+A number is an unbroken string of the digits 0-9.
+It may be preceded by an underscore _ to input a
+negative number.
+Numbers may contain decimal points.
+.HP 6
++  \- /  *  %  ^
+.br
+The
+top two values on the stack are added
+(+),
+subtracted
+(\-),
+multiplied (*),
+divided (/),
+remaindered (%),
+or exponentiated (^).
+The two entries are popped off the stack;
+the result is pushed on the stack in their place.
+Any fractional part of an exponent is ignored.
+.TP
+.BI s x
+The
+top of the stack is popped and stored into
+a register named
+.I x,
+where
+.I x
+may be any character.
+If
+the
+.B s
+is capitalized,
+.I x
+is treated as a stack and the value is pushed on it.
+.TP
+.BI l x
+The
+value in register
+.I x
+is pushed on the stack.
+The register
+.I x
+is not altered.
+All registers start with zero value.
+If the
+.B l
+is capitalized,
+register
+.I x
+is treated as a stack and its top value is popped onto the main stack.
+.TP
+.B  d
+The
+top value on the stack is duplicated.
+.TP
+.B  p
+The top value on the stack is printed.
+The top value remains unchanged.
+.B P
+interprets the top of the stack as an ascii string,
+removes it, and prints it.
+.TP
+.B  f
+All values on the stack and in registers are printed.
+.TP
+.B  q
+exits the program.
+If executing a string, the recursion level is
+popped by two.
+If
+.B q
+is capitalized,
+the top value on the stack is popped and the string execution level is popped
+by that value.
+.TP
+.B  x
+treats the top element of the stack as a character string
+and executes it as a string of dc commands.
+.TP
+.B  X
+replaces the number on the top of the stack with its scale factor.
+.TP
+.B  "[ ... ]"
+puts the bracketed ascii string onto the top of the stack.
+.HP 6
+.I  "<x  >x  =x"
+.br
+The
+top two elements of the stack are popped and compared.
+Register
+.I x
+is executed if they obey the stated
+relation.
+.TP
+.B  v
+replaces the top element on the stack by its square root.
+Any existing fractional part of the argument is taken
+into account, but otherwise the scale factor is ignored.
+.TP
+.B  !
+interprets the rest of the line as a UNIX command.
+.TP
+.B  c
+All values on the stack are popped.
+.TP
+.B  i
+The top value on the stack is popped and used as the
+number radix for further input.
+.B I
+pushes the input base on the top of the stack.
+.TP
+.B  o
+The top value on the stack is popped and used as the
+number radix for further output.
+.TP
+.SM
+.B O
+pushes the output base on the top of the stack.
+.TP
+.B  k
+the top of the stack is popped, and that value is used as
+a non-negative scale factor:
+the appropriate number of places
+are printed on output,
+and maintained during multiplication, division, and exponentiation.
+The interaction of scale factor,
+input base, and output base will be reasonable if all are changed
+together.
+.TP
+.B  z
+The stack level is pushed onto the stack.
+.TP
+.SM
+.B  Z
+replaces the number on the top of the stack with its length.
+.TP
+.B  ?
+A line of input is taken from the input source (usually the terminal)
+and executed.
+.TP
+.B "; :"
+are used by 
+.I bc
+for array operations.
+.PP
+An example which prints the first ten values of n! is
+.nf
+.PP
+.\" .in +3
+[la1+dsa*pla10>y]sy
+.br
+0sa1
+.br
+lyx
+.fi
+.SH "SEE ALSO"
+bc(1),
+which is a preprocessor for
+.I dc
+providing infix notation and a C-like syntax
+which implements functions and reasonable control
+structures for programs.
+.SH DIAGNOSTICS
+`x is unimplemented' where x is an octal number.
+.br
+`stack empty' for not enough elements on the stack to do what was asked.
+.br
+`Out of space' when the free list is exhausted (too many digits).
+.br
+`Out of headers' for too many numbers being kept around.
+.br
+`Out of pushdown' for too many items on the stack.
+.br
+`Nesting Depth' for too many levels of nested execution.

--- a/Applications/V7/cmd/dd.1
+++ b/Applications/V7/cmd/dd.1
@@ -1,0 +1,193 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH DD 1 
+.SH NAME
+dd \- convert and copy a file
+.SH SYNOPSIS
+.B dd
+[option=value] ...
+.SH DESCRIPTION
+.I Dd
+copies the specified input file
+to the specified output with
+possible conversions.
+The standard input and output are used by default.
+The input and output block size may be
+specified to take advantage of raw physical I/O.
+.PP
+.br
+.ns
+.TP 15
+.I option
+.I values
+.br
+.ns
+.TP 
+if=
+input file name; standard input is default
+.br
+.ns
+.TP 
+of=
+output file name; standard output is default
+.br
+.ns
+.TP 
+.RI ibs= n
+input block size
+.I n
+bytes (default 512)
+.br
+.ns
+.TP 
+.RI obs= n
+output block size (default 512)
+.br
+.ns
+.TP 
+.RI bs= n
+set both input and output block size,
+superseding
+.I ibs
+and
+.I obs;
+also, if no conversion is specified,
+it is particularly efficient since no copy need be done
+.br
+.ns
+.TP 
+.RI cbs= n
+conversion buffer size
+.br
+.ns
+.TP 
+.RI skip= n
+skip
+.IR n ""
+input records before starting copy
+.br
+.ns
+.TP
+.RI files= n
+copy
+.I n
+files from (tape) input
+.br
+.ns
+.TP 
+.RI seek= n
+seek
+.I n
+records from beginning of output file before copying
+.br
+.ns
+.TP 
+count=\fIn\fR
+copy only
+.IR n ""
+input records
+.br
+.ns
+.TP 
+conv=ascii
+.ds h \h'\w'conv='u'
+convert EBCDIC to ASCII
+.br
+.ns
+.IP \*hebcdic
+convert ASCII to EBCDIC
+.br
+.ns
+.IP \*hibm
+slightly different map of ASCII to EBCDIC
+.br
+.ns
+.IP \*hlcase
+map alphabetics to lower case
+.br
+.ns
+.IP \*hucase
+map alphabetics to upper case
+.br
+.ns
+.IP \*hswab
+swap every pair of bytes
+.br
+.ns
+.IP \*hnoerror
+do not stop processing on an error
+.br
+.ns
+.IP \*hsync
+pad every input record to
+.I  ibs
+.br
+.ns
+.IP "\*h... , ..."
+several comma-separated conversions
+.PP
+.fi
+Where sizes are specified,
+a number of bytes is expected.
+A number may end with
+.B "k, b"
+or
+.B w
+to specify multiplication by
+1024, 512, or 2 respectively;
+a pair of numbers may be separated by
+.B x
+to indicate a product.
+.PP
+.I Cbs
+is used only if
+.I ascii
+or
+.I ebcdic
+conversion is specified.
+In the former case
+.I cbs
+characters are placed into the conversion buffer, converted to
+ASCII, and trailing blanks trimmed and new-line added
+before sending the line to the output.
+In the latter case ASCII characters are read into the
+conversion buffer, converted to EBCDIC, and blanks added
+to make up an
+output record of size
+.IR cbs .
+.PP
+After completion,
+.I dd
+reports the number of whole and partial input and output
+blocks.
+.PP
+For example, to read an EBCDIC tape blocked ten 80-byte
+EBCDIC card images per record into the ASCII file
+.IR x :
+.IP ""
+dd if=/dev/rmt0 of=x ibs=800 cbs=80 conv=ascii,lcase
+.PP
+Note the use of raw magtape.
+.I Dd
+is especially suited to I/O on the raw
+physical devices because it allows reading
+and writing in arbitrary record sizes.
+.PP
+To skip over a file before copying from magnetic tape do
+.IP""
+(dd of=/dev/null; dd of=x) </dev/rmt0
+.SH "SEE ALSO"
+cp(1), tr(1)
+.SH DIAGNOSTICS
+f+p records in(out): numbers of full and partial records read(written)
+.SH BUGS
+The ASCII/EBCDIC conversion tables are
+taken
+from the 256 character standard in
+the CACM Nov, 1968.
+The `ibm' conversion, while less blessed as a standard,
+corresponds better to certain IBM print train conventions.
+There is no universal solution.
+.PP
+Newlines are inserted only on conversion to ASCII;
+padding is done only on conversion to EBCDIC.
+These should be separate options.

--- a/Applications/V7/cmd/deroff.1
+++ b/Applications/V7/cmd/deroff.1
@@ -1,0 +1,46 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH DEROFF 1 
+.SH NAME
+deroff \- remove nroff, troff, tbl and eqn constructs
+.SH SYNOPSIS
+.B deroff
+[
+.B \-w
+]
+file ...
+.SH DESCRIPTION
+.I Deroff
+reads each file in sequence
+and removes all
+.I nroff
+and
+.I troff
+command lines, backslash constructions, macro definitions,
+.I eqn
+constructs
+(between `.EQ' and `.EN' lines or between 
+delimiters),
+and table descriptions
+and writes the remainder on the standard output.
+.I Deroff
+follows chains of included files
+(`.so' and `.nx' commands);
+if a file has already been included, a `.so' is ignored and a `.nx' terminates execution.
+If no input file is given,
+.I deroff
+reads from the standard input file.
+.PP
+If the
+.B \-w
+flag is given, the output is a word list, one `word' (string of letters, digits, and apostrophes,
+beginning with a letter; apostrophes are removed) per line, and all other characters ignored.
+Otherwise, the output follows the original, with the deletions mentioned above.
+.SH "SEE ALSO"
+troff(1), eqn(1), tbl(1)
+.SH BUGS
+.I Deroff
+is not a complete
+.I troff
+interpreter,
+so it can be confused by subtle constructs.
+Most errors result in too much rather than too little output.

--- a/Applications/V7/cmd/diff.1
+++ b/Applications/V7/cmd/diff.1
@@ -1,0 +1,139 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH DIFF 1 
+.SH NAME
+diff \- differential file comparator
+.SH SYNOPSIS
+.B diff
+[
+.B \-efbh
+] file1 file2
+.SH DESCRIPTION
+.I Diff
+tells what lines must be changed in two files to bring them
+into agreement.
+If
+.I file1
+.RI ( file2 )
+is `\-', the standard input is used.
+If
+.I file1
+.RI ( file2 )
+is a directory, then a file in that directory
+whose file-name is the same as the file-name of 
+.I file2
+.RI ( file1 )
+is used.
+The normal output contains lines of these forms:
+.IP "" 5
+.I n1
+a
+.I n3,n4
+.br
+.I n1,n2
+d
+.I n3
+.br
+.I n1,n2
+c
+.I n3,n4
+.PP
+These lines resemble
+.I ed
+commands to convert
+.I file1
+into
+.IR file2 .
+The numbers after the letters pertain to
+.IR file2 .
+In fact, by exchanging `a' for `d' and reading backward
+one may ascertain equally how to convert 
+.I file2
+into
+.IR file1 .
+As in 
+.I ed,
+identical pairs where
+.I n1
+=
+.I n2
+or
+.I n3
+=
+.I n4
+are abbreviated as a single number.
+.PP
+Following each of these lines come all the lines that are
+affected in the first file flagged by `<', 
+then all the lines that are affected in the second file
+flagged by `>'.
+.PP
+The
+.B \-b
+option causes
+trailing blanks (spaces and tabs) to be ignored
+and other strings of blanks to compare equal.
+.PP
+The
+.B \-e
+option produces a script of
+.I "a, c"
+and 
+.I d
+commands for the editor
+.I ed,
+which will recreate
+.I file2
+from
+.IR file1 .
+The
+.B \-f
+option produces a similar script,
+not useful with
+.I ed,
+in the opposite order.
+In connection with
+.BR \-e ,
+the following shell program may help maintain
+multiple versions of a file.
+Only an ancestral file ($1) and a chain of 
+version-to-version
+.I ed
+scripts ($2,$3,...) made by
+.I diff
+need be on hand.
+A `latest version' appears on
+the standard output.
+.IP "" 5
+(shift; cat $*; echo \'1,$p\') \(bv ed \- $1
+.PP
+Except in rare circumstances,
+.I diff
+finds a smallest sufficient set of file
+differences.
+.PP
+Option
+.B \-h
+does a fast, half-hearted job.
+It works only when changed stretches are short
+and well separated,
+but does work on files of unlimited length.
+Options 
+.B \-e
+and
+.B \-f
+are unavailable with
+.BR \-h .
+.SH FILES
+/tmp/d?????
+.br
+/usr/lib/diffh for 
+.B \-h
+.SH "SEE ALSO"
+cmp(1), comm(1), ed(1)
+.SH DIAGNOSTICS
+Exit status is 0 for no differences, 1 for some, 2 for trouble.
+.SH BUGS
+Editing scripts produced under the
+.BR \-e " or"
+.BR \-f " option are naive about"
+creating lines consisting of a single `\fB.\fR'.

--- a/Applications/V7/cmd/diff3.1
+++ b/Applications/V7/cmd/diff3.1
@@ -1,0 +1,98 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH DIFF3 1 
+.SH NAME
+diff3 \- 3-way differential file comparison
+.SH SYNOPSIS
+.B diff3
+[
+.B \-ex3
+]
+file1 file2 file3
+.SH DESCRIPTION
+.I Diff3
+compares three versions of a file,
+and publishes disagreeing ranges of text
+flagged with these codes:
+.TP 16
+====
+all three files differ
+.TP 16
+====1
+.IR file1 " is different"
+.TP 16
+====2
+.IR file2 " is different"
+.TP 16
+====3
+.IR file3 " is different"
+.PP
+The type of change suffered in converting a given range
+of a given file to some other is
+indicated in one of these ways:
+.TP 16
+.IB f " : " n1 " a"
+Text is to be appended after line number
+.I n1
+in file
+.I f,
+where
+.I f
+= 1, 2, or 3.
+.TP 16
+.IB f " : " n1 " , " n2 " c"
+Text is to be
+changed in the range line
+.I n1
+to line
+.IR n2 .
+If 
+.I n1
+=
+.I n2,
+the range may be abbreviated to
+.IR n1 .
+.PP
+The original contents of the range follows immediately
+after a
+.B c
+indication.
+When the contents of two
+files are identical, the contents of the lower-numbered
+file is suppressed.
+.PP
+Under the
+.B \-e
+option,
+.I diff3
+publishes a script for the editor
+.I ed
+that will incorporate into
+.I file1
+all changes between
+.I file2
+and
+.I file3,
+.IR i.e .
+the changes that normally would be flagged ==== and ====3.
+Option
+.B \-x
+(\fB\-3\fR)
+produces a script to incorporate
+only changes flagged ==== (====3).
+The following command will apply the resulting script to
+`file1'.
+.PP
+.ti 16n
+(cat script; echo \'1,$p\') \(bv ed \- file1
+.SH FILES
+/tmp/d3?????
+.br
+/usr/lib/diff3
+.SH "SEE ALSO"
+diff(1)
+.SH BUGS
+Text lines that consist of a single `.' will
+defeat
+.B \-e.
+.br
+Files longer than 64K bytes won't work.

--- a/Applications/V7/cmd/fuzix-cmd.pkg
+++ b/Applications/V7/cmd/fuzix-cmd.pkg
@@ -24,9 +24,49 @@ f 0755 /usr/bin/newgrp        newgrp
 f 0755 /usr/bin/ptx           ptx
 f 0755 /usr/bin/rev           rev
 f 0755 /usr/bin/split         split
-f 0755 /usr/bin/sum           sum
 ##f 0755 /usr/bin/su            su
+f 0755 /usr/bin/sum           sum
 ##f 0755 /usr/bin/test          test
 f 0755 /usr/bin/time          time
 f 0755 /usr/bin/tsort         tsort
 f 0755 /usr/bin/wall          wall
+
+# Man pages - in a separate package so that storage-limited targets can
+# disable it.
+# Where a binary is commented out above, the man page is commented out here;
+# the binary is provided by a different package and the man page here may
+# not be correct/appropriate.
+# Where a man page is named .1m it is copied to FUZIX simply as .1 because our
+# man will not find a .1m man in man1
+
+package V7-cmd-man
+
+# no page for accton
+##f 0644 /usr/man/man1/ac.1           ac.1m
+##f 0644 /usr/man/man1/at.1           at.1
+# no page for atrun
+##f 0644 /usr/man/man1/col.1          col.1
+f 0644 /usr/man/man1/comm.1         comm.1
+f 0644 /usr/man/man8/cron.8         cron.8
+f 0644 /usr/man/man1/crypt.1        crypt.1
+f 0644 /usr/man/man1/dc.1           dc.1
+##f 0644 /usr/man/man1/dd.1           dd.1
+##f 0644 /usr/man/man1/deroff.1       deroff.1
+f 0644 /usr/man/man1/diff.1         diff.1
+f 0644 /usr/man/man1/diff3.1        diff3.1
+# no page for diffh
+f 0644 /usr/man/man1/join.1         join.1
+f 0644 /usr/man/man1/look.1         look.1
+f 0644 /usr/man/man8/makekey.8      makekey.8
+f 0644 /usr/man/man1/mesg.1         mesg.1
+f 0644 /usr/man/man1/newgrp.1       newgrp.1
+##f 0644 /usr/man/man1/pr.1           pr.1
+f 0644 /usr/man/man1/ptx.1          ptx.1
+f 0644 /usr/man/man1/rev.1          rev.1
+f 0644 /usr/man/man1/split.1        split.1
+##f 0644 /usr/man/man1/su.1           su.1
+f 0644 /usr/man/man1/sum.1          sum.1
+##f 0644 /usr/man/man1/test.1         test.1
+f 0644 /usr/man/man1/time.1         time.1
+f 0644 /usr/man/man1/tsort.1        tsort.1
+f 0644 /usr/man/man1/wall.1         wall.1m

--- a/Applications/V7/cmd/join.1
+++ b/Applications/V7/cmd/join.1
@@ -1,0 +1,105 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH JOIN 1 
+.SH NAME
+join \- relational database operator
+.SH SYNOPSIS
+.B join
+[
+options
+]
+file1 file2
+.SH DESCRIPTION
+.I Join
+forms, on the standard output,
+a join
+of the two relations specified by the lines of
+.I file1
+and
+.IR file2 .
+If
+.I file1
+is `\-', the standard input is used.
+.PP
+.I File1
+and 
+.I file2
+must be sorted in increasing ASCII collating
+sequence on the fields
+on which they are to be joined,
+normally the first in each line.
+.PP
+There is one line in the output 
+for each pair of lines in 
+.I file1 
+and 
+.I file2
+that have identical join fields.
+The output line normally consists of the common field,
+then the rest of the line from 
+.IR file1 ,
+then the rest of the line from
+.IR file2 .
+.PP
+Fields are normally separated by blank, tab or newline.
+In this case, multiple separators count as one, and
+leading separators are discarded.
+.PP
+These options are recognized:
+.TP
+.BI \-a n
+In addition to the normal output,
+produce a line for each unpairable line in file
+.IR n ,
+where
+.I n
+is 1 or 2.
+.TP
+.BI \-e \ s
+Replace empty output fields by string
+.IR s .
+.TP
+.BI \-j n\ m
+Join on the
+.IR m th
+field of file
+.IR n .
+If
+.I n
+is missing, use the
+.IR m th
+field in each file.
+.TP
+.BI \-o \ list
+Each output line comprises the fields specifed in
+.IR list ,
+each element of which has the form
+.IR n . m ,
+where
+.I n
+is a file number and
+.I m
+is a field number.
+.PP
+.TP
+.BI \-t c
+Use character
+.I c
+as a separator (tab character).
+Every appearance of
+.I c
+in a line is significant.
+.SH "SEE ALSO"
+sort(1), comm(1), awk(1)
+.SH BUGS
+With default field separation,
+the collating sequence is that of
+.IR sort\ \-b ;
+with
+.BR \-t ,
+the sequence is that of a plain sort.
+.PP
+The conventions of
+.I join, sort, comm, uniq, look
+and
+.IR awk (1)
+are wildly incongruous.

--- a/Applications/V7/cmd/look.1
+++ b/Applications/V7/cmd/look.1
@@ -1,0 +1,45 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH LOOK 1 
+.SH NAME
+look \- find lines in a sorted list
+.SH SYNOPSIS
+.B look
+[
+.B \-df
+]
+string
+[ file ]
+.SH DESCRIPTION
+.I Look
+consults a sorted
+.I file
+and prints all lines that begin with
+.IR string .
+It uses binary search.
+.PP
+The options 
+.B d
+and
+.B f
+affect comparisons as in
+.IR  sort (1):
+.TP 4
+.B  d
+`Dictionary' order:
+only letters, digits,
+tabs and blanks participate in comparisons.
+.TP 4
+.B  f
+Fold.
+Upper case letters compare equal to lower case.
+.PP
+If no
+.I file
+is specified,
+.I /usr/dict/words
+is assumed with collating sequence
+.B \-df.
+.SH FILES
+/usr/dict/words
+.SH "SEE ALSO"
+sort(1), grep(1)

--- a/Applications/V7/cmd/makekey.8
+++ b/Applications/V7/cmd/makekey.8
@@ -1,0 +1,50 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH MAKEKEY 8 
+.SH NAME
+makekey \- generate encryption key
+.SH SYNOPSIS
+.B /usr/lib/makekey
+.SH DESCRIPTION
+.I Makekey
+improves the usefulness of encryption schemes
+depending on a key by increasing the amount of time required to
+search the key space.
+It reads 10 bytes from its standard input,
+and writes 13 bytes on its standard output.
+The output depends on the input in a way intended
+to be difficult to compute (i.e. to require a substantial
+fraction of a second).
+.PP
+The first eight input bytes
+(the
+.IR "input key" )
+can be arbitrary ASCII characters.
+The last 
+two (the
+.IR salt )
+are best chosen from the set of digits, upper- and lower-case
+letters, and `.' and `/'.
+The salt characters are repeated as the first two characters of the output.
+The remaining 11 output characters are chosen from the same set as the salt
+and constitute the
+.I "output key."
+.PP
+The transformation performed is essentially the following:
+the salt is used to select one of 4096 cryptographic
+machines all based on the National Bureau of Standards
+DES algorithm, but modified in 4096 different ways.
+Using the input key as key,
+a constant string is fed into the machine and recirculated
+a number of times.
+The 64 bits that come out are distributed into the
+66 useful key bits in the result.
+.PP
+.I Makekey
+is intended for programs that perform encryption
+(e.g.
+.I ed
+and
+.IR crypt (1)).
+Usually its input and output will be pipes.
+.SH SEE ALSO
+crypt(1), ed(1)

--- a/Applications/V7/cmd/mesg.1
+++ b/Applications/V7/cmd/mesg.1
@@ -1,0 +1,35 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH MESG 1 
+.SH NAME
+mesg  \-  permit or deny messages
+.SH SYNOPSIS
+.B mesg
+[
+.B n
+] [
+.B y
+]
+.SH DESCRIPTION
+.I Mesg
+with argument
+.B n
+forbids messages via
+.IR  write (1)
+by revoking non-user
+write permission on the user's terminal.
+.I Mesg
+with argument
+.B y
+reinstates permission.
+All by itself,
+.I mesg
+reports the current state without changing it.
+.SH FILES
+/dev/tty*
+.br
+/dev
+.SH "SEE ALSO"
+write(1)
+.SH DIAGNOSTICS
+Exit status is 0 if messages are receivable,
+1 if not, 2 on error.

--- a/Applications/V7/cmd/newgrp.1
+++ b/Applications/V7/cmd/newgrp.1
@@ -1,0 +1,29 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH NEWGRP 1 
+.SH NAME
+newgrp \- log in to a new group
+.SH SYNOPSIS
+.B newgrp
+group
+.SH DESCRIPTION
+.I Newgrp
+changes the group identification of its caller,
+analogously to
+.IR  login (1).
+The same person remains logged in,
+and the current directory is unchanged,
+but calculations of access permissions to files are
+performed with respect to the
+new group ID.
+.PP
+A password is demanded if the group has
+a password and the user himself does not.
+.PP
+When most users log in, they
+are members of the group named `other.'
+.I Newgrp
+is known to the shell, which executes it directly without a fork.
+.SH FILES
+/etc/group, /etc/passwd
+.SH "SEE ALSO"
+login(1), group(5)

--- a/Applications/V7/cmd/pr.1
+++ b/Applications/V7/cmd/pr.1
@@ -1,0 +1,76 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH PR 1 
+.SH NAME
+pr  \-  print file
+.SH SYNOPSIS
+.B pr
+[ option ] ...
+[ file ] ...
+.SH DESCRIPTION
+.I Pr
+produces a printed listing of one or more
+.I files.
+The output is separated into pages headed by a date,
+the name of the file or a specified header, and the page number.
+If there are no file arguments,
+.I pr
+prints its standard input.
+.PP
+Options apply to all following files but may be reset
+between files:
+.TP
+.BI \- n
+Produce
+.IR n -column
+output.
+.TP
+.BI + n
+Begin printing with page
+.I  n.
+.TP
+.B  \-h
+Take the next argument as a page header.
+.TP
+.BI \-w n
+For purposes of multi-column output,
+take the width of the page to be
+.I n
+characters instead of the default 72.
+.TP
+.BI \-l n
+Take the length of the page to be
+.I n
+lines instead of the default 66.
+.TP
+.B  \-t
+Do not print the 5-line header or the
+5-line trailer normally supplied for each page.
+.TP
+.BI \-s c
+Separate columns by the single character
+.I c
+instead of by the appropriate amount of white space.
+A missing
+.I c
+is taken to be a tab.
+.TP
+.B  \-m
+Print all
+.I files
+simultaneously,
+each in one column,
+.PP
+Inter-terminal messages via
+.IR write (1)
+are
+forbidden during a
+.IR pr .
+.SH FILES
+/dev/tty?
+to suspend messages.
+.SH "SEE ALSO"
+cat(1)
+.SH DIAGNOSTICS
+There are no diagnostics when
+.I pr
+is printing on a terminal.

--- a/Applications/V7/cmd/ptx.1
+++ b/Applications/V7/cmd/ptx.1
@@ -1,0 +1,107 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH PTX 1
+.SH NAME
+ptx \- permuted index
+.SH SYNOPSIS
+.B ptx
+[ option ] ...
+[ input [ output ] ]
+.SH DESCRIPTION
+.I Ptx
+generates a permuted index to file
+.I input
+on file
+.I output
+(standard input and output default).
+It has three phases: the first does the permutation, generating
+one line for each keyword in an input line.
+The keyword is rotated to the front.
+The permuted file is then
+sorted.
+Finally, the sorted lines are rotated so the keyword
+comes at the middle of the page.
+.I Ptx
+produces output in the form:
+.br
+.IP
+\&.xx "tail" "before keyword" "keyword and after" "head"
+.LP
+where .xx may be an
+.I nroff
+or
+.IR troff (1)
+macro
+for user-defined formatting.
+The
+.I before keyword
+and
+.I keyword and after
+fields incorporate as much of the line as will fit
+around the keyword when it is printed at the middle of the page.
+.I Tail
+and
+.I head,
+at least one of which is an empty string "",
+are wrapped-around pieces small enough to fit
+in the unused space at the opposite end of the line.
+When original text must be discarded, `/' marks the spot.
+.PP
+The following options can be applied:
+.TP
+.BR \-f
+Fold upper and lower case letters for sorting.
+.TP 
+.BR \-t
+Prepare the output for the phototypesetter;
+the default line length is 100 characters.
+.TP 
+.BI \-w " n"
+Use the next argument,
+.I n,
+as the width of the output line.
+The default line length is 72 characters.
+.TP
+.BI \-g " n"
+Use the next argument,
+.I n,
+as the number of characters to allow for each gap
+among the four parts of the line as finally printed.
+The default gap is 3 characters.
+.TP 
+.BR \-o " only"
+Use as keywords only the words given in the \fIonly\fR file.
+.TP 
+.BR \-i " ignore"
+Do not use as keywords any words given in the
+.I
+ignore
+file.
+If the \fB-\fIi\fR and \fB-\fIo\fR options are missing, use /usr/lib/eign
+as the 
+.I
+ignore
+file.
+.TP 
+.BR \-b " break"
+Use the characters in the 
+.I
+break
+file to separate words.
+In any case, tab, newline, and space characters are always used as break characters.
+.TP
+.BR \-r
+Take any leading nonblank characters of each input line to
+be a reference identifier (as to a page or chapter)
+separate from the text of the line.
+Attach that identifier as a 5th field on each output line.
+.PP
+The index for this manual was generated using
+.I ptx.
+.SH FILES
+/bin/sort
+.br
+/usr/lib/eign
+.SH BUGS
+Line length counts do not account for overstriking or
+proportional spacing.
+.br

--- a/Applications/V7/cmd/rev.1
+++ b/Applications/V7/cmd/rev.1
@@ -1,0 +1,12 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH REV 1 
+.SH NAME
+rev \- reverse lines of a file
+.SH SYNOPSIS
+.B rev
+[ file ] ...
+.SH DESCRIPTION
+.I Rev
+copies the named files to the standard output,
+reversing the order of characters in every line.
+If no file is specified, the standard input is copied.

--- a/Applications/V7/cmd/sh/fuzix-sh.pkg
+++ b/Applications/V7/cmd/sh/fuzix-sh.pkg
@@ -1,4 +1,11 @@
-package  sh
+package  V7-sh
 
 f 0755 /bin/sh              sh
+
+
+# Man page - in a separate package so that storage-limited targets can
+# disable it.
+
+package V7-sh-man
+
 f 0644 /usr/man/man1/sh.1   sh.1

--- a/Applications/V7/cmd/split.1
+++ b/Applications/V7/cmd/split.1
@@ -1,0 +1,36 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH SPLIT 1 
+.SH NAME
+split \- split a file into pieces
+.SH SYNOPSIS
+.B split
+[
+.B \-\fIn
+]
+[ file [ name ] ]
+.SH DESCRIPTION
+.I Split
+reads
+.I file
+and writes
+it in
+.IR n -line
+pieces
+(default 1000), as many as necessary,
+onto
+a set of output files.  The name of the first output
+file is
+.I name
+with
+.B aa
+appended, and so on
+lexicographically.
+If no output name is given,
+.B x
+is default.
+.PP
+If no input file is given, or
+if
+.B \-
+is given in its stead,
+then the standard input file is used.

--- a/Applications/V7/cmd/su.1
+++ b/Applications/V7/cmd/su.1
@@ -1,0 +1,28 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH SU 1 
+.SH NAME
+su  \-  substitute user id temporarily
+.SH SYNOPSIS
+.B su
+[ userid ]
+.SH DESCRIPTION
+.I Su
+demands the password of the specified
+.I userid,
+and if it is given,
+changes to that 
+.I userid
+and invokes the Shell
+.IR sh (1)
+without changing the current directory or the
+user environment (see
+.IR environ (5)).
+The new user ID stays in force until the Shell exits.
+.PP
+If no 
+.I userid
+is specified, `root' is assumed.
+To remind the super-user of his responsibilities,
+the Shell substitutes `#' for its usual prompt.
+.SH "SEE ALSO"
+sh(1)

--- a/Applications/V7/cmd/sum.1
+++ b/Applications/V7/cmd/sum.1
@@ -1,0 +1,20 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH SUM 1 
+.SH NAME
+sum \- sum and count blocks in a file
+.SH SYNOPSIS
+.B sum
+file
+.SH DESCRIPTION
+.I Sum
+calculates and prints a 16-bit checksum for the named file,
+and also prints the number of blocks in the file.
+It is typically used to look for bad spots, or
+to validate a file communicated over
+some transmission line.
+.SH "SEE ALSO"
+wc(1)
+.SH DIAGNOSTICS
+`Read error'
+is indistinuishable from end of file on
+most devices; check the block count.

--- a/Applications/V7/cmd/test.1
+++ b/Applications/V7/cmd/test.1
@@ -1,0 +1,116 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH TEST 1 
+.SH NAME
+test \-  condition command
+.SH SYNOPSIS
+.B test
+expr
+.SH DESCRIPTION
+.I test
+evaluates the expression
+.IR expr ,
+and if its value is true then returns zero exit status; otherwise, a
+non zero exit status is returned.
+.I test
+returns a non zero exit if there are no arguments.
+.PP
+The following primitives are used to construct
+.IR expr .
+.TP 9n
+.BR \-r " file"
+true if the file exists and is readable.
+.TP 
+.BR \-w " file"
+true if the file exists and is writable.
+.TP 
+.BR \-f " file"
+true if the file exists and is not a directory.
+.TP 
+.BR \-d " file"
+true if the file exists and is a directory.
+.TP 
+.BR \-s " file"
+true if the file exists and has a size greater than zero.
+.TP 
+.BR \-t " [ fildes ]"
+true if the open file whose file descriptor number is
+.I fildes
+(1 by default)
+is associated with a terminal device.
+.TP 
+.BR \-z " s1"
+true if the length of string
+.I s1
+is zero.
+.TP 
+.BR \-n " s1"
+true if the length of the string
+.I s1
+is nonzero.
+.TP 
+.RB s1 " = " s2
+true
+if the strings
+.I s1
+and
+.I s2
+are equal.
+.TP 
+.RB s1 " != " s2
+true
+if the strings
+.I s1
+and
+.I s2
+are not equal.
+.TP 
+s1
+true if
+.I s1
+is not the null string.
+.TP 
+.RB n1 " \-eq " n2
+true if the integers
+.I n1
+and
+.I n2
+are algebraically equal.
+Any of the comparisons
+.BR \-ne ,
+.BR \-gt ,
+.BR \-ge ,
+.BR \-lt ,
+or
+.BR \-le
+may be used in place of
+.BR \-eq .
+.PP
+These primaries may be combined with the
+following operators:
+.TP 
+.B  !
+unary negation operator
+.TP 
+.B  \-a
+binary
+.I and
+operator
+.TP 
+.B  \-o
+binary
+.I or
+operator
+.TP 
+.BR "( " "expr" " )"
+parentheses for grouping.
+.PP
+.B \-a
+has higher precedence than
+.B \-o.
+Notice that all the operators and flags are separate
+arguments to
+.IR test .
+Notice also that parentheses are meaningful
+to the Shell and must be escaped.
+.SH "SEE ALSO"
+sh(1), find(1)

--- a/Applications/V7/cmd/time.1
+++ b/Applications/V7/cmd/time.1
@@ -1,0 +1,27 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH TIME 1 
+.SH NAME
+time \- time a command
+.SH SYNOPSIS
+.B time
+command
+.SH DESCRIPTION
+The
+given command is executed; after it is complete,
+.I time
+prints the elapsed time during the command, the time
+spent in the system, and the time spent in execution
+of the command.
+Times are reported in seconds.
+.PP
+The execution time can depend on what kind of memory
+the program happens to land in;
+the user time in MOS is often half what it is in core.
+.PP
+The times are printed on the diagnostic output stream.
+.SH BUGS
+Elapsed time is accurate to the second,
+while the CPU times are measured
+to the 60th second.
+Thus the sum of the CPU times can be up to a second larger
+than the elapsed time.

--- a/Applications/V7/cmd/tsort.1
+++ b/Applications/V7/cmd/tsort.1
@@ -1,0 +1,29 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH TSORT 1 
+.SH NAME
+tsort \- topological sort
+.SH SYNOPSIS
+.B tsort
+[ file ]
+.SH DESCRIPTION
+.I Tsort
+produces on the standard output a totally ordered list of items
+consistent with a partial ordering of items
+mentioned in the input
+.IR file .
+If no
+.I file
+is specified, the standard input is understood.
+.PP
+The input consists of pairs of items (nonempty strings)
+separated by blanks.
+Pairs of different items indicate ordering.
+Pairs of identical items indicate presence, but not ordering.
+.SH "SEE ALSO"
+lorder(1)
+.SH DIAGNOSTICS
+Odd data: there is an odd number of fields in the input file.
+.SH BUGS
+Uses a quadratic algorithm;
+not worth fixing for the typical use of ordering
+a library archive file.

--- a/Applications/V7/cmd/wall.1m
+++ b/Applications/V7/cmd/wall.1m
@@ -1,0 +1,25 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH WALL 1M 
+.SH NAME
+wall  \-  write to all users
+.SH SYNOPSIS
+.B /etc/wall
+.SH DESCRIPTION
+.I Wall
+reads its standard input until an end-of-file.
+It then sends this message,
+preceded by
+`Broadcast Message ...',
+to all logged in users.
+.PP
+The sender should be super-user to override
+any protections the users may have invoked.
+.SH FILES
+/dev/tty?
+.br
+/etc/utmp
+.SH "SEE ALSO"
+mesg(1), write(1)
+.SH DIAGNOSTICS
+`Cannot send to ...' when the open on
+a user's tty file fails.

--- a/Applications/V7/games/arithmetic.6
+++ b/Applications/V7/games/arithmetic.6
@@ -1,0 +1,66 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH ARITHMETIC 6 
+.SH NAME
+arithmetic \- provide drill in number facts
+.SH SYNOPSIS
+.B /usr/games/arithmetic
+[
+.B +\-x/
+] [ range ]
+.SH DESCRIPTION
+.I Arithmetic
+types out simple arithmetic problems,
+and waits for an answer to be typed in.
+If the answer is correct,
+it types back "Right!",
+and a new problem.
+If the answer is wrong,
+it replies "What?",
+and waits for another answer.
+Every twenty problems, it publishes
+statistics on correctness and the time required
+to answer.
+.PP
+To quit the program,
+type an interrupt (delete).
+.PP
+The first optional argument determines the kind of problem
+to be generated;
+.B +\-x/
+respectively cause
+addition, subtraction, multiplication, and division
+problems to be generated.
+One or more characters can be given;
+if more than one is given, the different types of
+problems will be mixed in random order; default is
+.B +\-
+.PP
+.I Range
+is a decimal number;
+all addends, subtrahends, differences, multiplicands, divisors,
+and quotients will be less than or equal to the value of
+.IR range .
+Default
+.I range
+is 10.
+.PP
+At the start, all numbers less than or equal to
+.I range
+are equally likely
+to appear.
+If the respondent makes a mistake,
+the numbers in the problem which was missed
+become more likely to reappear.
+.PP
+As a matter of educational philosophy, the program will
+not give correct answers,
+since the learner should, in principle,
+be able to calculate them.
+Thus the program is intended to provide drill for
+someone just past the first learning stage,
+not to teach number facts
+.I de
+.IR novo .
+For almost all users,
+the relevant statistic should be
+time per problem, not percent correct.

--- a/Applications/V7/games/backgammon.6
+++ b/Applications/V7/games/backgammon.6
@@ -1,0 +1,9 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH BACKGAMMON 6 
+.SH NAME
+backgammon \- the game
+.SH SYNOPSIS
+.B /usr/games/backgammon
+.SH DESCRIPTION
+This program does what you expect.
+It will ask whether you need instructions.

--- a/Applications/V7/games/fuzix-games.pkg
+++ b/Applications/V7/games/fuzix-games.pkg
@@ -2,6 +2,17 @@ package  V7-games
 if-file  arithmetic
 
 f 0755 /usr/bin/arithmetic    arithmetic
-f 0755 /usr/bin/wump          wump
-f 0755 /usr/bin/fish          fish
 f 0755 /usr/bin/backgammon    backgammon
+f 0755 /usr/bin/fish          fish
+f 0755 /usr/bin/wump          wump
+
+
+# Man pages - in a separate package so that storage-limited targets can
+# disable it.
+
+package V7-games-man
+
+f 0644 /usr/man/man6/arithmetic.6     arithmetic.6
+f 0644 /usr/man/man6/backgammon.6     backgammon.6
+# no page for fish
+f 0644 /usr/man/man6/wump.6           wump.6

--- a/Applications/V7/games/wump.6
+++ b/Applications/V7/games/wump.6
@@ -1,0 +1,30 @@
+.\" UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details.
+.TH WUMP 6 
+.SH NAME
+wump \- the game of hunt-the-wumpus
+.SH SYNOPSIS
+.B /usr/games/wump
+.SH DESCRIPTION
+.I Wump
+plays the game of `Hunt the Wumpus.'
+A Wumpus is a creature that lives in a cave with several rooms
+connected by tunnels.
+You wander among the rooms, trying to
+shoot the Wumpus with an arrow, meanwhile avoiding
+being eaten by the Wumpus and falling
+into
+Bottomless Pits.
+There are also Super Bats which are likely to pick you up
+and drop you in some random room.
+.PP
+The program asks various questions which you answer
+one per line;
+it will give a more detailed description
+if you want.
+.PP
+This program is based on one described in
+.I "People's Computer Company,"
+.I 2,
+2 (November 1973).
+.SH BUGS
+It will never replace Space War.

--- a/Standalone/filesystem-src/fuzix-basefs.pkg
+++ b/Standalone/filesystem-src/fuzix-basefs.pkg
@@ -128,6 +128,7 @@ d 0755 /usr/man/man4
 d 0755 /usr/man/man5
 d 0755 /usr/man/man6
 d 0755 /usr/man/man7
+d 0755 /usr/man/man8
 
 d 0755 /usr/src
 


### PR DESCRIPTION
Add man pages (origin: nordier distribution, like the source code) for all
V7 stuff where they exist.
In all cases man pages are in a separate package within the same package
file; this allows a space-limited system to disable the man packages.