### PR TITLE
util: 'cal' fix output.

### DIFF
--- a/Applications/util/cal.c
+++ b/Applications/util/cal.c
@@ -235,11 +235,7 @@ void j_yearly(int year)
     printf("\n\n");
     for (i = 0; i < 12; i++)
 	day_array(i + 1, year, days[i]);
-#if 0
     memset(lineout, ' ', sizeof(lineout) - 1);
-#else /* Hi-Tech C */
-    memset(lineout, sizeof(lineout) - 1, ' ');
-#endif
     lineout[sizeof(lineout) - 1] = '\0';
     for (month = 0; month < 12; month += 2) {
 	center(full_month[month], J_WEEK_LEN, J_HEAD_SEP);
@@ -270,11 +266,7 @@ void yearly(int year)
     printf("\n\n");
     for (i = 0; i < 12; i++)
 	day_array(i + 1, year, days[i]);
-#if 0
     memset(lineout, ' ', sizeof(lineout) - 1);
-#else /* Hi-Tech C */
-    memset(lineout, sizeof(lineout) - 1, ' ');
-#endif
     lineout[sizeof(lineout) - 1] = '\0';
     for (month = 0; month < 12; month += 3) {
 	center(full_month[month], WEEK_LEN, HEAD_SEP);


### PR DESCRIPTION
'cal' was trying to use the wrong memset() prototype, causing the the 3rd column of a yearly dump of months to disappear.