### PR TITLE
lib: fix 6502 syscall generator

### DIFF
--- a/Library/tools/syscall_6502.c
+++ b/Library/tools/syscall_6502.c
@@ -55,7 +55,7 @@ static void write_makefile(void)
   fprintf(fp, "AS = ca65\n");
   fprintf(fp, "AR = ar65\n");
   fprintf(fp, "ASYS = syscall.s\n");
-  fprintf(fp, "ASRCS = syscall_%s.s\n", syscall_name[i]);
+  fprintf(fp, "ASRCS = syscall_%s.s\n", syscall_name[0]);
   for (i = 1; i < NR_SYSCALL; i++)
     fprintf(fp, "ASRCS += syscall_%s.s\n", syscall_name[i]);
   fprintf(fp, "\n\nASRCALL = $(ASRCS) $(ASYS)\n");


### PR DESCRIPTION
was trying to use an initialized index to array of syscall names. Caused a segfault on my machine.