### PR TITLE
Fix vt color handling with multiple vts

### DIFF
--- a/Kernel/include/vt.h
+++ b/Kernel/include/vt.h
@@ -32,6 +32,8 @@ struct vt_switch {
   signed char cursory;
   signed char ncursory;
   uint8_t cursorhide;
+  uint8_t ink;
+  uint8_t paper;
 };
 
 struct vt_repeat {

--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -26,7 +26,7 @@ extern uint8_t hz;
 
 
 uint8_t vtattr_cap;
-
+uint8_t curattr;
 
 #define tbuf1 (uint8_t *)(0x2000+TTYSIZ*0)
 #define tbuf2 (uint8_t *)(0x2000+TTYSIZ*1)
@@ -476,7 +476,7 @@ void platform_interrupt(void)
 
 void vtattr_notify(void)
 {
-	curpty->attr = ((vtink&7)<<3) + (vtpaper&7);
+	curattr = ((vtink&7)<<3) + (vtpaper&7);
 }
 
 int gfx_ioctl(uint8_t minor, uarg_t arg, char *ptr)

--- a/Kernel/platform-coco3/devtty.h
+++ b/Kernel/platform-coco3/devtty.h
@@ -23,10 +23,10 @@ struct pty {
 	unsigned char right;    /* right most coord */
 	unsigned char bottom;   /* bottom most coord */
 	struct display *fdisp;  /* ptr to struct for ioctl */
-	uint8_t attr;           /* attribute byte to apply */
 };
 
 extern struct pty *curpty;
+extern uint8_t curattr;
 
 int my_tty_close( uint8_t minor ); /* wrapper call to close DW ports */
 int gfx_ioctl(uint8_t minor, uarg_t arg, char *ptr);

--- a/Kernel/platform-coco3/video.c
+++ b/Kernel/platform-coco3/video.c
@@ -1,4 +1,5 @@
 #include <kernel.h>
+#include <vt.h>
 #include <devtty.h>
 #include <video.h>
 
@@ -60,7 +61,7 @@ void plot_char(int8_t y, int8_t x, uint16_t c)
 	unsigned char *p=char_addr(y,x);
 	map_for_video();
 	*p++ = VT_MAP_CHAR(c);
-	*p = curpty->attr;
+	*p = curattr;
 	map_for_kernel();
 }
 
@@ -69,7 +70,7 @@ void clear_lines(int8_t y, int8_t ct)
 	uint16_t wc= ct * VT_WIDTH;
 	map_for_video();
 	uint16_t *s = (uint16_t *)char_addr(y, 0);
-	uint16_t w = ' ' * 0x100 + curpty->attr;
+	uint16_t w = ' ' * 0x100 + curattr;
 	while(  wc-- )
 		*s++=w;
 	map_for_kernel();
@@ -79,7 +80,7 @@ void clear_across(int8_t y, int8_t x, int16_t l)
 {
 	map_for_video();
 	uint16_t *s = (uint16_t *)char_addr(y, x);
-	uint16_t w=' ' * 0x100 + curpty->attr;
+	uint16_t w=' ' * 0x100 + curattr;
 	while( l-- )
 		*s++=w;
 	map_for_kernel();

--- a/Kernel/vt.c
+++ b/Kernel/vt.c
@@ -369,6 +369,8 @@ void vt_save(struct vt_switch *vt)
 	vt->cursory = cursory;
 	vt->ncursory = ncursory;
 	vt->cursorhide = cursorhide;
+	vt->ink = vtink;
+	vt->paper = vtpaper;
 }
 
 void vt_load(struct vt_switch *vt)
@@ -379,6 +381,8 @@ void vt_load(struct vt_switch *vt)
 	cursory = vt->cursory;
 	ncursory = vt->ncursory;
 	cursorhide = vt->cursorhide;
+	vtink = vt->ink;
+        vtpaper = vt->paper;
 	vtattr_notify();
 }
 #endif


### PR DESCRIPTION
This makes common vt code keep track of each vt's ink/paper.  Fixes bug where one terminal's escape codes changes colors on all others.