### PR TITLE
Make the NAND flash work on the Pico

### DIFF
--- a/Applications/util/Makefile.generic
+++ b/Applications/util/Makefile.generic
@@ -40,6 +40,7 @@ SRCSNS = \
 SRCS  = \
 	banner.c \
 	bd.c \
+	blkdiscard.c \
 	cal.c \
 	chmem.c \
 	cksum.c \

--- a/Applications/util/blkdiscard.c
+++ b/Applications/util/blkdiscard.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#define perror_exit(s) \
+	do { perror(s); exit(1); } while (0)
+
+static bool force = false;
+static const char* filename;
+static int fd;
+static uint32_t size;
+
+static void syntax_error(void)
+{
+	fprintf(stderr, "Usage: blkdiscard [-f] device\n");
+	exit(1);
+}
+
+int main(int argc, char* const* argv)
+{
+	for (;;)
+	{
+		int opt = getopt(argc, argv, "f");
+		if (opt == -1)
+			break;
+
+		switch (opt)
+		{
+			case 'f':
+				force = true;
+				break;
+
+			default:
+				syntax_error();
+		}
+	}
+	if (optind != (argc-1))
+		syntax_error();
+	filename = argv[optind];
+
+	fd = open(filename, O_RDWR);
+	if (fd == -1)
+		perror_exit("cannot open block device");
+
+	if (ioctl(fd, BLKGETSIZE, &size) == -1)
+		perror_exit("cannot get size of partition");
+
+	if (!force)
+	{
+		printf("This will destroy %dkB of data on %s. Proceed? ", size/2, filename);
+		fflush(stdout);
+		if (getchar() != 'y')
+		{
+			printf("Aborted.\n");
+			exit(1);
+		}
+	}
+
+	printf("Erasing...\n");
+	fflush(stdout);
+	{
+		uint16_t blkno;
+		for (blkno=0; blkno<size; blkno++)
+		{
+			if (ioctl(fd, HDIO_TRIM, &blkno) == -1)
+				perror_exit("erase failed");
+		}
+	}
+
+	printf("Done.\n");
+	close(fd);
+	return 0;
+}
+

--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -186,8 +186,12 @@ int blkdev_ioctl(uint_fast8_t minor, uarg_t request, char *data)
         }
 #endif
 
-        default:
-            return -1;
+		case BLKGETSIZE:
+		{
+			uint_fast8_t partition = minor & 0x0F;
+			uint32_t size = (partition == 0) ? blk_op.blkdev->drive_lba_count : blk_op.blkdev->lba_count[partition-1];
+			return uputl(size, data);
+		}
     }
 }
 

--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -176,7 +176,7 @@ int blkdev_ioctl(uint_fast8_t minor, uarg_t request, char *data)
         {
             if (blk_op.blkdev->trim)
             {
-                blk_op.lba = ugetl(data, NULL);
+                blk_op.lba = ugetw(data);
                 if (translate_lba(minor))
                     return -1;
                 return blk_op.blkdev->trim();

--- a/Kernel/include/kernel.h
+++ b/Kernel/include/kernel.h
@@ -749,6 +749,7 @@ struct s_argblk {
                                            is device dependent */
 #define HDIO_EJECT		0x0105	/* Request a media eject */
 #define HDIO_TRIM       0x0106  /* Issue a TRIM request */
+#define BLKGETSIZE      0x0107  /* Use the Linux name */
 
 /*
  *	Floppy disk ioctl s0x01Fx (see fdc.h)

--- a/Kernel/platform-rpipico/README.md
+++ b/Kernel/platform-rpipico/README.md
@@ -97,6 +97,26 @@ The Pico's mask ROM contains many useful routines which can be used instead of
 libgcc, which would reduce the binary size. This hasn't been done yet because
 it would render the binaries non-portable.
 
+## Using the NAND flash
+
+The Pico's built-in NAND flash is supported, but not terribly useful as you
+still need an SD card for swap. It appears as `/dev/hda` inside Fuzix (the SD
+card is `/dev/hdb`). It's mapped via the Dhara FTL library, so you get proper
+wear levelling, but it requires formatting before use. To do this, from inside
+Fuzix do:
+
+```
+$ blkdiscard /dev/hda
+$ mkfs -f /dev/hda 32 2746
+```
+
+The FTL library requires empty flash sectors to work efficiently; the Fuzix
+filesystem has trim support, so the FTL library gets notified when sectors
+become free, but the flash needs initialising first. `blkdiscard` erases the
+entire flash; `mkfs -f` prevents `mkfs` from writing zeroes to the entire
+filesystem. If you let it do this, then the FTL library will think every block
+will be in use and will work extraordinarily badly.
+
 ## Issues
 
 There are many.
@@ -105,7 +125,6 @@ There are many.
   - CPU exceptions should be mapped to signals.
   - single-tasking mode should be switched off (which would allow pipes to
     work).
-  - the NAND flash driver is broken and disabled.
 
 ...and probably others.
 

--- a/Kernel/platform-rpipico/config.h
+++ b/Kernel/platform-rpipico/config.h
@@ -52,8 +52,8 @@ extern uint8_t progbase[PROGSIZE];
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL	  /* Location of root dev name */
 
-#define BOOTDEVICE 0x0002 /* hda2 */
-#define SWAPDEV    0x0001 /* hda1 */
+#define BOOTDEVICE 0x0012 /* hdb2 */
+#define SWAPDEV    0x0011 /* hdb1 */
 
 /* Device parameters */
 #define NUM_DEV_TTY 1

--- a/Kernel/platform-rpipico/devices.c
+++ b/Kernel/platform-rpipico/devices.c
@@ -59,7 +59,7 @@ void device_init(void)
     /* The flash device is too small to be useful, and a corrupt flash will
      * cause a crash on startup... oddly. */
 
-	//flash_dev_init();
+	flash_dev_init();
     
 	sd_rawinit();
 	devsd_init();

--- a/Kernel/platform-rpipico/rawflash.c
+++ b/Kernel/platform-rpipico/rawflash.c
@@ -31,8 +31,8 @@ int dhara_nand_read(const struct dhara_nand *n, dhara_page_t p,
                     dhara_error_t *err)
 {
     memcpy(data,
-        (uint8_t*)XIP_NOCACHE_BASE + (FLASH_OFFSET + (p*512)),
-        512);
+        (uint8_t*)XIP_NOCACHE_BASE + FLASH_OFFSET + (p*512) + offset,
+        length);
 	if (err)
 		*err = DHARA_E_NONE;
 	return 0;

--- a/Kernel/platform-rpipico/update-flash.sh
+++ b/Kernel/platform-rpipico/update-flash.sh
@@ -91,6 +91,7 @@ cd /bin
 bget ../../Applications/util/banner
 bget ../../Applications/util/basename
 bget ../../Applications/util/bd
+bget ../../Applications/util/blkdiscard
 bget ../../Applications/util/cal
 bget ../../Applications/util/cat
 bget ../../Applications/util/chgrp
@@ -172,6 +173,7 @@ bget ../../Applications/util/yes
 chmod 0755 banner
 chmod 0755 basename
 chmod 0755 bd
+chmod 0755 blkdiscard
 chmod 0755 cal
 chmod 0755 cat
 chmod 0755 chgrp

--- a/Library/include/syscalls.h
+++ b/Library/include/syscalls.h
@@ -71,6 +71,8 @@ struct sockaddr_in;
 
 #define HDIO_GETGEO		0x0101
 #define HDIO_GET_IDENTITY	0x0102	/* Not yet implemented anywhere */
+#define HDIO_TRIM 		0x0106
+#define BLKGETSIZE		0x0107
 
 /* uadmin */
 


### PR DESCRIPTION
This finally fixes the NAND flash code. It also adds a `BLKGETSIZE` ioctl to get the LBA size of a partition, fixes a bug in `HDIO_TRIM`, exports both to userland, and adds a userspace tool for erasing an entire partition.