### PR TITLE
Fill unused sector records with 0xff

### DIFF
--- a/Kernel/tools/makejv3.c
+++ b/Kernel/tools/makejv3.c
@@ -57,8 +57,6 @@ static void jvc_writeheaders(uint8_t * ptr)
 			}
 		}
 	}
-	/* Writeable */
-	*ptr = 1;
 }
 
 
@@ -77,8 +75,6 @@ static void jvc_pc_writeheaders(uint8_t * ptr)
 			}
 		}
 	}
-	/* Writeable */
-	*ptr = 1;
 }
 
 static char buf[512];
@@ -198,6 +194,7 @@ void main(int argc, char *argv[])
 		perror(argv[3]);
 		exit(1);
 	}
+	memset(hdrbuf, 0xff, sizeof(hdrbuf));
 	if (pc) {
 		if (!ddens)
 			usage();
@@ -219,3 +216,4 @@ void main(int argc, char *argv[])
 	close(outfd);
 	exit(0);
 }
+


### PR DESCRIPTION
JV3 unused sector records should be filled with 0xff.
This also fills in the last non-record byte to 0xff making the JV3 image writeable.

This is (somewhat) documented in: https://www.tim-mann.org/trs80/dskspec.html#:~:text=directory%20track%20instead.-,The%20JV3%20Format,headers%20and%20data%20can%20follow.

"If a sector header is not in use (free), its track and sector fields must contain 0xFF"