### PR TITLE
curses: tailor tty VMIN to FUZIX

### DIFF
--- a/Library/libs/curses/setterm.c
+++ b/Library/libs/curses/setterm.c
@@ -6,14 +6,17 @@ static void ttysetflags(void)
   _tty.c_iflag |= ICRNL | IXON;
   _tty.c_oflag |= OPOST | ONLCR;
   _tty.c_lflag |= ECHO | ICANON | IEXTEN | ISIG;
+  _tty.c_cc[VEOF] = 4;
 
   if (_cursvar.rawmode) {
 	_tty.c_iflag &= ~(ICRNL | IXON);
 	_tty.c_oflag &= ~(OPOST);
 	_tty.c_lflag &= ~(ICANON | IEXTEN | ISIG);
+	_tty.c_cc[VMIN] = 1;
   }
   if (_cursvar.cbrkmode) {
 	_tty.c_lflag &= ~(ICANON);
+	_tty.c_cc[VMIN] = 1;
   }
   if (!_cursvar.echoit) {
 	_tty.c_lflag &= ~(ECHO | ECHONL);


### PR DESCRIPTION
VMIN and VEOF are unioned in FUZIX, so reset VMIN to 0 on raw(),
otherwise set it to EOF (4).  This makes raw() seem to behave better.