### PR TITLE
Atari ST vt boot fixes

### DIFF
--- a/Kernel/cpu-68000/rules.mk
+++ b/Kernel/cpu-68000/rules.mk
@@ -2,7 +2,7 @@ export CROSS_LD=m68k-uclinux-ld
 export CROSS_CC = m68k-uclinux-gcc
 # Do not use the Fedora gcc 5.3.1. It miscompiles stuff badly.
 export CROSS_CCOPTS=-c -Os -fno-strict-aliasing -fomit-frame-pointer -fno-stack-protector -fno-PIC -fno-builtin -Wall -m68000 -I$(ROOT_DIR)/cpu-68000 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include
-export CROSS_AS=$(CROSS_CC) $(CROSS_CCOPTS) -m68060 #-Wa,-M
+export CROSS_AS=$(CROSS_CC) $(CROSS_CCOPTS) #-Wa,-M
 export CROSS_CC_SEG1=
 export CROSS_CC_SEG2=
 export CROSS_CC_SEG3=

--- a/Kernel/cpu-68000/rules.mk
+++ b/Kernel/cpu-68000/rules.mk
@@ -1,7 +1,7 @@
 export CROSS_LD=m68k-uclinux-ld
 export CROSS_CC = m68k-uclinux-gcc
 # Do not use the Fedora gcc 5.3.1. It miscompiles stuff badly.
-export CROSS_CCOPTS=-c -Os -fno-strict-aliasing -fomit-frame-pointer -fno-builtin -Wall -m68000 -I$(ROOT_DIR)/cpu-68000 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include
+export CROSS_CCOPTS=-c -Os -fno-strict-aliasing -fomit-frame-pointer -fno-stack-protector -fno-builtin -Wall -m68000 -I$(ROOT_DIR)/cpu-68000 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include
 export CROSS_AS=$(CROSS_CC) $(CROSS_CCOPTS) -m68060 #-Wa,-M
 export CROSS_CC_SEG1=
 export CROSS_CC_SEG2=

--- a/Kernel/cpu-68000/rules.mk
+++ b/Kernel/cpu-68000/rules.mk
@@ -1,7 +1,7 @@
 export CROSS_LD=m68k-uclinux-ld
 export CROSS_CC = m68k-uclinux-gcc
 # Do not use the Fedora gcc 5.3.1. It miscompiles stuff badly.
-export CROSS_CCOPTS=-c -Os -fno-strict-aliasing -fomit-frame-pointer -fno-stack-protector -fno-builtin -Wall -m68000 -I$(ROOT_DIR)/cpu-68000 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include
+export CROSS_CCOPTS=-c -Os -fno-strict-aliasing -fomit-frame-pointer -fno-stack-protector -fno-PIC -fno-builtin -Wall -m68000 -I$(ROOT_DIR)/cpu-68000 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include
 export CROSS_AS=$(CROSS_CC) $(CROSS_CCOPTS) -m68060 #-Wa,-M
 export CROSS_CC_SEG1=
 export CROSS_CC_SEG2=

--- a/Kernel/devio.c
+++ b/Kernel/devio.c
@@ -714,6 +714,8 @@ void kprintf(const char *fmt, ...)
 		kputchar(*fmt);
 		fmt++;
 	}
+
+	va_end(ap);
 }
 
 #ifdef CONFIG_IDUMP

--- a/Kernel/lowlevel-68000.S
+++ b/Kernel/lowlevel-68000.S
@@ -460,7 +460,10 @@ flush_icache:
 		beq noflush
 		; Flush the icache
 		move.w #$9,d0
+		save
+		chip 68020
 		movec d0,cacr
+		restore
 noflush:
 		rts
 
@@ -596,6 +599,8 @@ cpu_type:
 		move.l #cpu_ill_error,16
 		move.l a7,a1
 		moveq #0,d0
+		save
+		chip 68060
 		movec vbr,d1		; faults on a 68000
 		moveq #10,d0
 		movec cacr,d1		; faults on a 68000 and 010
@@ -605,6 +610,7 @@ cpu_type:
 		moveq #40,d0
 		movec pcr,d1		; faults on all but 68060
 		moveq #60,d0
+		restore
 cpu_type_exit:
 		move.l #illegal,16
 		move.b d0,cpu_has_trapvec

--- a/Kernel/lowlevel-68000.S
+++ b/Kernel/lowlevel-68000.S
@@ -596,6 +596,8 @@ probe_error:
 ;	bigger than a 68010 !
 ;
 cpu_type:
+		move.w sr,-(sp)
+		move #$2700,sr		; disable interrupts
 		move.l #cpu_ill_error,16
 		move.l a7,a1
 		moveq #0,d0
@@ -614,7 +616,7 @@ cpu_type:
 cpu_type_exit:
 		move.l #illegal,16
 		move.b d0,cpu_has_trapvec
-		rts
+		rte
 ;
 ;	We found the faulting instruction for this CPU type so bail
 ;

--- a/Kernel/platform-atarist/Makefile
+++ b/Kernel/platform-atarist/Makefile
@@ -4,6 +4,7 @@ CSRCS += devices.c main.c libc.c
 
 ASRCS = p68000.S crt0.S
 ASRCS += tricks.S
+ASRCS += cartridge.S
 
 LSRCS = ../lib/68000exception.c
 LOBJS = $(patsubst ../lib/%.c,%.o, $(LSRCS))
@@ -61,3 +62,6 @@ loader:	loader.S loader.ld
 	$(CROSS_LD) -M -o loader.elf -T loader.ld loader.o >loader.map
 	m68k-uclinux-objcopy loader.elf -O binary loader.bin
 	../tools/atariboot loader.bin
+
+../fuzix.bin: image
+cartridge.S: ../fuzix.bin

--- a/Kernel/platform-atarist/cartridge.S
+++ b/Kernel/platform-atarist/cartridge.S
@@ -1,0 +1,20 @@
+	.mri	1
+
+start:	move	#$2700,sr	; Disable interrupts
+
+	move.w	#$600,a0
+	move.l	#kernel_begin,a1
+	move.w	#(kernel_end-kernel_begin+3)/4,d0
+install:
+	move.l	(a1)+,(a0)+
+	dbra	d0,install
+
+	jmp	$600
+
+	even
+kernel_begin:
+	incbin	"../fuzix.bin"
+kernel_end:
+
+	section .filename
+	asciz	"FUZIX.TOS"

--- a/Kernel/platform-atarist/cartridge.ld
+++ b/Kernel/platform-atarist/cartridge.ld
@@ -1,0 +1,51 @@
+OUTPUT_FORMAT("binary")
+
+MEMORY
+{
+	cartridge(rx) : ORIGIN = 0xfa0000 - 4, LENGTH = 128K + 4
+}
+
+SECTIONS
+{
+	.cartridge : ALIGN(4) {
+		LONG(0)				/* For the Hatari emulator */
+		LONG(0xabcdef42)		/* CA_MAGIC */
+		LONG(0)				/* CA_NEXT or NULL */
+		LONG(_ca_run | 0x01000000) 	/* CA_INIT */
+		LONG(_ca_run)			/* CA_RUN */
+		SHORT(0)			/* CA_TIME */
+		SHORT(0)			/* CA_DATE */
+		LONG(_ca_end - _ca_run)		/* CA_SIZE */
+		KEEP(*(.filename))		/* CA_NAME */
+	} >cartridge
+
+	_ca_run = ALIGN(4) ;
+
+	.text : {
+		*(.text)
+		*(.text.*)
+	} >cartridge = 0
+
+	.rodata : ALIGN(4) {
+		*(.rodata)
+		*(.rodata.*)
+	} >cartridge = 0
+
+	.data : ALIGN(4) {
+		*(.data)
+		*(.data.*)
+	} >cartridge = 0
+
+	_ca_end = . ;
+
+	.zero : {
+		BYTE(0)
+		. = 0xfc0000 - _ca_end ;
+	} >cartridge = 0
+
+	/DISCARD/ : {
+		*(.comment)
+		*(.debug)
+		*(.bss)
+	}
+}

--- a/Kernel/platform-atarist/libc.c
+++ b/Kernel/platform-atarist/libc.c
@@ -1,4 +1,4 @@
-#include "cpu.h"
+#include <kernel.h>
 
 void *memcpy(void *d, const void *s, size_t sz)
 {

--- a/Kernel/platform-atarist/loader.S
+++ b/Kernel/platform-atarist/loader.S
@@ -62,7 +62,7 @@ run:
 load:
 	clr.w	-(sp)		; Drive A: (FIXME - should work off boot)
 	move.w #1,-(sp)		; From sector 1
-	move.w #$256,-(sp)	; 256 sectors
+	move.w #256,-(sp)	; 256 sectors
 	move.l #$40000,-(sp)	; read address
 	move.w #2,-(sp)		; read, ignore media change
 	move.w #4,-(sp)		; rwabs

--- a/Kernel/platform-atarist/p68000.S
+++ b/Kernel/platform-atarist/p68000.S
@@ -60,7 +60,7 @@ set_palette:
 
 mode_ok:
 	move.l $42E,d0		; Top of RAM
-	sub.l #32000,d0		; Frame buffer space
+	sub.l #64000,d0		; Frame buffer space FIXME: Ought to be 32000
 	move.l d0,screenbase	; Save our video base
 
 	; $FF820D on the STe will be zero already
@@ -75,7 +75,7 @@ mode_ok:
 	lsr.l #2,d0
 	move.w d0,ramsize
 	sub.w  #64,d0		; Guess for kernel
-	sub.w  #32,d0		; Video memory
+	sub.w  #64,d0		; Video memory FIXME: Ought to be 32
 	move.w d0,procmem		; guesses for now
 
 	bsr install_vectors

--- a/Kernel/platform-atarist/p68000.S
+++ b/Kernel/platform-atarist/p68000.S
@@ -32,16 +32,16 @@ init_hardware:
 	;	Check for high reslution mode
 	;
 
-	move.b $FFFA03,d0
-	btst #7,d0
-	bne normal_monitor
+	cmp.b #2,$FFFF8260.w
+	bne.s colour_monitor
+monochrome_monitor:
 	move.w #0,videomode
 	move.b #50,videorows	; 640x400 is special
 	move.b #49,videobot
 	move.b #2,$FF8260
 	bra set_palette
 
-normal_monitor:
+colour_monitor:
 	move.w #1,videomode
 	move.b #25,videorows	; 640x200 mode
 	move.b #24,videobot

--- a/Kernel/platform-atarist/p68000.S
+++ b/Kernel/platform-atarist/p68000.S
@@ -36,6 +36,8 @@ init_hardware:
 	bne.s colour_monitor
 monochrome_monitor:
 	move.w #0,videomode
+	move.w #0,vshift
+	move.w #78,vlen
 	move.b #50,videorows	; 640x400 is special
 	move.b #49,videobot
 	move.b #2,$FF8260
@@ -43,6 +45,8 @@ monochrome_monitor:
 
 colour_monitor:
 	move.w #1,videomode
+	move.w #1,vshift
+	move.w #156,vlen
 	move.b #25,videorows	; 640x200 mode
 	move.b #24,videobot
 	move.b #1,$FF8260
@@ -228,6 +232,7 @@ vaddr:
 	    move.b d1,d3		; save X
 	    and.w #1,d3			; low bit of X (it's all in words)
 	    and.w #$fffe,d1		; rest of X
+	    lsl.w d2,d0			; adjust for words/char
 	    lsl.w d2,d1			; adjust for words/char
 	    add.w d1,d0			; total offset
 	    add.w d3,d0			; low bit


### PR DESCRIPTION
A few minor updates were needed to start on the Atari ST using GCC 10.2.