### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,22 @@
+dist: trusty
+sudo: required
+
 matrix:
     include:
-        - env: PLATFORM=6502test
-        - env: PLATFORM=msp430fr5969
-        - env: PLATFORM=dragon-nx32
-        - env: PLATFORM=trs80
-before_install:
-    - sudo add-apt-repository ppa:david.given/ppa -y
-    - sudo add-apt-repository ppa:tormodvolden/m6809 -y
-    - sudo apt-get update -q
-    - sudo apt-get install libmpc2 libc6-i386 lib32stdc++6 lib32z1 libmpc2:i386
-    - export PATH=$PATH:/usr/local/bin:$HOME/msp430/bin
-    - |
-        if [ $PLATFORM = "6502test" ]; then
-            sudo apt-get install cc65
-        fi
-    - |
-        if [ $PLATFORM = "trs80" ]; then
-            sudo apt-get install sdcc
-        fi
-    - |
-        if [ $PLATFORM = "msp430fr5969" ]; then
-            wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-linux-installer-3.5.0.0.run -O /tmp/msp430.installer
-            chmod a+rx /tmp/msp430.installer
-            /tmp/msp430.installer --mode unattended --prefix $HOME/msp430
-            rm /tmp/msp430.installer
-        fi
-    - |
-        if [ $PLATFORM = "dragon-nx32" ]; then
-            sudo apt-get install lwtools gcc6809
-        fi
-language: c
-script:
-    - make PLATFORM=$PLATFORM -j4
+        - env: TARGET=rc2014
+        - env: TARGET=trs80
+        - env: TARGET=z80pack
+        - env: TARGET=dragon-nx32
 
+before_install:
+    - sudo add-apt-repository -y ppa:p-pisati/fuzix
+    - sudo apt-get update -q
+    - sudo apt-get install -y byacc automake			# FUZIX build deps
+    - sudo apt-get install -y sdcc						# z80pack build deps
+    - sudo apt-get install -y lwtools gcc6809			# dragon-nx32 build deps
+    - sudo update-alternatives --set yacc /usr/bin/byacc
+
+language: c
+
+script:
+    - FUZIX_CCOPTS=-O0 make TARGET=$TARGET -j2

--- a/Applications/MWC/cmd/Makefile.z80
+++ b/Applications/MWC/cmd/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU) $(Z80_PLATFORM)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel .y
 

--- a/Applications/MWC/cmd/asz80/Makefile.z80
+++ b/Applications/MWC/cmd/asz80/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../../../Library/tools/fcc -m$(USERCPU) -O2 -DTARGET_Z80
+FCC = ../../../../Library/tools/fcc -m$(USERCPU) $(FUZIX_CCOPTS) -DTARGET_Z80
 
 .SUFFIXES: .c .rel
 

--- a/Applications/SmallC/Makefile.z80
+++ b/Applications/SmallC/Makefile.z80
@@ -2,7 +2,7 @@
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -DTINY
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS = initials.rel data.rel error.rel expr.rel function.rel gen.rel io.rel \
        lex.rel main.rel outstack.rel preproc.rel primary.rel stmt.rel \

--- a/Applications/V7/cmd/Makefile.z80
+++ b/Applications/V7/cmd/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/V7/cmd/sh/Makefile.z80
+++ b/Applications/V7/cmd/sh/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../../../Library/tools/fcc -m $(USERCPU) -O2 -fsigned-char
+FCC = ../../../../Library/tools/fcc -m $(USERCPU) $(FUZIX_CCOPTS) -fsigned-char
 
 .SUFFIXES: .c .rel
 

--- a/Applications/V7/games/Makefile.z80
+++ b/Applications/V7/games/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/as09/Makefile.z80
+++ b/Applications/as09/Makefile.z80
@@ -3,7 +3,7 @@
 PLATFORM = 6809
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -c
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS =	as.rel assemble.rel errors.rel express.rel \
 	genbin.rel genlist.rel genobj.rel gensym.rel \

--- a/Applications/cursesgames/Makefile.z80
+++ b/Applications/cursesgames/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../Library/tools/fcc -O2 -m$(USERCPU)
+FCC = ../../Library/tools/fcc $(FUZIX_CCOPTS) -m$(USERCPU)
 ASM_OPT = -l -o -s
 LINKER_OPT = -mz80 --nostdlib --no-std-crt0 --code-loc $(PROGLOAD) --data-loc  0
 BINMAN = ../../Library/tools/binman

--- a/Applications/flashrom/Makefile.z80
+++ b/Applications/flashrom/Makefile.z80
@@ -1,7 +1,7 @@
 .SUFFIXES: .c .rel
 
 FCC = ../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2 $(Z80_PLATFORM)
+FCCOPTS = $(FUZIX_CCOPTS) $(Z80_PLATFORM)
 SRCS  = flashrom.c
 OBJS = $(SRCS:.c=.rel)
 APPS = $(OBJS:.rel=)

--- a/Applications/games/Makefile.z80
+++ b/Applications/games/Makefile.z80
@@ -1,4 +1,4 @@
-FCC = ../../Library/tools/fcc -O2 -m$(USERCPU)
+FCC = ../../Library/tools/fcc $(FUZIX_CCOPTS) -m$(USERCPU)
 
 .SUFFIXES: .c .rel
 

--- a/Applications/ld09/Makefile.z80
+++ b/Applications/ld09/Makefile.z80
@@ -1,7 +1,7 @@
 .SUFFIXES: .c .rel
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
-CFLAGS = -c -O2
+CFLAGS = -c $(FUZIX_CCOPTS)
 
 DEFS	=
 

--- a/Applications/ue/Makefile.z80
+++ b/Applications/ue/Makefile.z80
@@ -2,7 +2,7 @@
 
 CC = fcc -m$(USERCPU) $(Z80_PLATFORM)
 CFLAGS = -c
-COPT = -O2
+COPT = $(FUZIX_CCOPTS)
 
 OBJS = ue.rel
 LIBS = term-ansi.c term-fuzix.c term.c

--- a/Applications/util/Makefile.z80
+++ b/Applications/util/Makefile.z80
@@ -1,5 +1,5 @@
 FCC = ../../Library/tools/fcc -m$(USERCPU)
-FCCOPTS = -O2
+FCCOPTS = $(FUZIX_CCOPTS)
 
 .SUFFIXES: .c .rel
 

--- a/Library/include/getopt.h
+++ b/Library/include/getopt.h
@@ -7,6 +7,7 @@
 extern char *optarg;
 extern int opterr;
 extern int optind;
+extern int optopt;
 
 extern int getopt(int __argc, char *__argv[], char *__shortopts);
 

--- a/Library/include/stdlib.h
+++ b/Library/include/stdlib.h
@@ -89,10 +89,7 @@ extern void qsort(void *__base, size_t __num, size_t __size, cmp_func_t __cmp);
 
 #define mb_len(a,b)	strnlen(a,b)
 
-extern int opterr;
-extern int optind;
-extern char *optarg;
-extern int getopt(int __argc, char *__argv[], char *__optstring);
+#include <getopt.h>
 
 extern char *getpass(char *__prompt);
 

--- a/Library/libs/Makefile.z80
+++ b/Library/libs/Makefile.z80
@@ -6,7 +6,7 @@ LINKER = sdldz80
 #PLATFORM = -zx128
 PLATFORM =
 export PLATFORM
-CC_OPT = -O2 -c
+CC_OPT = $(FUZIX_CCOPTS) -c
 CC_NOOPT = -c
 ASM_OPT = -l -o -s
 LINKER_OPT = -m -i -o

--- a/Library/libs/getopt.c
+++ b/Library/libs/getopt.c
@@ -18,6 +18,7 @@
 
 int   opterr = 1;		/* error => print message */
 int   optind = 1;		/* next argv[] index */
+int   optopt;
 const char *optarg = NULL;	/* option parameter if any */
 
 static int Err(const char *name, const char *mess, int c)
@@ -30,6 +31,7 @@ static int Err(const char *name, const char *mess, int c)
 		     name, mess, c
 	  );
    }
+   optopt = c;
    return '?';			/* erroneous-option marker */
 }
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ PATH := /opt/fcc/bin:$(PATH)
 # (eg for 65c816 with 6502 user)
 export TARGET CPU USERCPU PATH
 
+# FUZIX_CCOPTS is the global CC optimization level
+ifeq ($(FUZIX_CCOPTS),)
+	FUZIX_CCOPTS = -O2
+endif
+export FUZIX_CCOPTS
+
 all: stand ltools libs apps kernel
 
 


### PR DESCRIPTION
This pull request re-enable the Travis CI and in particular:

1) move to use my own ppa[1] where i packaged a good sdcc snapshot (the revision that we discussed in this other bug[2]), the gcc6809 that was used historically and the latest cc65 release

2) at the moment i've enabled these builds:

z80: rc2014 trs80 and z80pack
mc6809: dragon-nx32

unfortunately i couldn't enable any 6502 based build since both the v65
and v65816 targets fail.

After pulling this, you should connect your Github account to Travis (https://travis-ci.org/), and in the Settings -> General section enable:

Build pushed branches
Build pushed pull requests
Auto cancel branch builds
Auto cancel pull requests build

and that's it - you can manually trigger a build at that point, or as soon as you push a new commit to your repo (or as soon as someone send you a pull request), travis will kick these four builds in parallel and report the result (the entire build process takes ~around 15mins).

1: https://launchpad.net/~p-pisati/+archive/ubuntu/fuzix
2: https://github.com/EtchedPixels/FUZIX/issues/616