### PR TITLE
drivewire: fix up the 'dw' utility

### DIFF
--- a/Applications/dw/dw.c
+++ b/Applications/dw/dw.c
@@ -46,11 +46,11 @@ int main( int argc, char *argv[]){
 		tcgetattr( fddw, &new );
 		new.c_lflag &= ~ECHO;
 		new.c_cflag |= HUPCL;
+		new.c_iflag |= IGNCR;
 		tcsetattr( fddw, TCSANOW, &new );
 	
 		write( fddw, "dw ", 3);
 		write( fddw, ibuf, len );
-
 		while(1){
 			len=read( fddw, obuf, 128 );
 			if( len<=0 ){

--- a/Applications/dw/dw.c
+++ b/Applications/dw/dw.c
@@ -44,7 +44,8 @@ int main( int argc, char *argv[]){
 
 		tcgetattr( fddw, &prior );
 		tcgetattr( fddw, &new );
-		new.c_lflag = ~ECHO;
+		new.c_lflag &= ~ECHO;
+		new.c_cflag |= HUPCL;
 		tcsetattr( fddw, TCSANOW, &new );
 	
 		write( fddw, "dw ", 3);


### PR DESCRIPTION
* was double spacing
* was hanging as tty does not pay attention to drop of carrier unless told.
* bit flipping bug in setting ECHO.