### PR TITLE
Quick fixes for netd

### DIFF
--- a/Applications/netd/dig.c
+++ b/Applications/netd/dig.c
@@ -191,7 +191,7 @@ int main( int argc, char *argv[] ){
 	if( argv[x][0] == '@' )
 	    strncpy( server, &(argv[x][1]), 16);
 	else
-	    strncpy( name, argv[x], 16 );
+	    strncpy( name, argv[x], 256 );
     }
 
     fd = socket( AF_INET, SOCK_DGRAM, 0);

--- a/Applications/netd/gethostbyname.c
+++ b/Applications/netd/gethostbyname.c
@@ -180,6 +180,7 @@ struct hostent *gethostbyname( char *name ){
 
  process:
     /* process packet */
+    alarm(0);
     {
 	struct header *h = (struct header *)buf;
 	struct RRtail *t;


### PR DESCRIPTION
"user_request" flag does nothing in the UDP handling, and UDP doesn't need any complicated closing anyway, so release and free up UDP struct ASAP after kernel's close().
