### PR TITLE
coco3: make different coco3 platforms

### DIFF
--- a/Kernel/filesys.c
+++ b/Kernel/filesys.c
@@ -1,4 +1,4 @@
-#define DEBUG
+#undef DEBUG
 #include <kernel.h>
 #include <kdata.h>
 #include <printf.h>

--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -101,7 +101,7 @@ image: boot.bin
 	../syscall_fs3.o \
 	../usermem_std-6809.o devtty.o libc.o ../vt.o usermem_gime.o video.o \
 	videoll.o dwtime.o \
-	../syscall_net.o net_native.o $(DEVICES)
+	../syscall_net.o net_native.o $(DRIVERS)
 # make DECB disk w/ new kernel
 	rm -f fuzix.dsk
 	decb dskini fuzix.dsk

--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -21,6 +21,47 @@ CROSS_CCOPTS += -I../dev/
 
 JUNK = $(CSRCS:.c=.o) $(ASRCS:.s=.o) $(DSRCS:.c=.o)
 
+# Set 'SUBTARGET' to one of: emu, real, fpga, nano. 
+
+ifndef SUBTARGET
+SUBTARGET = emu
+endif
+
+ifeq ($(SUBTARGET),real)
+COCO_IDE = 1
+COCO_SDC = 1
+endif
+
+ifeq ($(SUBTARGET),emu)
+COCO_IDE = 1
+COCO_BECKER = 1
+endif
+
+ifeq ($(SUBTARGET),fpga)
+COCO_SDFPGA = 1
+COCO_BECKER = 1
+endif
+
+ifeq ($(SUBTARGET),nano)
+COCO_SDNANO = 1
+endif
+
+ifdef COCO_SDC
+DRIVERS += devsdc.o sdc.o
+CROSS_CC += -DCONFIG_COCOSDC
+endif
+
+ifdef COCO_IDE
+DRIVERS += devide.o devide_discard.o ide.o
+CROSS_CC += -DCONFIG_COCOIDE
+endif
+
+ifdef COCO_BECKER
+ASOPTS = --defsym BECKER=1
+else
+ASOPTS = --defsym BECKER=0 
+endif
+
 all:	$(OBJS)
 
 $(COBJS): %$(BINEXT): %.c
@@ -53,15 +94,14 @@ image: boot.bin
 	crt0.o commonmem.o \
 	coco3.o ../start.o ../version.o ../lowlevel-6809.o \
 	tricks.o main.o ../timer.o ../kdata.o devices.o \
-	drivewire.o devdw.o ttydw.o blkdev.o mbr.o devide.o devide_discard.o \
-	ide.o devsdc.o sdc.o devlpr.o \
+	drivewire.o devdw.o ttydw.o blkdev.o mbr.o devlpr.o \
 	../devio.o ../filesys.o ../process.o ../inode.o ../syscall_fs.o \
 	../syscall_proc.o ../syscall_other.o ../mm.o ../bank16k.o ../swap.o \
 	../tty.o ../devsys.o ../usermem.o ../syscall_fs2.o ../syscall_exec16.o \
 	../syscall_fs3.o \
 	../usermem_std-6809.o devtty.o libc.o ../vt.o usermem_gime.o video.o \
 	videoll.o dwtime.o \
-	../syscall_net.o net_native.o
+	../syscall_net.o net_native.o $(DEVICES)
 # make DECB disk w/ new kernel
 	rm -f fuzix.dsk
 	decb dskini fuzix.dsk

--- a/Kernel/platform-coco3/config.h
+++ b/Kernel/platform-coco3/config.h
@@ -87,8 +87,6 @@ extern unsigned char vt_map( unsigned char c );
 
 /* Block device define */
 #define MAX_BLKDEV  4     /* 2 IDE + 2 SDC */
-#undef  CONFIG_COCOSDC    /* Darren Atkinson's "CoCoSDC" cartridge */
-#define CONFIG_IDE        /* enable if IDE interface present */
 
 #define CONFIG_RTC        /* enable RTC code */
 #define CONFIG_DWTIME_INTERVAL 10  /* time between dw timer polls in secs */

--- a/Kernel/platform-coco3/devices.c
+++ b/Kernel/platform-coco3/devices.c
@@ -46,7 +46,9 @@ bool validdev(uint16_t dev)
 }
 void device_init(void)
 {
+#ifdef CONFIG_COCOIDE
 	devide_init( );
+#endif
 #ifdef CONFIG_COCOSDC
 	devsdc_init( );
 #endif

--- a/Kernel/platform-coco3/drivewire.s
+++ b/Kernel/platform-coco3/drivewire.s
@@ -164,7 +164,7 @@ NOINTMASK equ  1
 
 ; Hardcode these for now so that we can use below files unmodified
 H6309    equ 0
-BECKER   equ 1
+* BECKER   equ 1
 ARDUINO  equ 0
 JMCPBCK  equ 0
 BAUD38400 equ 0


### PR DESCRIPTION
This will let me have special builds tailored for each major coco3 platforms: real, emulated, fpga, and the fppa nano.   Each can have their own driver matrix.