### PR TITLE
devsys: read should return no. of bytes

### DIFF
--- a/Kernel/devsys.c
+++ b/Kernel/devsys.c
@@ -45,7 +45,9 @@ int sys_read(uint8_t minor, uint8_t rawflag, uint8_t flag)
 			udata.u_count = sizeof(struct p_tab);
 		if (udata.u_offset + udata.u_count > PTABSIZE * sizeof(struct p_tab))
 			return 0;
-		return uput(addr + udata.u_offset, udata.u_base, udata.u_count);
+		if (uput(addr + udata.u_offset, udata.u_base, udata.u_count) )
+			return 0;
+		return udata.u_count;
 #ifdef CONFIG_DEV_MEM
         case 4:
                 return devmem_read();

--- a/Kernel/syscall_fs2.c
+++ b/Kernel/syscall_fs2.c
@@ -411,7 +411,7 @@ arg_t _getfsys(void)
 		udata.u_error = ENXIO;
 		return (-1);
 	}
-	return uput((char *) m->m_fs, (char *) buf, sizeof(struct filesys));
+	return uput((char *) &m->m_fs, (char *) buf, sizeof(struct filesys));
 }
 
 #undef dev


### PR DESCRIPTION
'ps' was failing, due to a 0 return on read.  uput only returns 0 or -1, not number of bytes.