### PR TITLE
Simplify the ELF loader by quite a lot

### DIFF
--- a/Applications/rules.armm0
+++ b/Applications/rules.armm0
@@ -7,8 +7,8 @@ LINKER = arm-none-eabi-ld
 CFLAGS = -mcpu=Cortex-M0plus -ffunction-sections -fdata-sections -fno-strict-aliasing -fomit-frame-pointer -fno-builtin -Wall -g -Os -isystem $(ROOT)/Library/include
 LINKER_OPT = -L$(ROOT)/Library/libs -lc$(PLATFORM) -pie -static -no-dynamic-linker -z max-page-size=4
 LIBGCCDIR = $(dir $(shell $(CC) $(CFLAGS) -print-libgcc-file-name))
-LINKER_OPT += -L$(LIBGCCDIR) -lgcc -T $(ROOT)/Library/elfexe32.ld
-STRIP_OPT = -R .dynamic -R .dynsym -R .dynstr -R .shstrtab -R .hash -R .ARM.exidx -R .ARM.attributes
+LINKER_OPT += -L$(LIBGCCDIR) -lgcc -T $(ROOT)/Library/elfexe32.ld --no-export-dynamic -Bstatic -no-dynamic-linker
+STRIP_OPT =
 CRT0 = $(ROOT)/Library/libs/crt0_$(PLATFORM).o
 CRT0NS = $(ROOT)/Library/libs/crt0nostdio_$(PLATFORM).o
 ELF2FUZIX = $(ROOT)/Library/tools/elf2bin -p arm-none-eabi

--- a/Kernel/include/elf.h
+++ b/Kernel/include/elf.h
@@ -359,6 +359,7 @@ typedef struct {
 #define DT_JMPREL	23		/* add. of PLT's relocation entries */
 #define DT_BIND_NOW	24		/* Bind now regardless of env setting */
 #define DT_NUM		25		/* Number used. */
+#define DT_RELCOUNT 0x6ffffffa  /* GNU extension: number of relocations */
 #define DT_LOPROC	0x70000000	/* reserved range for processor */
 #define DT_HIPROC	0x7fffffff	/*  specific dynamic array tags */
 
@@ -453,11 +454,6 @@ struct elf_args {
 #define AuxInfo		Aux32Info
 
 #define ELF_TARG_VER	1	/* The ver for which this code is intended */
-
-/* Private Fuzix program header types */
-
-#define PT_FUZIX_BSS    (PT_LOOS+0)
-#define PT_FUZIX_REL    (PT_LOOS+1)
 
 /* ARM relocations */
 

--- a/Kernel/include/elf.h
+++ b/Kernel/include/elf.h
@@ -310,6 +310,8 @@ typedef struct {
 #define PT_SHLIB	5		/* reserved - purpose undefined */
 #define PT_PHDR		6		/* program header */
 #define PT_NUM		7		/* Number of segment types */
+#define PT_LOOS     0x60000000  /* reserved range for operating system */
+#define PT_HIOS     0x6fffffff  /*  specific segment types */
 #define PT_LOPROC	0x70000000	/* reserved range for processor */
 #define PT_HIPROC	0x7fffffff	/*  specific segment types */
 
@@ -451,6 +453,11 @@ struct elf_args {
 #define AuxInfo		Aux32Info
 
 #define ELF_TARG_VER	1	/* The ver for which this code is intended */
+
+/* Private Fuzix program header types */
+
+#define PT_FUZIX_BSS    (PT_LOOS+0)
+#define PT_FUZIX_REL    (PT_LOOS+1)
 
 /* ARM relocations */
 

--- a/Library/elfexe32.ld
+++ b/Library/elfexe32.ld
@@ -3,6 +3,8 @@ ENTRY (_start)
 PHDRS {
 	text PT_LOAD;
 	data PT_LOAD;
+	bss 0x60000000;
+	rel 0x60000001;
 	noload PT_LOAD FLAGS(0);
 }
 
@@ -16,6 +18,10 @@ SECTIONS {
 		*(.rodata1)
 		*(.rodata.*)
 		__text_end = .;
+	} : text
+
+	.special ALIGN(4) : {
+		*(.ARM.exidx)
 	} : text
 
 	.data ALIGN(4) : {
@@ -38,9 +44,9 @@ SECTIONS {
 		*(.bss*)
 		*(COMMON)
 		__bss_end = .;
-	}
+	} : bss
 
-	.rel.dyn : { *(.rel.dyn) } : noload 
+	.rel.dyn : { *(.rel.dyn) } : rel 
 	.dynamic : { *(.dynamic) } : noload
 	.dynsym : { *(.dynsym) } : noload
 

--- a/Library/elfexe32.ld
+++ b/Library/elfexe32.ld
@@ -1,11 +1,10 @@
 ENTRY (_start)
 
 PHDRS {
+	dynamic PT_DYNAMIC;
 	text PT_LOAD;
 	data PT_LOAD;
-	bss 0x60000000;
-	rel 0x60000001;
-	noload PT_LOAD FLAGS(0);
+	info PT_LOAD;
 }
 
 SECTIONS {
@@ -20,9 +19,9 @@ SECTIONS {
 		__text_end = .;
 	} : text
 
-	.special ALIGN(4) : {
-		*(.ARM.exidx)
-	} : text
+	.got ALIGN(4) : { *(.got*) } : text
+	.plt ALIGN(4) : { *(.plt*) } : text
+	.ARM.exidx ALIGN(4) : { *(.ARM.exidx) } : text
 
 	.data ALIGN(4) : {
 		__data_start = .;
@@ -44,11 +43,12 @@ SECTIONS {
 		*(.bss*)
 		*(COMMON)
 		__bss_end = .;
-	} : bss
+	} : data
 
-	.rel.dyn : { *(.rel.dyn) } : rel 
-	.dynamic : { *(.dynamic) } : noload
-	.dynsym : { *(.dynsym) } : noload
+	.dynamic : { *(.dynamic) } :dynamic :info
+	.dynsym : { *(.dynsym) } :info
+	.rel.dyn : { *(.rel*) } :info
+	.hash : { *(.hash*) } :info
 
 	/DISCARD/ : { *(.comment .note) }
 }


### PR DESCRIPTION
By changing the linker script to bake information about the size of the BSS and where the relocations are into the ELF file, I can remove all the section header stuff from the loader, which simplifies things considerably.

However, GNU ld then behaves very oddly if I try to strip certain sections (including rearranging or removing program headers... I think it could be a bug). This means I have to be rather less aggressive there. This doesn't affect the amount of data in memory, but it does make the files on disk a bit bigger.