### PR TITLE
net_native: a slight addition

### DIFF
--- a/Kernel/dev/net/net_native.c
+++ b/Kernel/dev/net/net_native.c
@@ -490,6 +490,7 @@ int net_connect(struct socket *s)
  */
 void net_close(struct socket *s)
 {
+	struct sockdata *sd = s->s_priv;
 	/* Caution here - the native tcp socket will hang around longer */
 	sd->newstate = SS_CLOSED;
 	netn_asynchronous_event(s, NEV_STATE|NEVW_STATE);


### PR DESCRIPTION
"sd" doesn't exist: get it from "s"