### PR TITLE
bank16k: report correct memory used

### DIFF
--- a/Kernel/bank16k.c
+++ b/Kernel/bank16k.c
@@ -173,7 +173,7 @@ int pagemap_realloc(usize_t code, usize_t size, usize_t stack)
 
 usize_t pagemap_mem_used(void)
 {
-	return pfptr << 4;
+	return procmem - (pfptr << 4);
 }
 
 #ifdef SWAPDEV

--- a/Kernel/bank16k_low.c
+++ b/Kernel/bank16k_low.c
@@ -155,7 +155,7 @@ int pagemap_realloc(uint16_t size)
 
 uint16_t pagemap_mem_used(void)
 {
-	return pfptr << 4;
+	return procmem - (pfptr << 4);
 }
 
 


### PR DESCRIPTION
pfptr goes down as memory is allocated. return it's compliement instead.