### PR TITLE
rc2014: fixed missing functions when ppide enabled

### DIFF
--- a/Kernel/platform-rc2014/fuzix.lnk
+++ b/Kernel/platform-rc2014/fuzix.lnk
@@ -41,6 +41,7 @@ devsys.rel
 devinput.rel
 usermem.rel
 usermem_std-z80.rel
+platform-rc2014/ppide_rbc.rel
 platform-rc2014/discard.rel
 platform-rc2014/devtty.rel
 platform-rc2014/mbr.rel


### PR DESCRIPTION
ppide_rbc.c has #ifdef CONFIG_PPIDE so we don't add useless code if PPIDE isn't configured