### PR TITLE
armm4: fix the hack that prevents relocations from being written for ARM targets

### DIFF
--- a/Applications/rules.armm4
+++ b/Applications/rules.armm4
@@ -13,6 +13,6 @@ STRIP_OPT =
 CRT0 = $(ROOT)/Library/libs/crt0_$(PLATFORM).o
 CRT0NS = $(ROOT)/Library/libs/crt0nostdio_$(PLATFORM).o
 # ELF2FUZIX = PATH=$(CROSS_PATH_BIN):$(PATH) $(ROOT)/Library/tools/elf2bin -p arm-none-eabi
-ELF2FUZIX = $(ROOT)/Standalone/elf2flt -s 8192
+ELF2FUZIX = $(ROOT)/Standalone/elf2flt -v -s 8192
 .SUFFIXES: .c .o
 HOSTCC = cc

--- a/Standalone/elf2flt.c
+++ b/Standalone/elf2flt.c
@@ -502,7 +502,7 @@ int main(int argc, char* const* argv)
 				break;
 		}
 		/* HACK: Ignore all the crap after the BSS */
-		if (endian32(sh->sh_type) == SHT_NOBITS)
+		if ((endian32(sh->sh_type) == SHT_NOBITS) && (arch != EM_ARM))
 			break;
 	}
 


### PR DESCRIPTION
With the original hack:

```
reloc: 0 entries
Writing 0 relocations.
```
After modifying the hack:
```
reloc: 108 entries
Writing 108 relocations.
```

Finally, rootfs is usable!

```
FUZIX version 0.4pre1
Copyright (c) 1988-2002 by H.F.Bower, D.Braun, S.Nitschke, H.Peraza
Copyright (c) 1997-2001 by Arcady Schekochikhin, Adriano C. R. da Cunha
Copyright (c) 2013-2015 Will Sowerbutts <will@sowerbutts.com>
Copyright (c) 2014-2021 Alan Cox <alan@etchedpixels.co.uk>
Devboot
256kB total RAM, 256kB available to processes (15 processes max)
Enabling interrupts ... ok.
SD drive 0: hda: hda1
bootdev: hda1
Mounting root fs (root_dev=1, ro): OK
Starting /init
init version 0.9.0ac#1
Checking root file system.
Current date is Sat 2021-09-04
Enter new date:
Current time is 13:15:47
Enter new time:

 ^ ^
 n n   Fuzix 0.3.1
 >@<
       Welcome to Fuzix
 m m

login: root

Welcome to FUZIX.
# free
         total         used         free
Mem:       256           59          197
Swap:        0            0            0
#
```