### PR TITLE
Fix regression in 32-bit exec

### DIFF
--- a/Kernel/platform-dk-tm4c129x/syscall.c
+++ b/Kernel/platform-dk-tm4c129x/syscall.c
@@ -3,9 +3,9 @@
 
 struct svc_frame
 {
-  uint32_t lr;
-  uint32_t pc;
   uint32_t r12;
+  uint32_t pc;
+  uint32_t lr;
   uint32_t r0;
   uint32_t r1;
   uint32_t r2;

--- a/Kernel/syscall_exec32.c
+++ b/Kernel/syscall_exec32.c
@@ -85,9 +85,9 @@ static void relocate(struct binfmt_flat *bf, uaddr_t progbase, uint32_t size)
 	/* We can use _uput/_uget as we set up the memory map so we know
 	   it is valid */
 	while (n--) {
-		uint32_t v = _ugetl(rp++);
+		uint32_t v = ntohl(_ugetl(rp++));
 		if (v < size) {
-			uint32_t *mp = (uint32_t *)(progbase + ntohl(v));
+			uint32_t *mp = (uint32_t *)(progbase + v);
 			_uputl(_ugetl(mp) + progbase, mp);
 		}
 	}

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 #		(or xroar emulator )
 # coco3:	Tandy COCO3 512K (or MAME)
 # cromemco:	Cromemco with banked memory
+# dk-tm4c129x:	Texas Instruments Tiva C Series Development Board
 # dragon-mooh:	Dragon 32/64 with Mooh 512K card (or xroar emulator)
 # dragon-nx32:	Dragon 32/64 with Spinx 512K card (or xroar emulator)
 # easy-z80:	Easy-Z80 RC2014 compatible system


### PR DESCRIPTION
This set of patches addresses the regression in ability to work with old 'working' rootfs images. Sadly, the most recently created rootfs image still does not work.

Booting with the old image:
```
FUZIX version 0.4pre1
Copyright (c) 1988-2002 by H.F.Bower, D.Braun, S.Nitschke, H.Peraza
Copyright (c) 1997-2001 by Arcady Schekochikhin, Adriano C. R. da Cunha
Copyright (c) 2013-2015 Will Sowerbutts <will@sowerbutts.com>
Copyright (c) 2014-2021 Alan Cox <alan@etchedpixels.co.uk>
Devboot
256kB total RAM, 256kB available to processes (15 processes max)
Enabling interrupts ... ok.
SD drive 0: hda: hda1
bootdev: hda1
Mounting root fs (root_dev=1, ro): OK
Starting /init
init version 0.9.0ac#1
Checking root file system.
Current date is Wed 2021-05-12
Enter new date:
Current time is 23:02:35
Enter new time:

 ^ ^
 n n   Fuzix 0.3.1
 >@<
       Welcome to Fuzix
 m m

login: root

Welcome to FUZIX.
# free
         total         used         free
Mem:       256           59          197
Swap:        0            0            0
# fforth
 ok
3 5 + .
8  ok
^d
#
```

Booting with the new image:
```
FUZIX version 0.4pre1
Copyright (c) 1988-2002 by H.F.Bower, D.Braun, S.Nitschke, H.Peraza
Copyright (c) 1997-2001 by Arcady Schekochikhin, Adriano C. R. da Cunha
Copyright (c) 2013-2015 Will Sowerbutts <will@sowerbutts.com>
Copyright (c) 2014-2021 Alan Cox <alan@etchedpixels.co.uk>
Devboot
256kB total RAM, 256kB available to processes (15 processes max)
Enabling interrupts ... ok.
SD drive 0: hda: hda1
bootdev: hda1
Mounting root fs (root_dev=1, ro): OK
Starting /init
init version 0.9.0ac#1
/etc/rc: Unknown error 1113915252

 ^ ^
 n n   Fuzix 0.3.1
 >@<
       Welcome to Fuzix
 m m

login: root
login: unable to change owner of controlling tty

Welcome to FUZIX.
```
