### PR TITLE
compatibility: fix exec issue with 32-bit little-endian architectures

### DIFF
--- a/Kernel/cpu-armm0/cpu.h
+++ b/Kernel/cpu-armm0/cpu.h
@@ -64,6 +64,9 @@ inline static void __hard_irqrestore(uint32_t ps)
 
 #define no_cache_udata()
 
+#define ntohs(x) ((uint16_t)(__builtin_bswap16((uint16_t)(x))))
+#define ntohl(x) ((uint32_t)(__builtin_bswap32((uint32_t)(x))))
+
 #define CPUTYPE	CPUTYPE_ARMM0
 
 /* Memory helpers: Max of 32767 blocks (16MB) as written */

--- a/Kernel/syscall_exec32.c
+++ b/Kernel/syscall_exec32.c
@@ -78,7 +78,7 @@ static void relocate(struct binfmt_flat *bf, uaddr_t progbase, uint32_t size)
 	uint32_t *rp = (uint32_t *)(progbase + bf->reloc_start);
 	uint32_t n = bf->reloc_count;
 	while (n--) {
-		uint32_t v = *rp++;
+		uint32_t v = ntohl(*rp++);
 		if (v < size && !(v&1))	/* Revisit for non 68K */
 			/* FIXME: go via user access methods */
 			*((uint32_t *)(progbase + 0x40 + v)) += progbase + 0x40;
@@ -140,6 +140,16 @@ arg_t _execve(void)
 		udata.u_error = ENOEXEC;
 		goto nogood;
 	}
+
+	binflat.rev = ntohl(binflat.rev);
+	binflat.entry = ntohl(binflat.entry);
+	binflat.data_start = ntohl(binflat.data_start);
+	binflat.data_end = ntohl(binflat.data_end);
+	binflat.bss_end = ntohl(binflat.bss_end);
+	binflat.stack_size = ntohl(binflat.stack_size);
+	binflat.reloc_start = ntohl(binflat.reloc_start);
+	binflat.reloc_count = ntohl(binflat.reloc_count);
+	binflat.flags = ntohl(binflat.flags);
 
 	/* FIXME: ugly - save this as valid_hdr modifies it */
 	true_brk = binflat.bss_end;


### PR DESCRIPTION
We're almost there with running FUZIX on dk-tm4c129x!

Now it looks like that:
```
FUZIX version 0.4pre1
Copyright (c) 1988-2002 by H.F.Bower, D.Braun, S.Nitschke, H.Peraza
Copyright (c) 1997-2001 by Arcady Schekochikhin, Adriano C. R. da Cunha
Copyright (c) 2013-2015 Will Sowerbutts <will@sowerbutts.com>
Copyright (c) 2014-2021 Alan Cox <alan@etchedpixels.co.uk>
Devboot
256kB total RAM, 256kB available to processes (15 processes max)
Enabling interrupts ... ok.
SD drive 0: hda: hda1
bootdev: hda1
Mounting root fs (root_dev=1, ro): OK
Starting /init
init version 0.9.0ac#1
/etc/rc: Unknown error 1113915252

 ^ ^
 n n   Fuzix 0.3.1
 >@<
       Welcome to Fuzix
 m m

login: root
login: unable to change owner of controlling tty

Welcome to FUZIX.
```
I wonder whatever happened to `/etc/rc`...
