### PR TITLE
net_native: clear event upon unhooking.

### DIFF
--- a/Kernel/dev/net/net_native.c
+++ b/Kernel/dev/net/net_native.c
@@ -96,8 +96,10 @@ int netdev_write(uint8_t flags)
 		wakeup_all(s);
 		break;
 	case NE_UNHOOK:
-		if (s->s_state == SS_DEAD)
+		if (s->s_state == SS_DEAD){
+			sd->event = 0;
 			sock_closed(s);
+		}
 		else
 			kputs("bad unhook (in use)\n");
 		break;


### PR DESCRIPTION
this prevents netdev_findevent() from continually reporting on a
dead socket, thus preventing any other socket/event from being
reported to the network daemon.