### PR TITLE
Have video memory be linear

### DIFF
--- a/Kernel/platform-trs80/trs80-bank.s
+++ b/Kernel/platform-trs80/trs80-bank.s
@@ -67,7 +67,7 @@ init_hardware:
 
 opsave:	    .db 0x06	; used as a word so keep together
 save94:	    .db 0x01
-_opreg:	    .db 0x06	; kernel map, 80 columns
+_opreg:	    .db 0x86	; kernel map, 80 columns, linear video memory
 _modout:    .db 0x50	; 80 column, sound enabled, altchars off,
 			; external I/O enabled, 4MHz
 


### PR DESCRIPTION
Bit 7 of $84 is the video page bit.  Unintuitively it specifies which page is second.  In normal operation it is set to 1 so that when video memory is mapped to $F800 you have page 0 at $F800 and page 1 at $FC00.

This change has been verified on a real machine.  It makes no difference on xtrs which is a bug in its emulation.

The boot block sets the high bit of $84 so no change is needed there.