### PR TITLE
coco3: fix link script typo

### DIFF
--- a/Applications/util/coco3.link
+++ b/Applications/util/coco3.link
@@ -4,6 +4,6 @@ section .header load 0x0100
 section .text
 section .text.startup
 section .text.hot
-section .test.unlikely
+section .text.unlikely
 section .data
 section .bss

--- a/Kernel/platform-coco3/fuzix.link
+++ b/Kernel/platform-coco3/fuzix.link
@@ -6,7 +6,7 @@ section .videodata
 section .text2
 section .text
 section .text.hot
-section .test.unlikely
+section .text.unlikely
 section .data
 section .buffers
 section .discard


### PR DESCRIPTION
I'll swear that I've fixed this problem before... guess not!