### PR TITLE
coco3: give all terminals some reasonable default ink/paper colors

### DIFF
--- a/Kernel/platform-coco3/devtty.c
+++ b/Kernel/platform-coco3/devtty.c
@@ -151,13 +151,13 @@ static struct mode_s mode[5] = {
 	{   0x80, 0x08, 40, 21, 39, 20, &(fmodes[4])  },
 };
 
-
+ 
 static struct pty ptytab[] VSECTD = {
 	{
-		(unsigned char *) 0x2000, 
-		NULL, 
-		0, 
-		{0, 0, 0, 0}, 
+		(unsigned char *) 0x2000,
+		NULL,
+		0,
+		{0, 0, 0, 0, 0, 0, 7, 0},
 		0x10000 / 8,
 		0x04,
 		0x74,              /* 80 column */
@@ -169,10 +169,10 @@ static struct pty ptytab[] VSECTD = {
 		050
 	},
 	{
-		(unsigned char *) 0x3000, 
-		NULL, 
-		0, 
-		{0, 0, 0, 0}, 
+		(unsigned char *) 0x3000,
+		NULL,
+		0,
+		{0, 0, 0, 0, 0, 0, 7, 0},
 		0x11000 / 8,
 		0x04,
 		0x6c,              /* 40 column */


### PR DESCRIPTION
The vt switcher structure has grown a few bytes recently, match up initial platform structures, give a reasonable color to the second vt. (kernel vt core sets first vt up for us) 