### PR TITLE
Fix 6809 build

### DIFF
--- a/Applications/V7/cmd/sh/Makefile.6809
+++ b/Applications/V7/cmd/sh/Makefile.6809
@@ -37,10 +37,10 @@ $(FOBJS): fshbuild/%.o: %.c
 	$(CC) -c $(CFLAGS) $(COPT) -DBUILD_FSH $< -o $@
 
 sh: $(OBJS) $(CRT0)
-	$(LINKER) -o  $@ $(LINKER_OPT) $(CRT0) $^
+	$(LINKER) -o  $@ $(LINKER_OPT) $^
 
-fsh: $(FOBJS)
-	$(LINKER) -o $@ $(LINKER_OPT) $(CRT0) $^ -lreadline6809
+fsh: $(FOBJS) $(CRT0)
+	$(LINKER) -o $@ $(LINKER_OPT)  $^ -lreadline6809
 
 clean:
 	rm -f $(OBJS) $(FOBJS) fsh sh $(SRCS:.c=) core *~

--- a/Library/libs/crt0_6809.s
+++ b/Library/libs/crt0_6809.s
@@ -14,7 +14,7 @@ start:
 		.db 0x00			; 6309 not needed
 		.db __sectionbase_.header__/256	; page to load at
 		.db 0				; no hints
-		.dw __sectionlen_.text__+__sectionlen_.header__	; gives us code size info
+		.dw __sectionbase_.data__-__sectionbase_.header__ ; gives us header + all text segments
 		.dw __sectionlen_.data__	; gives us data size info
 		.dw __sectionlen_.bss__		; bss size info
 		.db 16				; entry relative to start


### PR DESCRIPTION
This commit fixes 6809 build, in issue #771 

gcc spits out some automagic text sections that weren't accounted for in the fuzix header for 6809.

cheers, brett