### PR TITLE
Amstrad NC boot fixes, raw disk I/O fixes

### DIFF
--- a/Kernel/platform-amstradnc/devfd.c
+++ b/Kernel/platform-amstradnc/devfd.c
@@ -92,16 +92,19 @@ static int devfd_transfer(bool is_read, uint8_t is_raw)
 {
     int ct = 0;
     int tries;
-    int blocks = udata.u_nblock;
-    uint16_t lba = udata.u_block;
+    int blocks;
+    uint16_t lba;
+
+    /* This must happen first, as it updates the udata variables. */
+    if (is_raw && d_blkoff(BLKSHIFT))
+        return -1;
+    blocks = udata.u_nblock;
+    lba = udata.u_block;
 
     // kprintf("[%s %d @ %x : %d:%x]\n", is_read ? "read" : "write",
     //     blocks, lba, is_raw, udata.u_dptr);
     // if (!is_read)
     //     return blocks << BLKSHIFT;
-
-    if (is_raw && d_blkoff(BLKSHIFT))
-        return -1;
 
     fd_select(0);
     fd765_is_user = is_raw;

--- a/Kernel/platform-amstradnc/nc200/Makefile
+++ b/Kernel/platform-amstradnc/nc200/Makefile
@@ -60,7 +60,7 @@ floppyimage: cardimage floppyskeleton.img autoprg.bin $(ROOT_DIR)/fuzix.bin
 	dd if=$(ROOT_DIR)/fuzix.bin bs=16k skip=0 count=1 | mcopy -i $(ROOT_DIR)/fuzixfloppy.img - ::load4000.80
 	dd if=$(ROOT_DIR)/fuzix.bin bs=16k skip=1 count=1 | mcopy -i $(ROOT_DIR)/fuzixfloppy.img - ::load4000.81
 	dd if=$(ROOT_DIR)/fuzix.bin bs=16k skip=2 count=1 | mcopy -i $(ROOT_DIR)/fuzixfloppy.img - ::load4000.82
-	echo -n | mcopy -i $(ROOT_DIR)/fuzixfloppy.img - ::call4000.80
+	echo -n | mcopy -i $(ROOT_DIR)/fuzixfloppy.img - ::call4100.80
 
 floppyskeleton.img: floppyskeleton.s
 	sdasz80 -fflopzws floppyskeleton.rel floppyskeleton.s


### PR DESCRIPTION
Enabling raw disk I/O caused horrible crashes --- turned out I didn't realise that `d_blkoff()` modifies the udata variables. It works now, and is much, much faster.

I also found that the NC200 was suddenly failing to start 90% of the time, which eventually turned out to be because it was reading the resume vector from an umapped page and getting gibberish. I rewrote the bootblock code to be more consistent across both platforms. PCMCIA boot still doesn't work on the NC200, though.

Cowgol runs! About half way (taking approx. ten minutes) before hanging --- I think it's running out of memory.