### PR TITLE
Fix expr.y and find.y to work with regular yacc

### DIFF
--- a/Applications/MWC/cmd/expr.y
+++ b/Applications/MWC/cmd/expr.y
@@ -80,6 +80,8 @@ int	cbsiz = CODELEN;			/* Initial size of codebuf */
 
 #define YYSTYPE	char *
 
+char	**av;		/* Global version of argv[] in main() */
+int	avx;		/* Index into av[] */
 %}
 
 
@@ -153,9 +155,6 @@ expr:
 
 
 
-
-char	**av;		/* Global version of argv[] in main() */
-int	avx;		/* Index into av[] */
 
 int main(int argc, char *argv[])
 {

--- a/Applications/MWC/cmd/find.y
+++ b/Applications/MWC/cmd/find.y
@@ -29,6 +29,34 @@
 #define	snode(f,s)	lnode(FUN,f,0,s)
 
 #define YYSTYPE	NODE *
+
+NODE	*code;
+int	seflag;			/* Set if a side effect (print, exec) found */
+
+char	*next(void);
+NODE	*bnode(int, NODE *, NODE *);
+NODE	*enode(int type);
+NODE	*lnode(int op, int (*fn)(NODE *), int val, char *str);
+NODE	*nnode(int (*fun)(NODE *));
+NODE	*onode(int (*fun)(NODE *));
+NODE	*getuser(void);
+NODE	*getgroup(void);
+NODE	*getnewer(void);
+int	xname(NODE *np);
+int	xperm(NODE *np);
+int	xtype(NODE *np);
+int	xlinks(NODE *np);
+int	xuser(NODE *np);
+int	xgroup(NODE *np);
+int	xsize(NODE *np);
+int	xinum(NODE *np);
+int	xatime(NODE *np);
+int	xctime(NODE *np);
+int	xmtime(NODE *np);
+int	xnewer(NODE *np);
+int	xexec(NODE *np);
+int	xprint(NODE *np);
+int	xnop(NODE *np);
 %}
 %start	command
 
@@ -111,39 +139,12 @@ char	nospace[] = "out of memory";
 
 time_t	curtime;
 
-NODE	*code;
-int	seflag;			/* Set if a side effect (print, exec) found */
-
 char	*buildname(struct dirent *dp, char *ep);
 int	execute(NODE *np);
 void	find(char *dir);
 void	fentry(char *ep, struct stat *sbp);
 void	ffork(char *ep, struct stat *sbp);
 void	usage(void);
-char	*next(void);
-NODE	*bnode(int, NODE *, NODE *);
-NODE	*enode(int type);
-NODE	*lnode(int op, int (*fn)(NODE *), int val, char *str);
-NODE	*nnode(int (*fun)(NODE *));
-NODE	*onode(int (*fun)(NODE *));
-NODE	*getuser(void);
-NODE	*getgroup(void);
-NODE	*getnewer(void);
-int	xname(NODE *np);
-int	xperm(NODE *np);
-int	xtype(NODE *np);
-int	xlinks(NODE *np);
-int	xuser(NODE *np);
-int	xgroup(NODE *np);
-int	xsize(NODE *np);
-int	xinum(NODE *np);
-int	xatime(NODE *np);
-int	xctime(NODE *np);
-int	xmtime(NODE *np);
-int	xnewer(NODE *np);
-int	xexec(NODE *np);
-int	xprint(NODE *np);
-int	xnop(NODE *np);
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
The original versions of `expr.y` and `find.y` worked fine with `byacc` but not other versions of `bison/yacc`.  The issue is that _`byacc` emits code in a different order than other yaccs_ so it worked with byacc but not the others.  Fix is to move globals up to the "global declarations" section and now the output from various versions of bison/byacc/yacc all compile.

Reviewed by: @beretta42 (Brett Gordon)