### PR TITLE
Applications: levee: Build versions for ansi, vt52 and termcap

### DIFF
--- a/Applications/levee/.gitignore
+++ b/Applications/levee/.gitignore
@@ -1,7 +1,4 @@
 levee
-levee-l
-levee-a
-levee-v
-*.o-l
-*.o-a
-*.o-v
+levee-termcap
+levee-ansi
+levee-vt52

--- a/Applications/levee/Makefile
+++ b/Applications/levee/Makefile
@@ -1,18 +1,33 @@
-.SUFFIXES: .c .rel
+.SUFFIXES: .c -vt52.rel -ansi.rel -termcap.rel
 
 CSRCS = beep.c blockio.c display.c doscall.c editcor.c exec.c find.c
 CSRCS += flexcall.c gemcall.c globals.c insert.c main.c misc.c modify.c
 CSRCS += move.c rmxcall.c ucsd.c undo.c unixcall.c wildargs.c
 
-OBJS = $(CSRCS:.c=.rel)
+HFILES = extern.h grep.h levee.h proto.h
+OBJSVT52 = $(CSRCS:.c=-vt52.rel)
+OBJSANSI = $(CSRCS:.c=-ansi.rel)
+OBJSTERMCAP = $(CSRCS:.c=-termcap.rel)
 
-levee: $(OBJS)
-	fcc -o levee-vt52 $(OBJS)
+all:	levee-vt52 levee-ansi levee-termcap
 
-$(OBJS): $(CSRCS)
+levee-vt52: $(OBJSVT52)
+	fcc -o levee-vt52 $(OBJSVT52)
 
-.c.rel:
-	fcc -O3 -DVT52=1 -DANSI=0 -c $(@:.rel=.c)
+levee-ansi: $(OBJSANSI)
+	fcc -o levee-ansi $(OBJSANSI)
+
+levee-termcap: $(OBJSTERMCAP)
+	fcc -o levee-termcap $(OBJSTERMCAP)
+
+%-ansi.rel:	%.c $(HFILES)
+	fcc -O3 -DVT52=0 -DANSI=1 -DTERMCAP=0 -c $< -o $@
+
+%-vt52.rel:	%.c $(HFILES)
+	fcc -O3 -DVT52=1 -DANSI=0 -DTERMCAP=0 -c $< -o $@
+
+%-termcap.rel:	%.c $(HFILES)
+	fcc -O3 -DVT52=0 -DANSI=0 -DTERMCAP=1 -c $< -o $@
 
 clean:
-	rm -rf $(OBJS) *.lst *.sym *.map *.noi *.lk *.ihx *.tmp *~ *.rel *.asm levee levee.bin
+	rm -rf $(OBJSVT52) $(OBJSANSI) $(OBJSTERMCAP) *.lst *.sym *.map *.noi *.lk *.ihx *.tmp *~ *.rel *.asm levee levee.bin

--- a/Applications/levee/display.c
+++ b/Applications/levee/display.c
@@ -20,6 +20,7 @@
 #include "extern.h"
 
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 /* do a gotoXY -- allowing -1 for same row/column */
 

--- a/Applications/levee/fuzix-levee.pkg
+++ b/Applications/levee/fuzix-levee.pkg
@@ -13,3 +13,9 @@ package  levee-ansi
 if-file  levee-ansi
 
 f 0755 /bin/levee-ansi       levee-ansi
+
+
+package  levee-termcap
+if-file  levee-termcap
+
+f 0755 /bin/levee-termcap    levee-termcap

--- a/Applications/levee/levee.h
+++ b/Applications/levee/levee.h
@@ -61,8 +61,8 @@
 /* use "-DANSI=1 -DVT52=0" etc. on compile line */
 /*#define VT52	0*/		/* this must be nonzero for the Atari ST */
 /*#define ANSI	0*/
-#define TERMCAP	0
-#define ZTERM	0
+/*#define TERMCAP	0 */
+/*#define ZTERM	0 */
 
 #if ST
 

--- a/Applications/levee/termcap.i
+++ b/Applications/levee/termcap.i
@@ -122,7 +122,6 @@ void tc_init(void)
 #if RMX
     char *p = termcap;
 #else
-    char *getenv();
     char *p = getenv("TERMCAP");
 #endif
     char *lp, *ptr;
@@ -137,7 +136,7 @@ void tc_init(void)
 	exit(1);
     }
 #endif
-    lp = Malloc(strlen(p)+1);
+    lp = malloc(strlen(p)+1);
     if (!lp) {
 	puts("lv: out of memory\n");
 	exit(1);


### PR DESCRIPTION
The termcap version needs work still, should load from /etc/termcap rather than $TERMCAP.