### PR TITLE
Fix a few new bugs in netd

### DIFF
--- a/Applications/netd/coconic.c
+++ b/Applications/netd/coconic.c
@@ -159,4 +159,4 @@ int device_init( void )
 }
 
 
-int has_arp = 1;
+uint8_t has_arp = 1;

--- a/Applications/netd/device.h
+++ b/Applications/netd/device.h
@@ -25,3 +25,5 @@ int device_read( char *buf, int len );
 */
 int device_init( void );
 
+/* set this is 1 if interface needs ARP */
+extern uint8_t has_arp;

--- a/Applications/netd/lwwire.c
+++ b/Applications/netd/lwwire.c
@@ -175,4 +175,4 @@ int device_init( void )
     return 0;
 }
 
-int has_arp = 1;
+uint8_t has_arp = 1;

--- a/Applications/netd/lwwire.c
+++ b/Applications/netd/lwwire.c
@@ -32,7 +32,9 @@ static int dwnet_poll( void )
     if( ret < 0 ){
 	return -1;
     }
-    return (buf[0]<<8) + buf[1];
+    ret = (buf[0]<<8) + buf[1];
+    if (ret<0) return 0;
+    return ret;
 }
 
 

--- a/Applications/netd/slip.c
+++ b/Applications/netd/slip.c
@@ -154,4 +154,4 @@ int device_init(void)
     return 0;
 }
 
-int has_arp = 0;
+uint8_t has_arp = 0;


### PR DESCRIPTION
all the pendanticy of gcc didn't catch that has_arp was global, but I guess including the header in the device driver helps.  Also fix lwwire.c returned -1 when there's not an error.  Still needs some debugging in set_timer(), as this call mysteriously kills netd daemon.