### PR TITLE
68k: Makefile: add tools missing in pkgs, and fix filesystem creation

### DIFF
--- a/Applications/MWC/cmd/Makefile.68000
+++ b/Applications/MWC/cmd/Makefile.68000
@@ -14,7 +14,7 @@ CRT0NS = ../../../Library/libs/crt0nostdio_68000.o
 ELF2FUZIX = elf2flt
 .SUFFIXES: .c .o .y
 
-SRCS  = ac.c almanac.c at.c calendar.c col.c cron.c deroff.c ed.c expr.c find.c m4.c make.c moo.c pr.c tar.c test.c ttt.c units.c
+SRCS  = ac.c almanac.c at.c calendar.c col.c cron.c deroff.c du.c ed.c expr.c find.c m4.c make.c moo.c pr.c tar.c test.c ttt.c units.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/Applications/V7/cmd/Makefile.68000
+++ b/Applications/V7/cmd/Makefile.68000
@@ -16,9 +16,9 @@ ELF2FUZIX = elf2flt
 
 SRCS  = ac.c col.c dc.c diff.c makekey.c ptx.c sum.c wall.c
 SRCS += accton.c  comm.c   dd.c      diffh.c  mesg.c     rev.c    test.c
-SRCS += at.c      cron.c   deroff.c  join.c   newgrp.c   split.c  time.c
-SRCS += atrun.c   crypt.c  diff3.c   look.c   pr.c       su.c     tsort.c
-SRCS += pg.c
+SRCS += at.c      cron.c   deroff.c  ed.c     join.c     newgrp.c split.c
+SRCS += time.c    atrun.c  crypt.c   diff3.c  look.c     pr.c     su.c
+SRCS += tsort.c   pg.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/Applications/games/Makefile.68000
+++ b/Applications/games/Makefile.68000
@@ -20,8 +20,8 @@ SRCSNS =
 
 SRCS  = adv01.c adv02.c adv03.c adv04.c adv05.c adv06.c adv07.c \
         adv08.c adv09.c adv10.c adv11.c adv12.c adv13.c adv14a.c adv14b.c \
-        myst01.c myst02.c myst03.c myst04.c myst05.c myst06.c myst07.c \
-	myst08.c myst09.c myst10.c myst11.c fortune-gen.c qrun.c fortune.c \
+        advint.c myst01.c myst02.c myst03.c myst04.c myst05.c myst06.c \
+	myst07.c myst08.c myst09.c myst10.c myst11.c fortune-gen.c qrun.c fortune.c \
 	fweep.c startrek.c hamurabi.c cowsay.c
 
 SRCSFP = 

--- a/Applications/util/Makefile.68000
+++ b/Applications/util/Makefile.68000
@@ -25,6 +25,7 @@ SRCSNS = \
 	date.c \
 	dirname.c \
 	false.c \
+	gptparse.c \
 	groups.c \
 	head.c \
 	init.c \
@@ -43,6 +44,7 @@ SRCSNS = \
 	reboot.c \
 	rm.c \
 	rmdir.c \
+	seq.c \
 	substroot.c \
 	sum.c \
 	sync.c \


### PR DESCRIPTION
This patch fixes the build_filesystem script:

```
~/FUZIX/Standalone/filesystem-src$ ./build-filesystem test.img 256 65535
Found package mini
Found package basefs
Found package ccp
Found package BCPL
Found package adventure
Found package MWC-cmd
Found package ld09
Found package drivewire
Found package netd-base
Found package netd-lwwire
Found package netd-coconic
Found package dasm09
Found package games
Found package V7-cmd
Found package V7-cmd-man
Found package V7-sh
Found package V7-sh-man
Found package V7-games
Found package V7-games-man
Found package fview
Found package cursesgames
Found package as09
Found package SmallC
Found package TCL
Found package levee-vt52
Found package levee-ansi
Found package levee-termcap
Found package rpilot
Found package ue
Found package flashrom
Found package fforth
Found package util-mini
Found package util
Resolving package mini: enabled=0
Resolving package basefs: enabled=1
Resolving package ccp: enabled=0
Resolving package BCPL: enabled=0
Resolving package adventure: enabled=1
Resolving package MWC-cmd: enabled=1
Resolving package ld09: enabled=1
Resolving package drivewire: enabled=0
Resolving package netd-base: enabled=1
Resolving package netd-lwwire: enabled=0
Resolving package netd-coconic: enabled=0
Resolving package dasm09: enabled=0
Resolving package games: enabled=1
Resolving package V7-cmd: enabled=1
Resolving package V7-cmd-man: enabled=1
Resolving package V7-sh: enabled=1
Resolving package V7-sh-man: enabled=1
Resolving package V7-games: enabled=1
Resolving package V7-games-man: enabled=1
Resolving package fview: enabled=0
Resolving package cursesgames: enabled=1
Resolving package as09: enabled=1
Resolving package SmallC: enabled=1
Resolving package TCL: enabled=0
Resolving package levee-vt52: enabled=0
Resolving package levee-ansi: enabled=0
Resolving package levee-termcap: enabled=0
Resolving package rpilot: enabled=0
Resolving package ue: enabled=1
Resolving package flashrom: enabled=1
Resolving package fforth: enabled=1
Resolving package util-mini: enabled=1
Resolving package util: enabled=1
Processing package basefs
Processing package adventure
Processing package MWC-cmd
Processing package ld09
Processing package netd-base
Processing package games
Processing package V7-cmd
Processing package V7-cmd-man
Processing package V7-sh
Processing package V7-sh-man
Processing package V7-games
Processing package V7-games-man
Processing package cursesgames
Processing package as09
Processing package SmallC
Processing package ue
Processing package flashrom
Processing package fforth
Processing package util-mini
Processing package util
Making 512 byte/block filesystem with normal byte order on device test.img with fsize = 65535 and isize = 256.
Opening test.img (offset 0)
Opening test.img (offset 0)
Fuzix UCP version 1.3ac.
Opening test.img (offset 0)
Device 0 has fsize = 65535 and isize = 256. Continue? y
Memory pool 12288 bytes
Pass 1: Checking inodes...
Pass 2: Rebuilding free list...
Rebuild free list? y
Pass 3: Checking block allocation...
Pass 4: Checking directory entries...
Pass 5: Checking link counts...
Done.
```

Signed-off-by: Paolo Pisati <p.pisati@gmail.com>