### PR TITLE
coco3: take cmd line for default video mode

### DIFF
--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -533,21 +533,33 @@ uint8_t rgb_def_pal[16]={
 	0, 8, 32, 40, 16, 24, 48, 63
 };
 
+
+static void apply_defmode( uint8_t defmode )
+{
+	int i;
+	for( i=0; i<2; i++){
+		memcpy( &(ptytab[i].vmod), &(mode[defmode]), sizeof( struct mode_s ) );
+	}
+	apply_gime(1);
+}
+
+__attribute__((section(".discard")))
+void set_defmode( uint8_t *s )
+{
+	defmode = s[7]-0x30;
+	if( defmode > 4 )
+		defmode = 0;
+	apply_defmode(defmode);
+}
+
 __attribute__((section(".discard")))
 void devtty_init()
 {
 	int i;
-	int defmode=0;
 	/* set default keyboard delay/repeat rates */
 	keyrepeat.first = REPEAT_FIRST * (TICKSPERSEC/10);
 	keyrepeat.continual = REPEAT_CONTINUAL * (TICKSPERSEC/10);
-	/* scan cmdline for params for vt */
-
-       	/* apply default/cmdline mode to terminal structs */
-	for( i=0; i<2; i++){
-		memcpy( &(ptytab[i].vmod), &(mode[defmode]), sizeof( struct mode_s ) );
-	}
-	apply_gime( 1 );    /* apply initial tty1 to regs */
+	apply_defmode(0);
 	/* make video palettes match vt.h's definitions. */
 	memcpy( (uint8_t *)0xffb0, rgb_def_pal, 16 );
 }

--- a/Kernel/platform-coco3/devtty.h
+++ b/Kernel/platform-coco3/devtty.h
@@ -30,5 +30,6 @@ extern struct pty *curpty;
 
 int my_tty_close( uint8_t minor ); /* wrapper call to close DW ports */
 int gfx_ioctl(uint8_t minor, uarg_t arg, char *ptr);
+void set_defmode( uint8_t *s );
 
 #endif

--- a/Kernel/platform-coco3/main.c
+++ b/Kernel/platform-coco3/main.c
@@ -98,6 +98,10 @@ uint8_t platform_param(char *p)
 	    swapdev = bootdevice(p+5);
 	    return -1;
 	}
+	if (!strncmp(p,"VTMODE=", 7)){
+	    set_defmode( p );
+	    return -1;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Because life with a NTSC T.V. at 80 columns sucks.