### PR TITLE
coco3: stack blast on mmu bank copies

### DIFF
--- a/Kernel/platform-coco3/tricks.s
+++ b/Kernel/platform-coco3/tricks.s
@@ -285,14 +285,20 @@ a@	leau	-14,u
 	leau	-14,u
 	pulu	dp,d,x,y
 	pshs	dp,d,x,y
-	cmpu	#0x2002+7	; end of copy?
+	cmpu	#0x2002+42+7	; end of copy? (leave space for interrupt)
 	bne	a@		; no repeat
-	ldd	0x2000
-	pshs	d
+	ldx	@temp		; put stack back
+	exg	x,s		; and data to ptr to x now
+	leau	-7,u
+b@	ldd	,--u		; move last 44 bytes with a normal stack
+	std	,--x		; 4 bytes per loop
+	ldd	,--u
+	std	,--x
+	cmpx	#0x4000
+	bne	b@
 	;; restore mmu
 	ldd	#0x0102
 	std	0xffa9
 	;; return
-	lds	@temp
 	puls	dp,d,x,y,u,pc		; return
 @temp	rmb	2

--- a/Kernel/platform-coco3/tricks.s
+++ b/Kernel/platform-coco3/tricks.s
@@ -260,33 +260,39 @@ copybank
 	puls	d,pc		; return
 
 ;;; copy data from one 8k bank to another
-;;;   todo: stack blast here for speed
 ;;;   takes: b = dest, a = src bank
 copy_mmu
-	pshs	d,x,u
+	pshs	dp,d,x,y,u
+	sts	@temp
 	std	0xffa9		; map in src,dest into mmu
-	ldx	#0x4000		; to and from ptrs
-	ldu	#0x2000
-a@	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	ldd	,u++
-	std	,x++
-	cmpx	#0x6000		; end of copy?
+	lds	#0x6000		; to and from ptrs
+	ldu	#0x4000+7
+a@	leau	-14,u
+	pulu	dp,d,x,y	; transfer 7 bytes at a time
+	pshs	dp,d,x,y	; 6 times.. 42 bytes per loop
+	leau	-14,u
+	pulu	dp,d,x,y
+	pshs	dp,d,x,y
+	leau	-14,u
+	pulu	dp,d,x,y
+	pshs	dp,d,x,y
+	leau	-14,u
+	pulu	dp,d,x,y
+	pshs	dp,d,x,y
+	leau	-14,u
+	pulu	dp,d,x,y
+	pshs	dp,d,x,y
+	leau	-14,u
+	pulu	dp,d,x,y
+	pshs	dp,d,x,y
+	cmpu	#0x2002+7	; end of copy?
 	bne	a@		; no repeat
+	ldd	0x2000
+	pshs	d
 	;; restore mmu
 	ldd	#0x0102
 	std	0xffa9
 	;; return
-	puls	d,x,u,pc		; return
+	lds	@temp
+	puls	dp,d,x,y,u,pc		; return
+@temp	rmb	2


### PR DESCRIPTION
This stack blasting copier is 3.8 cycles per byte copied. The old code was 7.3 cycles per byte. This method could also be helpful in the dragon-mooh port @tormodvolden.