### PR TITLE
coco3: make work with older RAM upgrades

### DIFF
--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -41,6 +41,7 @@
 	    .globl null_handler
 	    .globl video_init
 	    .globl _scanmem
+	    .globl copy_mmu
 
             include "kernel.def"
             include "../kernel09.def"
@@ -165,25 +166,18 @@ b@	sta	,x+
 	inca
 	decb
 	bne	b@
-	;; move mmu bank 0x6 to 0xB
-	lda	#$0b		; map mmu bank 0xB to cpu $0000
-	sta	$ffa8		;
-	ldx	#$0000		; dest
-	ldu	#$c000		; src
-c@	ldd	,u++		; copy 2 at a time
-	std	,x++		;
-	cmpx	#$2000		; are we done?
-	bne	c@		; loop if not done
-	clr	$ffa8		; reset cpu $0000
+	;; move mmu bank 0x6 to 0x0a
+	ldd	#$060a
+	jsr	copy_mmu
         ;; set temporary screen up
 	clr	$ff9c		; reset scroll register
-	ldb	#%01000100	; coco3 mode
+	ldb	#%01001100	; coco3 mode + fexx constant
 	stb	$ff90
 	;; detect PAL or NTSC ROM
 	ldb	#$3f		; put Super BASIC in mmu
 	stb	$ffae		;
 	lda	$c033		; get BASIC's "mirror" of Video Reg
-	ldb	#$0b		; put Fuzix Kernel back in mmu
+	ldb	#$0a		; put Fuzix Kernel back in mmu
 	stb	$ffae		;
 	anda	#$8		; mask off 50 hz bit
 	sta	_hz		; save for future use

--- a/Kernel/platform-coco3/coco3.s
+++ b/Kernel/platform-coco3/coco3.s
@@ -235,18 +235,15 @@ c@	ldd	,u++		; copy 2 at a time
 ;;;   takes: X = page table pointer
 ;;;   returns: nothing
 _program_vectors:
-	;; copy the common section into user-space
-	lda	0xffa8	     ; save mmu reg on stack
-	pshs	a,x,u
-
+	pshs	u
 	;; setup the null pointer / sentinal bytes in low process memory
-	lda	[1,s]	     ; get process's blk address for address 0
+	lda	,x	     ; get process's blk address for address 0
 	sta	0xffa8	     ; put in our mmu ( at address 0 )
 	lda	#0x7E
 	sta	0
-	puls	a,x,u	     ; restore mmu reg
-	sta	0xffa8	     ; 
-	rts		     ; return
+	clr	0xffa8	     ;
+	puls	u,pc
+
 
 ;;; This clear the interrupt source before calling the
 ;;; normal handler
@@ -399,8 +396,6 @@ a@	ldd	,x++
 blkdev_rawflg
 	pshs d,x     ; save regs
 	ldx #_blk_op ; X = blkdev operations
-        ldb 0xffa8   ; get mmu setting
-        stb ret+1    ; save in stash
         ldb 2,x      ; get raw mode
         decb         ; compare to 1
         bmi out@     ; less than or equal: 0, or 1 don't do map
@@ -417,7 +412,7 @@ out@	puls d,x,pc
 
 ;;; Helper for blkdev drivers to clean up memory after blkdev_rawflg
 blkdev_unrawflg
-ret     ldb #0
+        ldb #0
         stb 0xffa8
         incb
         stb 0xffa9

--- a/Kernel/platform-coco3/main.c
+++ b/Kernel/platform-coco3/main.c
@@ -76,10 +76,14 @@ void pagemap_init(void)
     int max = scanmem();
     
     /*  We have 64 8k pages for a CoCo3 so insert every other one
-     *  into the kernel allocator map.
+     *  into the kernel allocator map, skipping 3f. 3f holds our constant
+     *  page and tty buffers.  This code only works if page nos. are oddly
+     *  aligned after the kernel.
      */
-    for (i = 12; i < max ; i+=2)
+    for (i = 0xb; i < 0x3f; i+=2)
         pagemap_add(i);
+    for (i = 0x40; i < max; i+=2)
+	pagemap_add(i);
     /* add common page last so init gets it */
     pagemap_add(6);
     /* initialize swap pages */

--- a/Kernel/platform-coco3/tricks.s
+++ b/Kernel/platform-coco3/tricks.s
@@ -250,13 +250,8 @@ skip2@	incb
 ;;;   takes: B = dest bank, A = src bank
 copybank
 	pshs	d,x,u
-	;; save mmu state
-	ldd	0xffa8	
-	pshs	d
-	ldd	0xffaa
-	pshs	d
 	;; map in src and dest
-	ldd	4,s		; D = banks
+	ldd	,s		; D = banks
 	stb	0xffa8
 	incb
 	stb	0xffa9
@@ -286,9 +281,9 @@ a@	ldd	,u++
 	cmpx	#0x4000		; end of copy?
 	bne	a@		; no repeat
 	;; restore mmu
-	puls	d
-	std	0xffaa
-	puls	d
+	ldd	#0x0001
 	std	0xffa8
+	ldd	#0x0203
+	std	0xffaa
 	;; return
 	puls	d,x,u,pc		; return

--- a/Kernel/platform-coco3/usermem_gime.s
+++ b/Kernel/platform-coco3/usermem_gime.s
@@ -261,4 +261,4 @@ a@	lda	,u+		; get a byte
 	ldx 	#0		; return #0 - success
 	puls 	u,y,cc,pc	; return
 	;; kernel page mapping
-kmap	.db	0,1,2,3,4,5,0xb,7
+kmap	.db	0,1,2,3,4,5,0xa,7

--- a/Kernel/platform-coco3/videoll.s
+++ b/Kernel/platform-coco3/videoll.s
@@ -141,7 +141,7 @@ b@	ldb	,x+		; get a byte from src
 _putq
 	pshs	cc		; save interrupt state
 	orcc	#0x50		; stop interrupt till we restore map
-	lda	#10		; mmu page 10 for queue structs
+	lda	#0x3f		; mmu page 10 for queue structs
 	sta	0xffa9		;
 	stb	,x		; store the character
 	lda	#1		; restore kernel map
@@ -156,7 +156,7 @@ _putq
 _getq
 	pshs	cc		; save interrupt state
 	orcc	#0x50		; stop interrupt till we restore map
-	lda	#10		; mmu page 10 for queue structs
+	lda	#0x3f		; mmu page 10 for queue structs
 	sta	0xffa9		;
 	ldb	,x
 	lda	#1		; restore kernel map


### PR DESCRIPTION
This makes FUZIX work on CoCo3 with older DISTO style (non readable mmu) upgrades.