### PR TITLE
compatibility: allow position independed executables too

### DIFF
--- a/Standalone/elf2flt.c
+++ b/Standalone/elf2flt.c
@@ -405,7 +405,8 @@ int main(int argc, char* const* argv)
 	if (crossendian && verbose)
 		printf("[Cross endian conversion]\n");
 
-	if (endian16(elffile->e_type) != ET_EXEC) {
+	if ((endian16(elffile->e_type) != ET_EXEC) &&
+	    (endian16(elffile->e_type) != ET_DYN)) {
 		fprintf(stderr, "elf2flt: only executable files.\n");
 		exit(1);
 	}


### PR DESCRIPTION
armm4 Makefiles use `-fpie -DPIE` flags, this results in creation of position independent executables, their type is not ET_EXEC but ET_DYN.
