### PR TITLE
6809: compile and add advsys interpreter to games package

### DIFF
--- a/Applications/games/Makefile.6809
+++ b/Applications/games/Makefile.6809
@@ -23,7 +23,7 @@ SRCS  = adv01.c adv02.c adv03.c adv04.c adv05.c adv06.c adv07.c \
         adv08.c adv09.c adv10.c adv11.c adv12.c adv13.c adv14a.c adv14b.c \
         myst01.c myst02.c myst03.c myst04.c myst05.c myst06.c myst07.c \
         myst08.c myst09.c myst10.c myst11.c fortune-gen.c startrek.c \
-	hamurabi.c
+	hamurabi.c advint.c
 
 SRCSFP =
 

--- a/Applications/games/fuzix-games.pkg
+++ b/Applications/games/fuzix-games.pkg
@@ -16,6 +16,7 @@ f 0755 /usr/bin/adv12         adv12
 f 0755 /usr/bin/adv13         adv13
 f 0755 /usr/bin/adv14a        adv14a
 f 0755 /usr/bin/adv14b        adv14b
+f 0755 /usr/bin/advint        advint
 f 0755 /usr/bin/fortune       fortune
 f 0755 /usr/bin/fortune-gen   fortune-gen
 f 0755 /usr/bin/myst01        myst01


### PR DESCRIPTION
This compiled for gcc6809 straight-away, and plays online dat files quite nicely