### PR TITLE
travis: bump CI to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 sudo: required
 
 matrix:
@@ -12,7 +12,7 @@ matrix:
         - env: TARGET=n8vem-mark4
 
 before_install:
-    - sudo add-apt-repository -y ppa:p-pisati/fuzix
+    - sudo add-apt-repository -n -y ppa:p-pisati/fuzix
     - sudo apt-get update -q
     - sudo apt-get install -y byacc automake			# FUZIX build deps
     - sudo update-alternatives --set yacc /usr/bin/byacc


### PR DESCRIPTION
Focal is the latest LTS Ubuntu release (supported up to April 2025), while Xenial, our current CI base OS, is about to to EOL in ~1 month (April 2021).

Signed-off-by: Paolo Pisati <p.pisati@gmail.com>