### PR TITLE
Add HDIO_TRIM for use with flash devices.

### DIFF
--- a/Kernel/dev/blkdev.h
+++ b/Kernel/dev/blkdev.h
@@ -5,6 +5,7 @@
    and implement a sector transfer function matching the following prototype. */
 typedef uint_fast8_t (*transfer_function_t)(void);
 typedef int (*flush_function_t)(void);
+typedef int (*trim_function_t)(void);
 
 /* the following details should be required only by partition parsing code */
 #define MAX_PARTITIONS 15                   /* must be at least 4, at most 15 */
@@ -12,6 +13,9 @@ typedef struct {
     uint8_t driver_data;                    /* opaque parameter used by underlying driver (should be first) */
     transfer_function_t transfer;           /* function to read and write sectors */
     flush_function_t flush;                 /* flush device cache */
+#if defined CONFIG_TRIM
+	trim_function_t trim;					/* trim a sector */
+#endif
     uint32_t drive_lba_count;               /* count of sectors on raw disk device */
     uint32_t lba_first[MAX_PARTITIONS];     /* LBA of first sector of each partition; 0 if partition absent */
     uint32_t lba_count[MAX_PARTITIONS];     /* count of sectors in each partition; 0 if partition absent */

--- a/Kernel/filesys.c
+++ b/Kernel/filesys.c
@@ -1012,6 +1012,9 @@ void freeblk(uint16_t dev, blkno_t blk, uint_fast8_t level)
             freeblk(dev, bn[j], level-1);
         brelse(buf);
     }
+#ifdef CONFIG_TRIM
+	(void) d_ioctl(dev, HDIO_TRIM, &blk);
+#endif
     blk_free(dev, blk);
 }
 #endif

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -746,6 +746,7 @@ struct s_argblk {
 #define HDIO_RAWCMD		0x4104	/* Issue a raw command, ioctl data
                                            is device dependent */
 #define HDIO_EJECT		0x0105	/* Request a media eject */
+#define HDIO_TRIM       0x0106  /* Issue a TRIM request */
 
 /*
  *	Floppy disk ioctl s0x01Fx (see fdc.h)

--- a/Kernel/swap.c
+++ b/Kernel/swap.c
@@ -57,6 +57,8 @@ void swapmap_init(uint_fast8_t swap)
 int swapread(uint16_t dev, blkno_t blkno, usize_t nbytes,
                     uaddr_t buf, uint16_t page)
 {
+	int res;
+
 	udata.u_dptr = swap_map(buf);
 	udata.u_block = blkno;
 	if (nbytes & BLKMASK)
@@ -67,7 +69,18 @@ int swapread(uint16_t dev, blkno_t blkno, usize_t nbytes,
 	kprintf("SR | L %p M %p Bytes %d Page %d Block %d\n",
 		buf, udata.u_dptr, nbytes, page, udata.u_block);
 #endif
-	return ((*dev_tab[major(dev)].dev_read) (minor(dev), 2, 0));
+	res = ((*dev_tab[major(dev)].dev_read) (minor(dev), 2, 0));
+
+#ifdef CONFIG_TRIM
+	while (nbytes != 0)
+	{
+		d_ioctl(dev, HDIO_TRIM, (void*)&blkno);
+		blkno++;
+		nbytes -= 1<<BLKSHIFT;
+	}
+#endif
+
+	return res;
 }
 
 


### PR DESCRIPTION
This adds an HDIO_TRIM ioctl to block devices which can be used to pass information about unused blocks to a flash driver. This is needed to make slow flash like the ESP8266's work (via an FTL). Blocks are trimmed by the filesystem when freed, and by the swapper when swapping in a process, as processes are only ever swapped in once and this ought to speed up swapping out.

It'd be possible to add support to devsd for this, issuing CMD38 commands to the card, but erasing's a bit more complex on SD cards and usually not necessary, so I haven't looked into doing that yet.