### PR TITLE
6809: build 'clear', makefile up-to-date

### DIFF
--- a/Applications/V7/cmd/Makefile.6809
+++ b/Applications/V7/cmd/Makefile.6809
@@ -18,24 +18,40 @@ SRCS  = ac.c col.c dc.c diff.c makekey.c ptx.c sum.c wall.c
 SRCS += accton.c  comm.c   dd.c      diffh.c  mesg.c     rev.c    test.c
 SRCS += at.c      cron.c   deroff.c  join.c   newgrp.c   split.c  time.c
 SRCS += atrun.c   crypt.c  diff3.c   look.c   pr.c       su.c     tsort.c
-SRCS += pg.c ed.c sort.c tty.c
+SRCS += pg.c ed.c sort.c tty.c wall.c
+
+SRCSNS = ed.c
+
+SRCSTC = clear.c
 
 OBJS = $(SRCS:.c=.o)
+OBJSNS = $(SRCSNS:.c=.o)
+OBJSTC = $(SRCSTC:.c=.o)
 
+APPSTC = $(OBJSTC:.o=)
+APPSNS = $(OBJSNS:.o=)
 APPS = $(OBJS:.o=)
 
-all: $(APPS) size.report
+APPS_ALL = $(APPS) $(APPSNS) $(APPSTC)
+
+all: $(APPS_ALL) size.report
 
 $(APPS): $(CRT0)
 
 $(APPS): %: %.o
 	$(LINKER) -o $@ $(LINKER_OPT) $^
 
+$(APPSNS): %: %.o
+	$(LINKER) -o $@ $(LINKER_OPT) $(CRT0NS) $^
+
+$(APPSTC): %: %.o
+	$(LINKER) -o $@ $(LINKER_OPT) $(CRT0) -ltermcap6809 $^
+
 size.report: $(APPS)
 	ls -l $^ > $@
 
 clean:
-	rm -f $(OBJS) $(APPS) $(SRCS:.c=) core *~ *.asm *.lst *.sym *.map *.noi *.lk *.ihx *.tmp *.bin size.report
+	rm -f $(OBJS) $(APPS) $(APPSNS) $(APPSTC) $(SRCS:.c=) core *~ *.asm *.lst *.sym *.map *.noi *.lk *.ihx *.tmp *.bin size.report
 
 rmbak:
 	rm -f *~ core


### PR DESCRIPTION
Bring makefile fpr 6809 for V7/cmds up-to-date