### PR TITLE
Add prototype of a standalone tool for making bFLT files from static PIE elf files.

### DIFF
--- a/Kernel/include/flat.h
+++ b/Kernel/include/flat.h
@@ -1,0 +1,31 @@
+#ifndef FLAT_H
+#define FLAT_H
+
+/* We don't quite use the ucLinux names, we don't want to load a ucLinux binary
+ * in error! */
+#define FLAT_FUZIX_MAGIC "bFLT"
+
+#define FLAT_VERSION 4
+
+struct binfmt_flat {
+	uint8_t magic[4];
+	uint32_t rev;
+	uint32_t entry;
+	uint32_t data_start;
+	uint32_t data_end;
+	uint32_t bss_end;
+	uint32_t stack_size;
+	uint32_t reloc_start;
+	uint32_t reloc_count;
+	uint32_t flags;
+	uint32_t filler[6];
+};
+
+#define FLAT_FLAG_RAM    0x0001 /* load program entirely into RAM */
+#define FLAT_FLAG_GOTPIC 0x0002 /* program is PIC with GOT */
+#define FLAT_FLAG_GZIP   0x0004 /* all but the header is compressed */
+#define FLAT_FLAG_GZDATA 0x0008 /* only data/relocs are compressed (for XIP) */
+#define FLAT_FLAG_KTRACE 0x0010 /* output useful kernel trace for debugging */
+
+#endif
+

--- a/Kernel/syscall_exec32.c
+++ b/Kernel/syscall_exec32.c
@@ -27,24 +27,11 @@
 #include <version.h>
 #include <kdata.h>
 #include <printf.h>
+#include <flat.h>
 
 /* FIXME: we need to put this back on boxes with a malloc but for now
    lets keep it easy */
 #define ARGBUF_SIZE	512
-
-struct binfmt_flat {
-	uint8_t magic[4];
-	uint32_t rev;
-	uint32_t entry;
-	uint32_t data_start;
-	uint32_t data_end;
-	uint32_t bss_end;
-	uint32_t stack_size;
-	uint32_t reloc_start;
-	uint32_t reloc_count;
-	uint32_t flags;
-	uint32_t filler[6];
-};
 
 static void close_on_exec(void)
 {
@@ -60,7 +47,7 @@ static int valid_hdr(inoptr ino, struct binfmt_flat *bf)
 {
 	if (bf->stack_size < 4096)
 		bf->stack_size = 4096;
-	if (bf->rev != 4)
+	if (bf->rev != FLAT_VERSION)
 		return 0;
 	if (bf->entry >= bf->data_start)
 		return 0;
@@ -156,7 +143,7 @@ arg_t _execve(void)
 
 	/* Hard coded for our 68K format. We don't quite use the ucLinux
 	   names, we don't want to load a ucLinux binary in error! */
-	if (memcmp(binflat.magic, "bFLT", 4) || !valid_hdr(ino, &binflat)) {
+	if (memcmp(binflat.magic, FLAT_FUZIX_MAGIC, 4) || !valid_hdr(ino, &binflat)) {
 		udata.u_error = ENOEXEC;
 		goto nogood2;
 	}

--- a/Standalone/Makefile
+++ b/Standalone/Makefile
@@ -2,7 +2,7 @@ CC=gcc
 #Use this for playing with the experimental libdsk support
 #CCOPTS=-O2 -DLIBDSK -ldsk -g -Wall -pedantic -Wno-char-subscripts -Wno-deprecated-declarations
 CCOPTS=-O2 -g -Wall -pedantic -Wno-char-subscripts -Wno-deprecated-declarations
-TARGETS=mkfs fsck ucp chmem size
+TARGETS=mkfs fsck ucp chmem size elf2flt
 
 all:	$(TARGETS)
 
@@ -22,6 +22,9 @@ chmem:	chmem.o
 	$(CC) $(CCOPTS) -o $@ $<
 
 size:	size.o
+	$(CC) $(CCOPTS) -o $@ $<
+
+elf2flt:	elf2flt.o
 	$(CC) $(CCOPTS) -o $@ $<
 
 %.o:	%.c

--- a/Standalone/elf2flt.c
+++ b/Standalone/elf2flt.c
@@ -1,0 +1,227 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <arpa/inet.h>
+
+typedef uint32_t uaddr_t;
+#include "../Kernel/include/elf.h"
+#include "../Kernel/include/flat.h"
+
+#define perror_exit(msg) \
+	do { perror(msg); exit(1); } while (0)
+#define alignup(v,a) \
+	(uint32_t)((intptr_t)((v) + (a)-1) & ~((a)-1))
+
+#define ELFSTRUCT(offset) \
+	(void*)((uint8_t*)elffile + offset)
+
+static int stacksize = 4096;
+
+static void syntax_error(void)
+{
+	fprintf(stderr, "syntax: elf2flt [-s stacksize] -o outputfile inputfile\n");
+	exit(1);
+}
+
+static void write_error(void)
+{
+	perror_exit("cannot write output file");
+}
+
+void* load_file(const char* filename)
+{
+	int fd = open(filename, O_RDONLY);
+	if (fd == -1)
+		perror_exit("cannot open input file");
+	
+	struct stat st;
+	if (fstat(fd, &st) == -1)
+		perror_exit("cannot stat input file");
+
+	void* ptr = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+	close(fd);
+
+	if (ptr == MAP_FAILED)
+		perror_exit("cannot map input file");
+
+	return ptr;
+}
+
+int main(int argc, char* const* argv)
+{
+	const char* inputfilename = NULL;
+	const char* outputfilename = NULL;
+	for (;;)
+	{
+		int opt = getopt(argc, argv, "s:o:");
+		if (opt == -1)
+			break;
+
+		switch (opt)
+		{
+			case 'o':
+				outputfilename = optarg;
+				break;
+
+			case 's':
+				stacksize = strtoul(optarg, NULL, 0);
+				break;
+
+			default:
+				syntax_error();
+		}
+	}
+
+	if (!outputfilename
+			|| ((optind+1) != argc))
+		syntax_error();
+	inputfilename = argv[optind];
+
+	Elf32_Ehdr* elffile = load_file(inputfilename);
+	FILE* outfp = fopen(outputfilename, "wb");
+	if (!outfp)
+		perror_exit("cannot open output file");
+
+	/* Scan the section headers looking for stuff. */
+
+	Elf32_Shdr* shdr = ELFSTRUCT(elffile->e_shoff);
+	uint32_t bsshi = 0;
+	uint32_t bsslo = 0xffffffff;
+	uint32_t datahi = 0;
+	uint32_t datalo = 0xffffffff;
+	uint32_t texthi = 0;
+	uint32_t textlo = 0xffffffff;
+	uint32_t reloff = 0xffffffff;
+	uint32_t relcount = 0;
+	for (int i=0; i<elffile->e_shnum; i++)
+	{
+		Elf32_Shdr* sh = &shdr[i];
+		uint32_t seclo = sh->sh_addr;
+		uint32_t sechi = sh->sh_addr + sh->sh_size;
+		switch (sh->sh_type)
+		{
+			case SHT_PROGBITS: /* Initialised data */
+				if (sh->sh_flags & SHF_ALLOC)
+				{
+					if (sh->sh_flags & SHF_EXECINSTR)
+					{
+						/* Text segment. */
+
+						if (seclo < textlo)
+							textlo = seclo;
+						if (sechi > texthi)
+							texthi = sechi;
+					}
+					else
+					{
+						/* Data segment. */
+
+						if (seclo < datalo)
+							datalo = seclo;
+						if (sechi > datahi)
+							datahi = sechi;
+					}
+				}
+				break;
+
+			case SHT_NOBITS: /* Zero-initialised data */
+				if (sh->sh_flags & SHF_ALLOC)
+				{
+					/* BSS segment. */
+
+					if (seclo < bsslo)
+						bsslo = seclo;
+					if (sechi > bsshi)
+						bsshi = sechi;
+				}
+				break;
+
+			case SHT_REL: /* Relocation section */
+				if (relcount != 0)
+				{
+					fprintf(stderr, "failed: multiple relocation sections\n");
+					exit(1);
+				}
+				reloff = sh->sh_offset;
+				relcount = sh->sh_size / sizeof(Elf32_Rel);
+				break;
+		}
+	}
+
+	printf("text:  0x%08x to 0x%08x\n", textlo, texthi);
+	printf("data:  0x%08x to 0x%08x\n", datalo, datahi);
+	printf("bss:   0x%08x to 0x%08x\n", bsslo, bsshi);
+	printf("reloc: %d entries\n", relcount);
+
+	if ((bsslo < texthi) || (bsslo < datahi) || (datalo < texthi))
+	{
+		fprintf(stderr, "failed: overlapping segments (ELF file is too complex?)\n");
+		exit(1);
+	}
+
+	/* Now, load all the PROGBITS segments into memory. */
+
+	uint8_t* memory = calloc(1, datahi - textlo);
+	for (int i=0; i<elffile->e_shnum; i++)
+	{
+		Elf32_Shdr* sh = &shdr[i];
+		switch (sh->sh_type)
+		{
+			case SHT_PROGBITS: /* Initialised data */
+				if (sh->sh_flags & SHF_ALLOC)
+					memcpy(memory - textlo + sh->sh_addr, ELFSTRUCT(sh->sh_offset), sh->sh_size);
+				break;
+		}
+	}
+
+	/* Assemble the bFLT header. */
+
+	struct binfmt_flat flatheader =
+	{
+		.magic = FLAT_FUZIX_MAGIC,
+		.rev = htonl(FLAT_VERSION),
+		.flags = htonl(FLAT_FLAG_RAM),
+		.entry = htonl(elffile->e_entry + sizeof(flatheader)),
+		.data_start = htonl(textlo + sizeof(flatheader)),
+		.data_end = htonl(datahi + sizeof(flatheader)),
+		.bss_end = htonl(bsshi + sizeof(flatheader)),
+		.reloc_start = htonl(datahi + sizeof(flatheader)),
+		.reloc_count = htonl(relcount),
+		.stack_size = htonl(stacksize),
+	};
+	if (fwrite(&flatheader, sizeof(flatheader), 1, outfp) != 1)
+		write_error();
+	if (fwrite(memory, datahi, 1, outfp) != 1)
+		write_error();
+
+	Elf32_Rel* rel = ELFSTRUCT(reloff);
+	for (int i=0; i<relcount; i++)
+	{
+		uint32_t type = ELF32_R_TYPE(rel->r_info);
+		uint32_t addr;
+		switch (type)
+		{
+			case R_ARM_RELATIVE:
+				addr = rel->r_offset;
+				break;
+
+			default:
+				fprintf(stderr, "Unknown ELF relocation type %d\n", type);
+				exit(1);
+		}
+
+		addr = htonl(addr);
+		if (fwrite(&addr, sizeof(addr), 1, outfp) != 1)
+			write_error();
+
+		rel++;
+	}
+	fclose(outfp);
+}
+


### PR DESCRIPTION
This turned out to be pretty simple, but it currently won't work: the kernel loader needs a fair bit of work as it's currently hard-coded for the 68000, and the tool needs to be taught about 68000 relocations anyway. Also, it appears that bFLT is limited to 32-bit relocations only. I don't know how this works with platforms like the PowerPC where 32-bit constants are traditionally inlined but split into two 16-bit fields in two 32-bit instructions.