### PR TITLE
init: crunched table not reseting runlevel mask, correct cleanup.

### DIFF
--- a/Applications/util/init.c
+++ b/Applications/util/init.c
@@ -285,6 +285,7 @@ static void parse_initline(void)
 		bad_line();
 		return;
 	}
+	*idata = 0;
 	while (*sdata != ':') {
 		if (*sdata == '\n' || sdata > sdata_end) {
 			bad_line();
@@ -482,7 +483,7 @@ static int cleanup_runlevel(uint8_t oldmask, uint8_t newmask, int sig)
 
 	while (n < initcount) {
 		/* Dying ? */
-		if ((p[3] & oldmask) && !(p[3] && newmask)) {
+		if ((p[3] & oldmask) && !(p[3] & newmask)) {
 			/* Count number still to die */
 			if (p[4] == INIT_RESPAWN && initpid[n].pid) {
 				/* Group kill */


### PR DESCRIPTION
init was adding bits to runlevel mask in crunched table without starting it at zero.  rarely resulting in a matching entry when cleaning up.  Also fix "group kill procs in this run level, that are not in new runlevel" syntax error.