### PR TITLE
Z80 fuzix ccopts

### DIFF
--- a/Applications/MWC/cmd/Makefile.z80
+++ b/Applications/MWC/cmd/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU) $(Z80_PLATFORM)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel .y
 

--- a/Applications/MWC/cmd/asz80/Makefile.z80
+++ b/Applications/MWC/cmd/asz80/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../../../Library/tools/fcc -m$(USERCPU) -O2 -DTARGET_Z80
+FCC = ../../../../Library/tools/fcc -m$(USERCPU) $(FUZIX_CCOPTS) -DTARGET_Z80
 
 .SUFFIXES: .c .rel
 

--- a/Applications/SmallC/Makefile.z80
+++ b/Applications/SmallC/Makefile.z80
@@ -2,7 +2,7 @@
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -DTINY
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS = initials.rel data.rel error.rel expr.rel function.rel gen.rel io.rel \
        lex.rel main.rel outstack.rel preproc.rel primary.rel stmt.rel \

--- a/Applications/V7/cmd/Makefile.z80
+++ b/Applications/V7/cmd/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/V7/cmd/sh/Makefile.z80
+++ b/Applications/V7/cmd/sh/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../../../Library/tools/fcc -m $(USERCPU) -O2 -fsigned-char
+FCC = ../../../../Library/tools/fcc -m $(USERCPU) $(FUZIX_CCOPTS) -fsigned-char
 
 .SUFFIXES: .c .rel
 

--- a/Applications/V7/games/Makefile.z80
+++ b/Applications/V7/games/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/as09/Makefile.z80
+++ b/Applications/as09/Makefile.z80
@@ -3,7 +3,7 @@
 PLATFORM = 6809
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -c
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS =	as.rel assemble.rel errors.rel express.rel \
 	genbin.rel genlist.rel genobj.rel gensym.rel \

--- a/Applications/cursesgames/Makefile.z80
+++ b/Applications/cursesgames/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../Library/tools/fcc -O2 -m$(USERCPU)
+FCC = ../../Library/tools/fcc $(FUZIX_CCOPTS) -m$(USERCPU)
 ASM_OPT = -l -o -s
 LINKER_OPT = -mz80 --nostdlib --no-std-crt0 --code-loc $(PROGLOAD) --data-loc  0
 BINMAN = ../../Library/tools/binman

--- a/Applications/flashrom/Makefile.z80
+++ b/Applications/flashrom/Makefile.z80
@@ -1,7 +1,7 @@
 .SUFFIXES: .c .rel
 
 FCC = ../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2 $(Z80_PLATFORM)
+FCCOPTS = $(FUZIX_CCOPTS) $(Z80_PLATFORM)
 SRCS  = flashrom.c
 OBJS = $(SRCS:.c=.rel)
 APPS = $(OBJS:.rel=)

--- a/Applications/games/Makefile.z80
+++ b/Applications/games/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../Library/tools/fcc -O2 -m$(USERCPU)
+FCC = ../../Library/tools/fcc $(FUZIX_CCOPTS) -m$(USERCPU)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/ld09/Makefile.z80
+++ b/Applications/ld09/Makefile.z80
@@ -1,7 +1,7 @@
 .SUFFIXES: .c .rel
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
-CFLAGS = -c -O2
+CFLAGS = -c $(FUZIX_CCOPTS)
 
 DEFS	=
 

--- a/Applications/ue/Makefile.z80
+++ b/Applications/ue/Makefile.z80
@@ -2,7 +2,7 @@
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -c
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS = ue.rel
 LIBS = term-ansi.c term-fuzix.c term.c

--- a/Applications/util/Makefile.z80
+++ b/Applications/util/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Library/libs/Makefile.z80
+++ b/Library/libs/Makefile.z80
@@ -6,7 +6,7 @@ LINKER = sdldz80
 #PLATFORM = -zx128
 PLATFORM =
 export PLATFORM
-CC_OPT = -O2 -c
+CC_OPT = $(FUZIX_CCOPTS) -c
 CC_NOOPT = -c
 ASM_OPT = -l -o -s
 LINKER_OPT = -m -i -o

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ PATH := /opt/fcc/bin:$(PATH)
 # (eg for 65c816 with 6502 user)
 export TARGET CPU USERCPU PATH
 
+# FUZIX_CCOPTS is the global CC optimization level
+ifeq ($(FUZIX_CCOPTS),)
+	FUZIX_CCOPTS = -O2
+endif
+export FUZIX_CCOPTS
+
 all: stand ltools libs apps kernel
 
 


### PR DESCRIPTION
One of the major slowdown in the z80 build is the O2 optimization level.

This pull request introduce a new global $FUZIX_CCOPTS variable that encapsulate the cc optimization level (and possibly other cc options), and is reused by all the z80 Makefiles down the road.
By default this pull request doesn't change the actual O2 level, but can that on the command line:

$ FUZIX_CCOPTS=-O0 make ...

On a sluggish Intel Atom c750 4 cores / 8 threads, make -j4 goes down from ~2hours to ~30 minutes.
On the Github / Google Cloud default instance for Travis CI (2 x 2.6Ghz Xeon with 7.5Gb of ram) i could rebuild the entire z80pack in less than 15 minutes, without any swap usage.

While not perfect (this pull only cover the z80 side of the build), it is mandatory for another feature that i would like to (re)enable: the Github / Travis continuos integration - that has a time limit of 50 minutes per job for the free instance, and without this hack we constantly blow that time limit.