### PR TITLE
Make LIBZ80 autodetection error check

### DIFF
--- a/Library/tools/libclean
+++ b/Library/tools/libclean
@@ -6,6 +6,11 @@
 #
 CPU=$1
 LIBZ80=$(../../Kernel/tools/findsdcc $CPU)
+if [ ! -d $LIBZ80 ]; then
+	THISSCRIPT=$(readlink -f "$0")
+	echo "ERROR: Autodetected \$LIBZ80 is not a directory. Please edit $THISSCRIPT and set LIBZ80 manually" >&2
+	exit 1
+fi
 
 cp $LIBZ80/$CPU.lib tmp.lib
 #


### PR DESCRIPTION
Helps bubble up one of the errors from #158 

I was experiencing the same problem (that the library was not being correctly detected) on Arch Linux because the actual binary is installed at `/sbin/sdcc` and `findsdcc` assumes that the libs can be found from a relative path.

Rather than trying to include packaging specific logic to `findsdcc`, I've added a simple check in `libclean` to hard fail if `LIBZ80` is not populated with a valid directory path and to instruct the user to manually set the variable to the correct path.

I've tested this code change by running `make` on my Arch install and having it fail, and then manually setting `LIBZ80` (before the check) and running again and it's now passing the check and continuing the build.