### PR TITLE
sc126: add new SPI defines for z80softspi

### DIFF
--- a/Kernel/platform-sc126/kernel.def
+++ b/Kernel/platform-sc126/kernel.def
@@ -19,3 +19,17 @@ PROGBASE		    .equ 0x0000
 PROGLOAD		    .equ 0x0100
 
 CONFIG_SWAP		    .equ 0
+
+
+;
+;      SPI uses the top bit
+;
+
+.macro ROTATE
+       rla
+.endm
+
+.macro LOADFIRST
+       in d,(c)
+       rlc d
+.endm


### PR DESCRIPTION
These were missing for sc126, copied from commit f7d0ed