### PR TITLE
netd: let Fuzix choose local port

### DIFF
--- a/Applications/netd/netd.c
+++ b/Applications/netd/netd.c
@@ -559,9 +559,7 @@ int dokernel( void )
 					ksend( NE_NEWSTATE );
 					m->conn->userrequest = 1;
 					c = conptr - uip_conns;
-					if (sm.s.s_type == SOCKTYPE_TCP)
-						activity |= (1 << c);
-					break;
+					activity |= (1 << c);
 				}
 				else if ( sm.s.s_type == SOCKTYPE_UDP ){
 					struct uip_udp_conn *conptr;

--- a/Applications/netd/netd.c
+++ b/Applications/netd/netd.c
@@ -214,18 +214,23 @@ void netd_appcall(void)
 		/* find see if anything is listening on this port */
 		{
 			int i;
-			for ( i = 0; i< NSOCKET; i++ ){
-				if ( map[i].port == uip_conn->lport ){
-					/* found a listening port */
-					/* FIXME: what am I supposed to send to the
-					   listening socket?
-					*/
-					ne.data = SS_ACCEPTWAIT;
-					ksend( NE_EVENT );
-					/* make a new link and Associate the new uip_connection
-					   with some lcn/socket the kernel readied */
-					flag = 1;
-					break;
+			/* fixme: this is next chunk is for listen() logic -
+			   it needs a better idea if a socket is listening, or
+			   just autobound */
+			if (0){
+				for ( i = 0; i< NSOCKET; i++ ){
+					if ( map[i].port == uip_conn->lport ){
+						/* found a listening port */
+						/* FIXME: what am I supposed to send to the
+						   listening socket?
+						*/
+						ne.data = SS_ACCEPTWAIT;
+						ksend( NE_EVENT );
+						/* make a new link and Associate the new uip_connection
+						   with some lcn/socket the kernel readied */
+						flag = 1;
+						break;
+					}
 				}
 			}
 		}
@@ -536,6 +541,9 @@ int dokernel( void )
 				break;
 			case SS_BOUND:
 				/* FIXME: probably needs to do something here  */
+				/* fixme: set IP here? */
+				if (sm.s.s_type == SOCKTYPE_TCP)
+					m->port = sm.s.s_addr[SADDR_SRC].port;
 				ne.data = SS_BOUND;
 				ksend( NE_NEWSTATE );
 				break;
@@ -546,7 +554,7 @@ int dokernel( void )
 					int port = sm.s.s_addr[SADDR_DST].port;
 					uip_ipaddr_copy( &addr, (uip_ipaddr_t *)
 							 &sm.s.s_addr[SADDR_DST].addr );
-					conptr = uip_connect( &addr, port );
+					conptr = uip_connect( &addr, port, m->port );
 					if ( !conptr ){
 						ne.data = SS_CLOSED;
 						ne.ret = ENOMEM;	/* should be ENOBUFS I think */

--- a/Applications/netd/uip.c
+++ b/Applications/netd/uip.c
@@ -405,16 +405,21 @@ uip_init(void)
 /*---------------------------------------------------------------------------*/
 #if UIP_ACTIVE_OPEN
 struct uip_conn *
-uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport)
+uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport, uint16_t lport)
 {
   register struct uip_conn *conn, *cconn;
 
   /* Find an unused local port. */
+  if(!lport){
  again:
-  ++lastport;
+    ++lastport;
 
-  if(lastport >= 32000) {
-    lastport = 4096;
+    if(lastport >= 32000) {
+      lastport = 4096;
+    }
+  }
+  else {
+      lastport = lport;
   }
 
   /* Check if this port is already in use, and if so try to find
@@ -423,6 +428,8 @@ uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport)
     conn = &uip_conns[c];
     if(conn->tcpstateflags != UIP_CLOSED &&
        conn->lport == uip_htons(lastport)) {
+      if(lport)
+	    return 0;
       goto again;
     }
   }

--- a/Applications/netd/uip.h
+++ b/Applications/netd/uip.h
@@ -597,7 +597,8 @@ void uip_unlisten(uint16_t port);
  * or NULL if no connection could be allocated.
  *
  */
-struct uip_conn *uip_connect(const uip_ipaddr_t *ripaddr, uint16_t port);
+struct uip_conn *uip_connect(const uip_ipaddr_t *ripaddr, uint16_t port,
+			     uint16_t lport);
 
 
 


### PR DESCRIPTION
as per issue #555
"uIP needs tweaking so that it uses the bind() provided local socket if presetn when we connect()."

if we pass a local port of 0 to uip, it'll choose the local port, else it'll use fuzix's idea of the port no.  is there a reason even to bother with uip picking it's local port?