### PR TITLE
coco3: add /dev/lpr

### DIFF
--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -1,6 +1,6 @@
 
 CSRCS = ttydw.c mbr.c dwtime.c
-CSRCS += devices.c main.c libc.c devsdc.c
+CSRCS += devices.c main.c libc.c devsdc.c devlpr.c
 
 CDSRCS = ../dev/devide_discard.c
 
@@ -54,7 +54,7 @@ image:
 	coco3.o ../start.o ../version.o ../lowlevel-6809.o \
 	tricks.o main.o ../timer.o ../kdata.o devices.o \
 	drivewire.o devdw.o ttydw.o blkdev.o mbr.o devide.o devide_discard.o \
-	ide.o devsdc.o sdc.o \
+	ide.o devsdc.o sdc.o devlpr.o \
 	../devio.o ../filesys.o ../process.o ../inode.o ../syscall_fs.o \
 	../syscall_proc.o ../syscall_other.o ../mm.o ../bank16k.o ../swap.o \
 	../tty.o ../devsys.o ../usermem.o ../syscall_fs2.o ../syscall_exec16.o \

--- a/Kernel/platform-coco3/README
+++ b/Kernel/platform-coco3/README
@@ -88,7 +88,7 @@ node       major   minor     description
 /dev/tty2  2       2         virtual terminal No. 2.
 /dev/tty3  2       3         Drivewire Virtual Window #0
 /dev/dw?   8       0-256     Drivewire Block Drives
-
+/dev/lpr   3       0         Drivewire Printer
 
 **************************
 BUILDING
@@ -172,16 +172,9 @@ DONE
 TO DO
 *************************
 
-* Swapping to disk has not been implemented yet, so a standard 512k
-upgrade is required.
-
-* IDE Drivers.
-
-* SDC Drivers.
+* Finish SDC Drivers Need ioctl for meta methods, userspace cntl program.
 
 * SCSI Drivers.
-
-* Better and more DriveWire Virtual Serial Ports.
 
 * Better support of the GIME chip's video modes
 

--- a/Kernel/platform-coco3/devices.c
+++ b/Kernel/platform-coco3/devices.c
@@ -10,6 +10,7 @@
 #include <devide.h>
 #include <dwtime.h>
 #include <netdev.h>
+#include <devlpr.h>
 
 
 struct devsw dev_tab[] =  /* The device driver switch table */
@@ -23,7 +24,7 @@ struct devsw dev_tab[] =  /* The device driver switch table */
   /* 2: /dev/tty	TTY devices */
   {  tty_open,     my_tty_close,   tty_read,  tty_write,  gfx_ioctl },
   /* 3: /dev/lpr	Printer devices */
-  {  nxio_open,     no_close,    no_rdwr,   no_rdwr,  no_ioctl  },
+  {  lpr_open,     lpr_close,    no_rdwr,   lpr_write,  no_ioctl  },
   /* 4: /dev/mem etc	System devices (one offs) */
   {  no_open,      sys_close,    sys_read, sys_write, sys_ioctl  },
   /* Pack to 7 with nxio if adding private devices and start at 8 */

--- a/Kernel/platform-coco3/devlpr.c
+++ b/Kernel/platform-coco3/devlpr.c
@@ -1,0 +1,64 @@
+/*
+  A simple line printer char driver.  
+    the only minor number, for now, is 0: the DriveWire Printer.
+*/
+
+
+#include <kernel.h>
+#include <version.h>
+#include <kdata.h>
+#include <device.h>
+#include <devlpr.h>
+
+
+int lpr_open(uint8_t minor, uint16_t flag)
+{
+	if (minor){
+		udata.u_error = ENODEV;
+		return -1;
+	}
+	return 0;
+}
+
+int lpr_close(uint8_t minor)
+{
+	uint8_t b = 0x46;
+	if (minor == 0)
+		dw_transaction(&b, 1, NULL, 0, 0);
+	return 0;
+}
+
+static int iopoll(int sofar)
+{
+	/* Ought to be a core helper for this lot ? */
+	if (need_reschedule())
+		_sched_yield();
+	if (chksigs()) {
+		if (sofar)
+			return sofar;
+		udata.u_error = EINTR;
+		return -1;
+	}
+	return 0;
+}
+
+
+int lpr_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
+{
+	uint8_t *p = udata.u_base;
+	uint8_t *pe = p + udata.u_count;
+	int n;
+	irqflags_t irq;
+	uint8_t buf[2];
+
+	buf[0]=0x50;
+	if (minor == 0) {
+		while (p < pe) {
+			if ((n = iopoll(pe - p)) != 0)
+				return n;
+			buf[1] = ugetc(p++);
+			dw_transaction(buf, 2, NULL, 0, 0);
+		}
+	} 
+	return pe - p;
+}

--- a/Kernel/platform-coco3/devlpr.h
+++ b/Kernel/platform-coco3/devlpr.h
@@ -1,0 +1,11 @@
+#ifndef __DEVLPR_DOT_H__
+#define __DEVLPR_DOT_H__
+
+extern int lpr_open(uint8_t minor, uint16_t flag);
+extern int lpr_close(uint8_t minor);
+extern int lpr_write(uint8_t minor, uint8_t rawflag, uint8_t flag);
+
+extern void dw_lpr(uint8_t c);
+extern void dw_lpr_close(void);
+
+#endif


### PR DESCRIPTION
Add /dev/lpr for Drivewire Printer, for now.