### PR TITLE
Update Travis environment and toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 
 matrix:

--- a/Library/libs/Makefile.6502
+++ b/Library/libs/Makefile.6502
@@ -31,8 +31,8 @@ OBJ_ASM = $(SRC_ASM:.s=.o)
 #	very tightly coded. We want to make use of them eventually
 #
 #
-SRC_C =  __argv.c abort.c aes256.c asctime.c assert.c atexit.c atoi.c
-SRC_C += bcmp.c bcopy.c bsearch.c bzero.c calloc.c cfree.c clock.c closedir.c
+SRC_C =  __argv.c abort.c aes256.c asctime.c assert.c atexit.c
+SRC_C += bcmp.c bcopy.c bsearch.c calloc.c cfree.c clock.c closedir.c
 SRC_C += closedir_r.c clock_gettime.c clock_getres.c clock_settime.c
 SRC_C += creat.c crypt.c ctermid.c ctime.c cuserid.c
 SRC_C += err.c errno.c error.c


### PR DESCRIPTION
Trusty is EOL upstream, move to Xenial and while here:

-update sdcc to 3.9.2-trunk-r11322 (latest upstream)
-update cc65 to 2.18 (latest upstream)
-update gcc6809 to 4.6.4

In particular, after updating cc65 to 2.18, a couple of 'Duplicate external identifier' error popped up:

    make[2]: Entering directory '/home/flag/fuzix_stuff/FUZIX/Applications/util'
    cl65 -o tar -L../../Library/libs -C ../../Library/libs/ld65-v65c816.cfg ../../Library/libs/crt0_6502.o tar.o c6502.lib -m tar.map
    ld65: Error: Duplicate external identifier: '_bzero'
    
    and
    
    make[2]: Entering directory '/home/flag/fuzix_stuff/FUZIX/Applications/MWC/cmd'
    cl65 -o m4 -L../../../Library/libs -C ../../../Library/libs/ld65-v65c816.cfg ../../../Library/libs/crt0_6502.o m4.o c6502.lib -m m4.map
    ld65: Error: Duplicate external identifier: '_atoi'

I fixed it by removing these functions from Fuzix libc for 6502: IOW, everyone building for 6502/65816 should move to cc65 2.18 after this patch is applied.