### PR TITLE
Allow for networking w/o level 2

### DIFF
--- a/Kernel/dev/net/net_native.c
+++ b/Kernel/dev/net/net_native.c
@@ -163,6 +163,7 @@ int netdev_ioctl(uarg_t request, char *data)
 				return -1;
 			i_ref(net_ino);
 			return 0;
+#ifdef CONFIG_LEVEL_2
 		case SELECT_BEGIN:
 		case SELECT_TEST:
 			/* We are always writable, but may not alway be readable */
@@ -171,6 +172,7 @@ int netdev_ioctl(uarg_t request, char *data)
 					*data &= ~SELECT_IN;
 			}
 			*data &= SELECT_IN|SELECT_OUT;
+#endif
 	}
 	udata.u_error = ENOTTY;
 	return -1;

--- a/Kernel/include/kdata.h
+++ b/Kernel/include/kdata.h
@@ -84,14 +84,14 @@ struct runload {
 extern struct runload loadavg[];
 
 // the system call dispatch table
-#ifdef CONFIG_LEVEL_2
 #ifdef CONFIG_NET
 #define FUZIX_SYSCALL_COUNT 99
 #else
+#ifdef CONFIG_LEVEL_2
 #define FUZIX_SYSCALL_COUNT 80
-#endif
 #else
 #define FUZIX_SYSCALL_COUNT 66
+#endif
 #endif
 
 typedef arg_t (*syscall_t)(void);

--- a/Kernel/kdata.c
+++ b/Kernel/kdata.c
@@ -102,14 +102,15 @@ const syscall_t syscall_dispatch[FUZIX_SYSCALL_COUNT] = {
 	_acct,			/* FUZIX system call 63 */
 	_memalloc,		/* FUZIX system call 64 */
 	_memfree,		/* FUZIX system call 65 */
-	/* Level 2 calls */
-#if defined(CONFIG_LEVEL_2)
+	/* Level 2 calls and Networking calls */
+#if defined(CONFIG_LEVEL_2) || defined(CONFIG_NET)
 	_nosys,			/* 66-71 reserved */
 	_nosys,
 	_nosys,
 	_nosys,
 	_nosys,
 	_nosys,
+#ifdef CONFIG_LEVEL_2
 	_select,		/* FUZIX system call 72 */
 	_setgroups,		/* FUZIX system call 73 */
 	_getgroups,		/* FUZIX system call 74 */
@@ -118,6 +119,16 @@ const syscall_t syscall_dispatch[FUZIX_SYSCALL_COUNT] = {
 	_setpgid,		/* FUZIX system call 77 */
 	_setsid,		/* FUZIX system call 78 */
 	_getsid,		/* FUZIX system call 79 */
+#else
+	_nosys, 	        /* FUZIX system call 72 */
+	_nosys, 	        /* FUZIX system call 73 */
+	_nosys, 	        /* FUZIX system call 74 */
+	_nosys, 	        /* FUZIX system call 75 */
+	_nosys, 	        /* FUZIX system call 76 */
+	_nosys, 	        /* FUZIX system call 77 */
+	_nosys, 	        /* FUZIX system call 78 */
+	_nosys, 	        /* FUZIX system call 79 */
+#endif
 	_nosys,			/* 80-89 reserved */
 	_nosys,
 	_nosys,
@@ -128,7 +139,7 @@ const syscall_t syscall_dispatch[FUZIX_SYSCALL_COUNT] = {
 	_nosys,
 	_nosys,
 	_nosys,
-#if defined(CONFIG_NET)		/* For now require L2 */
+#ifdef CONFIG_NET		/* For now require L2 */
 	_socket,		/* FUZIX system call 90 */
 	_listen,		/* FUZIX system call 91 */
 	_bind,			/* FUZIX system call 92 */

--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -61,8 +61,7 @@ image:
 	../syscall_fs3.o \
 	../usermem_std-6809.o devtty.o libc.o ../vt.o usermem_gime.o video.o \
 	videoll.o dwtime.o \
-	../level2.o ../syscall_level2.o ../select.o ../syscall_net.o \
-	net_native.o
+	../syscall_net.o net_native.o
 
 boot.bin: boot/boot.s
 	lwasm -lboot.list -oboot.bin boot/boot.s

--- a/Kernel/platform-coco3/config.h
+++ b/Kernel/platform-coco3/config.h
@@ -93,7 +93,7 @@ extern unsigned char vt_map( unsigned char c );
 #define CONFIG_DWTIME_INTERVAL 10  /* time between dw timer polls in secs */
 
 /* Level 2 groups, coredumps, network */
-#define CONFIG_LEVEL_2
+#undef CONFIG_LEVEL_2
 #define CONFIG_NET
 #define CONFIG_NET_NATIVE
 


### PR DESCRIPTION
This hopefully will make it easier to try native networking on lesser machines without the overhead of level 2 code.