### PR TITLE
atarist: Add cartridge target for easy emulation

### DIFF
--- a/Kernel/platform-atarist/Makefile
+++ b/Kernel/platform-atarist/Makefile
@@ -4,6 +4,7 @@ CSRCS += devices.c main.c libc.c
 
 ASRCS = p68000.S crt0.S
 ASRCS += tricks.S
+ASRCS += cartridge.S
 
 LSRCS = ../lib/68000exception.c
 LOBJS = $(patsubst ../lib/%.c,%.o, $(LSRCS))
@@ -61,3 +62,6 @@ loader:	loader.S loader.ld
 	$(CROSS_LD) -M -o loader.elf -T loader.ld loader.o >loader.map
 	m68k-uclinux-objcopy loader.elf -O binary loader.bin
 	../tools/atariboot loader.bin
+
+../fuzix.bin: image
+cartridge.S: ../fuzix.bin

--- a/Kernel/platform-atarist/cartridge.S
+++ b/Kernel/platform-atarist/cartridge.S
@@ -1,0 +1,20 @@
+	.mri	1
+
+start:	move	#$2700,sr	; Disable interrupts
+
+	move.w	#$600,a0
+	move.l	#kernel_begin,a1
+	move.w	#(kernel_end-kernel_begin+3)/4,d0
+install:
+	move.l	(a1)+,(a0)+
+	dbra	d0,install
+
+	jmp	$600
+
+	even
+kernel_begin:
+	incbin	"../fuzix.bin"
+kernel_end:
+
+	section .filename
+	asciz	"FUZIX.TOS"

--- a/Kernel/platform-atarist/cartridge.ld
+++ b/Kernel/platform-atarist/cartridge.ld
@@ -1,0 +1,51 @@
+OUTPUT_FORMAT("binary")
+
+MEMORY
+{
+	cartridge(rx) : ORIGIN = 0xfa0000 - 4, LENGTH = 128K + 4
+}
+
+SECTIONS
+{
+	.cartridge : ALIGN(4) {
+		LONG(0)				/* For the Hatari emulator */
+		LONG(0xabcdef42)		/* CA_MAGIC */
+		LONG(0)				/* CA_NEXT or NULL */
+		LONG(_ca_run | 0x01000000) 	/* CA_INIT */
+		LONG(_ca_run)			/* CA_RUN */
+		SHORT(0)			/* CA_TIME */
+		SHORT(0)			/* CA_DATE */
+		LONG(_ca_end - _ca_run)		/* CA_SIZE */
+		KEEP(*(.filename))		/* CA_NAME */
+	} >cartridge
+
+	_ca_run = ALIGN(4) ;
+
+	.text : {
+		*(.text)
+		*(.text.*)
+	} >cartridge = 0
+
+	.rodata : ALIGN(4) {
+		*(.rodata)
+		*(.rodata.*)
+	} >cartridge = 0
+
+	.data : ALIGN(4) {
+		*(.data)
+		*(.data.*)
+	} >cartridge = 0
+
+	_ca_end = . ;
+
+	.zero : {
+		BYTE(0)
+		. = 0xfc0000 - _ca_end ;
+	} >cartridge = 0
+
+	/DISCARD/ : {
+		*(.comment)
+		*(.debug)
+		*(.bss)
+	}
+}


### PR DESCRIPTION
A cartridge image can be built with

```
$(CROSS_LD) --orphan-handling=error --discard-all		\
	-nostdlib --no-relax --script=cartridge.ld		\
	-o ../cartridge cartridge.o
```

and then started using the `--cartridge Kernel/cartridge` option to the Hatari emulator, which will boot it very quickly.