### PR TITLE
bank16k: add swapping

### DIFF
--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -873,6 +873,9 @@ extern void swapmap_add(uint8_t swap);
 extern int swapmap_alloc(void);
 extern ptptr swapneeded(ptptr p, int selfok);
 extern void swapper(ptptr p);
+extern void swapper2(ptptr p, uint16_t map);
+extern uint8_t get_common();
+extern void swap_finish(uint8_t page, ptptr p);
 /* These two are provided by the bank code selected for the port */
 extern int swapout(ptptr p);
 extern void swapin(ptptr p, uint16_t map);
@@ -894,6 +897,7 @@ extern void inittod(void);
 /* provided by architecture or helpers */
 extern void device_init(void);	/* provided by platform */
 extern void pagemap_init(void);
+extern void copy_common(uint8_t page);
 extern void pagemap_add(uint8_t page);	/* FIXME: may need a page type for big boxes */
 extern void pagemap_free(ptptr p);
 extern int pagemap_alloc(ptptr p);

--- a/Kernel/swap.c
+++ b/Kernel/swap.c
@@ -133,16 +133,8 @@ ptptr swapneeded(ptptr p, int notself)
 	return n;
 }
 
-/*
- *	Called from switchin when we discover that we want to run
- *	a swapped process. We let pagemap_alloc cause any needed swap
- *	out of idle processes.
- */
-void swapper(ptptr p)
+void swapper2(ptptr p, uint16_t map)
 {
-        uint16_t map = p->p_page2;
-	pagemap_alloc(p);	/* May cause a swapout. May also destroy
-                                   the old value of p->page2 */
 #ifdef DEBUG
 	kprintf("Swapping in %p (page %d), utab.ptab %p\n", p, p->p_page,
 		udata.u_ptab);
@@ -154,4 +146,18 @@ void swapper(ptptr p)
 		p, p->p_page, udata.u_ptab);
 #endif
 }
+
+/*
+ *	Called from switchin when we discover that we want to run
+ *	a swapped process. We let pagemap_alloc cause any needed swap
+ *	out of idle processes.
+ */
+void swapper(ptptr p)
+{
+        uint16_t map = p->p_page2;
+	pagemap_alloc(p);	/* May cause a swapout. May also destroy
+                                   the old value of p->page2 */
+	return swapper2(p, map);
+}
+
 #endif


### PR DESCRIPTION
bank16k platforms wishing to swap will have to provide a copy_common( uint8_t pageno ), and do something like this in switchin():

```
call _get_common    ;   to get a usable common page
fix up platform-specific mmu and switch to new common
call _swap_finish   ;  to swap in the rest of the swapped out task
```  