### PR TITLE
kernel: syscall_16: put header in userspace too.

### DIFF
--- a/Kernel/syscall_exec16.c
+++ b/Kernel/syscall_exec16.c
@@ -155,7 +155,7 @@ arg_t _execve(void)
 	/* We are definitely going to succeed with the exec,
 	 * so we can start writing over the old program
 	 */
-
+	uput(hdr, (uint8_t *)progload, 16);
 	/* At this point, we are committed to reading in and
 	 * executing the program. This call must not block. */
 


### PR DESCRIPTION
new simpler exec() wasn't putting the hdr into userspace.