### PR TITLE
games: fix compilation

### DIFF
--- a/Applications/games/Makefile.z80
+++ b/Applications/games/Makefile.z80
@@ -2,7 +2,7 @@ FCC = ../../Library/tools/fcc -O2 -m$(USERCPU)
 
 .SUFFIXES: .c .rel
 
-SRCSNS = advint.c fortune.c qrun.cb #fweep.c
+SRCSNS = advint.c fortune.c qrun.c #fweep.c
 
 SRCS  = adv01.c adv02.c adv03.c adv04.c adv05.c adv06.c adv07.c \
         adv08.c adv09.c adv10.c adv11.c adv12.c adv13.c adv14a.c adv14b.c \


### PR DESCRIPTION
...
fortune: 2789 bytes from 256
ls -l adv01 adv02 adv03 adv04 adv05 adv06 adv07 adv08 adv09 adv10 adv11 adv12
adv13 adv14a adv14b myst01 myst02 myst03 myst04 myst05 myst06 myst07 myst0
8 myst09 myst10 myst11 fortune-gen startrek hamurabi cowsay advint fortune
qrun.cb >size.report
ls: cannot access 'qrun.cb': No such file or directory
Makefile.z80:37: recipe for target 'sizes' failed
make[2]: *** [sizes] Error 2
make[2]: Leaving directory '/home/flag/FUZIX/Applications/games'
Makefile:28: recipe for target 'games' failed
make[1]: *** [games] Error 2
make[1]: Leaving directory '/home/flag/FUZIX/Applications'
Makefile:61: recipe for target 'apps' failed
make: *** [apps] Error 2

Signed-off-by: Paolo Pisati <p.pisati@gmail.com>