### PR TITLE
Use byacc not yacc to generate /bin/find grammar

### DIFF
--- a/Applications/MWC/cmd/Makefile.z80
+++ b/Applications/MWC/cmd/Makefile.z80
@@ -36,6 +36,10 @@ expr.c: expr.y
 
 find.c: find.y
 
+# Nick
+.y.c:
+	byacc -o $@ $<
+
 .c.rel:
 	$(FCC) $(PLATFORM) $(FCCOPTS) -c $<
 


### PR DESCRIPTION
Bison output won't compile, at least on the Z80 port. Even if it worked, I think it is risky trying to use bison output in any kind of small context since it's pretty bloated.

I used byacc since it's readily available on a ubuntu system. Ideally we'd use something like V7 yacc, but this was just a quick solution to get going again for the time being.

This patch needs to be tested for correctness, I will get to it eventually but for the time being I just want to be able to complete the compilation process without errors.