### PR TITLE
coco3: implement sd card.

### DIFF
--- a/Kernel/platform-coco3/Makefile
+++ b/Kernel/platform-coco3/Makefile
@@ -2,17 +2,18 @@
 CSRCS = ttydw.c mbr.c dwtime.c
 CSRCS += devices.c main.c libc.c devsdc.c devlpr.c
 
-CDSRCS = ../dev/devide_discard.c
+CDSRCS = ../dev/devide_discard.c ../dev/devsd_discard.c
 
-DSRCS = ../dev/devdw.c ../dev/blkdev.c ../dev/devide.c
+DSRCS = ../dev/devdw.c ../dev/blkdev.c ../dev/devide.c ../dev/devsd.c
+
 NSRCS = ../dev/net/net_native.c
 
-ASRCS = coco3.s crt0.s ide.s
+ASRCS = coco3.s crt0.s ide.s sd.s
 ASRCS += tricks.s commonmem.s usermem_gime.s drivewire.s sdc.s videoll.s
 
 COBJS = $(CSRCS:.c=$(BINEXT))
 AOBJS = $(ASRCS:.s=$(BINEXT))
-DOBJS = devdw.o blkdev.o devide.o
+DOBJS = devdw.o blkdev.o devide.o devsd.o
 NOBJS = net_native.o
 CDOBJS = $(CDSRCS:.c=$(BINEXT))
 OBJS  = $(COBJS) $(AOBJS) $(DOBJS) $(CDOBJS) $(NOBJS)
@@ -54,6 +55,11 @@ endif
 ifdef COCO_IDE
 DRIVERS += devide.o devide_discard.o ide.o
 CROSS_CC += -DCONFIG_COCOIDE
+endif
+
+ifdef COCO_SDFPGA
+DRIVERS += devsd.o devsd_discard.o sd.o
+CROSS_CC += -DCONFIG_COCOSDFPGA
 endif
 
 ifdef COCO_BECKER

--- a/Kernel/platform-coco3/config.h
+++ b/Kernel/platform-coco3/config.h
@@ -103,3 +103,8 @@ unsigned char getq( unsigned *ptr );
 typedef unsigned char *queueptr_t;
 #define GETQ(p) getq(p)
 #define PUTQ(p, v) putq((p), (v))
+
+
+/* define for SD */
+#define SD_DRIVE_COUNT 1
+#define CONFIG_SD

--- a/Kernel/platform-coco3/devices.c
+++ b/Kernel/platform-coco3/devices.c
@@ -46,6 +46,9 @@ bool validdev(uint16_t dev)
 }
 void device_init(void)
 {
+#ifdef CONFIG_COCOSDFPGA
+	devsd_init();
+#endif
 #ifdef CONFIG_COCOIDE
 	devide_init( );
 #endif

--- a/Kernel/platform-coco3/sd.s
+++ b/Kernel/platform-coco3/sd.s
@@ -1,0 +1,78 @@
+;;;
+;;;  A Gary Becker FPGA SD 
+;;;  implementation for Will's fuzix sd driver
+;;;  This is almost so trivial it's stupid.
+;;; 
+	
+	.globl _sd_spi_clock
+	.globl _sd_spi_raise_cs
+	.globl _sd_spi_lower_cs
+	.globl _sd_spi_transmit_byte
+	.globl _sd_spi_receive_byte
+	.globl _sd_spi_transmit_sector
+	.globl _sd_spi_receive_sector
+
+	.area	.text
+
+_sd_spi_clock
+	rts
+	
+_sd_spi_raise_cs
+	lda	#$80
+	sta	$ff64
+	rts
+	
+_sd_spi_lower_cs
+	lda	#$81
+	sta	$ff64
+	rts
+	
+_sd_spi_transmit_byte
+	stb	$ff65
+	rts
+	
+_sd_spi_receive_byte
+	ldb	$ff65
+	rts
+
+	.area	.common
+	
+_sd_spi_transmit_sector
+	lda	#0		; loop counter
+	ldx	_blk_op		; X = buffer address
+	jsr	blkdev_rawflg	; flip mmu mapping to whatever rawflag says
+a@	ldb	,x+
+	stb	$ff65
+	nop
+	ldb	,x+
+	stb	$ff65
+	nop
+	deca			; bump counter
+	bne	a@		; loop
+	jsr	blkdev_unrawflg	; revert mmu to normal
+	rts
+	
+_sd_spi_receive_sector
+	lda	#512/8
+	ldx	_blk_op
+	jsr	blkdev_rawflg
+a@	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	ldb	$ff65
+	stb	,x+
+	deca
+	bne	a@
+	jsr	blkdev_unrawflg
+	rts	


### PR DESCRIPTION
Implements the low level bits needed to use Kernel/dev/devsd on the CoCoFPGA's sd card.