### PR TITLE
Vile

### DIFF
--- a/Applications/levee/fuzix-levee.pkg
+++ b/Applications/levee/fuzix-levee.pkg
@@ -4,7 +4,6 @@ if-file  levee-vt52
 
 f 0755 /bin/levee-vt52       levee-vt52
 l      /bin/levee-vt52       /bin/levee
-l      /bin/levee            /bin/vi
 f 0644 /usr/man/man1/levee.1 levee.1
 l      /usr/man/man1/levee.1 /usr/man/man1/vi.1
 

--- a/Applications/util/Makefile.6809
+++ b/Applications/util/Makefile.6809
@@ -48,7 +48,6 @@ SRCSNS = \
 	touch.c \
 	tr.c \
 	true.c \
-	vile.c \
 	while1.c \
 	whoami.c \
 	yes.c
@@ -123,7 +122,9 @@ SRCS  = \
 
 SRCTC = tget.c \
         tchelp.c \
-	marksman.c
+	marksman.c \
+	vile.c \
+
 
 SKIPPED =
 

--- a/Applications/util/fuzix-util.pkg
+++ b/Applications/util/fuzix-util.pkg
@@ -112,7 +112,8 @@ f 0755 /bin/uniq        uniq
 f 0755 /bin/uptime      uptime
 f 0755 /bin/uud         uud
 f 0755 /bin/uue         uue
-f 0755 /bin/vile        vi
+f 0755 /bin/vile        vile
+l /bin/vile /bin/vi
 f 0755 /bin/wc          wc
 f 0755 /bin/which       which
 f 0755 /bin/who         who


### PR DESCRIPTION
Both 'vile' and 'levee' where trying to install as 'vi', crashing build. Conjigure both to link 'vi' to one of them instead.  default link is to 'vile'.