### PR TITLE
coco3: fix blkdev mapper routines: blk_op is not in common.

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -392,8 +392,11 @@ a@	ldd	,x++
 	clr	0xffa8
 	puls	u,pc
 
+	.area	.common
 ;;; Helper for blkdev drivers to setup memory based on rawflag
+;;; WARNING: the blk_op struct will not be available for rawflag=1/2 after calling this!
 blkdev_rawflg
+	pshs d,x     ; save regs
 	ldx #_blk_op ; X = blkdev operations
         ldb 0xffa8   ; get mmu setting
         stb ret+1    ; save in stash
@@ -406,10 +409,10 @@ blkdev_rawflg
         stb 0xffa8   ; task 1, kernel task regs.
         incb         ; inc page no... next block no.
         stb 0xffa9   ; store it in mmu
-	rts
+	puls d,x,pc
 proc@	jsr map_process_always
  	; get parameters from C, X points to cmd packet
-out@	rts
+out@	puls d,x,pc
 
 ;;; Helper for blkdev drivers to clean up memory after blkdev_rawflg
 blkdev_unrawflg

--- a/Kernel/platform-coco3/ide.s
+++ b/Kernel/platform-coco3/ide.s
@@ -21,8 +21,8 @@ _devide_read_data:
 	pshs y,dp
 	lda #0xFF
 	tfr a,dp
-	jsr blkdev_rawflg
 	ldx _blk_op
+	jsr blkdev_rawflg
 	leay 512,x
 	sty endp
 readword:
@@ -38,8 +38,8 @@ _devide_write_data:
 	pshs y,dp
 	lda #0xFF
 	tfr a,dp
-	jsr blkdev_rawflg
 	ldx _blk_op
+	jsr blkdev_rawflg
 	leay 512,x
 	sty endp
 writeword:


### PR DESCRIPTION
low level ide routines where trying to use blk_op struct after flipping them out of memory map (via rawflag=1).  Also: coco3 blkdev memory helpers where not in common.