### PR TITLE
fortune: bug: main doesn't return success.

### DIFF
--- a/Applications/games/fortune-gen.c
+++ b/Applications/games/fortune-gen.c
@@ -66,4 +66,5 @@ int main(int argc, char *argv[])
     perror("fwrite3");
     exit(1);
   }
+  return 0;
 }


### PR DESCRIPTION
This bug was sending incorrect return values back to sh.