### PR TITLE
coco3: poke RAM mode on init, just in case.

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -145,6 +145,7 @@ init_early:
 init_hardware:
 	;; High speed poke
 	sta	0xffd9		; high speed poke
+	sta	0xffdf		; RAM mode
 	;; set system RAM size
 	jsr	_scanmem	; X = number of pages
 	tfr 	x,d


### PR DESCRIPTION
Don't trust our boot environment to correctly set this SAM register.