### PR TITLE
coco3: fix lp driver to return no of bytes written, not just 0

### DIFF
--- a/Kernel/platform-coco3/devlpr.c
+++ b/Kernel/platform-coco3/devlpr.c
@@ -60,5 +60,5 @@ int lpr_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
 			dw_transaction(buf, 2, NULL, 0, 0);
 		}
 	} 
-	return pe - p;
+	return udata.u_count;
 }


### PR DESCRIPTION
to fix a bug reported by Mikey https://github.com/n6il.