### PR TITLE
coco2cart: bug: sdc driver still not returning no of bytes read/writen

### DIFF
--- a/Kernel/platform-coco2cart/devsdc.c
+++ b/Kernel/platform-coco2cart/devsdc.c
@@ -58,7 +58,7 @@ typedef void (*sdc_transfer_function_t)( unsigned char *addr);
 
 
 /* blkdev method: transfer sectors */
-static uint8_t sdc_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
+static uint16_t sdc_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
 {
        	uint8_t nb = 0;
 	uint32_t lba;             /* holds 32 bit lsn */


### PR DESCRIPTION
With this fix it boots again on the CoCo2 w/ SDC.