### PR TITLE
Streamline CI and switch to a build matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false # keep on building even if one target fails
       matrix:
-        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, sbcv2, sc108]
+        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, rpipico, sbcv2, sc108]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -39,6 +39,10 @@ jobs:
           ;;
           rc2014-6502)
           PKGS="cc65"
+          ;;
+          rpipico)
+          PKGS="cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib"
+          echo "sub_target=kernel" >> $GITHUB_ENV
           ;;
           esac
         sudo apt-get update -q
@@ -76,17 +80,6 @@ jobs:
       run: echo "/usr/local/${M68K_CROSS_DIR}/m68k-linux/bin" >> $GITHUB_PATH
     - name: make
       run: make CROSS_COMPILE=m68k-linux- TARGET=tiny68k -j`nproc`
-
-  build-rpipico:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
-    - name: make kernel
-      run: make TARGET=rpipico kernel -j`nproc`
 
   build-z80-libc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false # keep on building even if one target fails
       matrix:
-        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, rpipico, sbcv2, sc108]
+        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, rc2014-68008, rpipico, sbcv2, sc108, tiny68k]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -40,6 +40,11 @@ jobs:
           rc2014-6502)
           PKGS="cc65"
           ;;
+          rc2014-68008|tiny68k)
+          wget -O - "${M68K_CROSS_URL}" | sudo tar zxvf - -C /usr/local
+          echo "/usr/local/${M68K_CROSS_DIR}/m68k-linux/bin" >> $GITHUB_PATH
+          echo "cross_cc=CROSS_COMPILE=m68k-linux-" >> $GITHUB_ENV
+          ;;
           rpipico)
           PKGS="cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib"
           echo "sub_target=kernel" >> $GITHUB_ENV
@@ -49,37 +54,7 @@ jobs:
         sudo apt-get install -y byacc automake ${PKGS}
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
-      run: make TARGET=${{ matrix.target }} ${{ env.sub_target }} -j`nproc`
-
-  build-rc2014-68008:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-        wget -O - "${M68K_CROSS_URL}" | sudo tar zxvf - -C /usr/local
-    - name: update env
-      run: echo "/usr/local/${M68K_CROSS_DIR}/m68k-linux/bin" >> $GITHUB_PATH
-    - name: make
-      run: make CROSS_COMPILE=m68k-linux- TARGET=rc2014-68008 -j`nproc`
-
-  build-tiny68k:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-        wget -O - "${M68K_CROSS_URL}" | sudo tar zxvf - -C /usr/local
-    - name: update env
-      run: echo "/usr/local/${M68K_CROSS_DIR}/m68k-linux/bin" >> $GITHUB_PATH
-    - name: make
-      run: make CROSS_COMPILE=m68k-linux- TARGET=tiny68k -j`nproc`
+      run: make ${{ env.cross_cc }} TARGET=${{ matrix.target }} ${{ env.sub_target }} -j`nproc`
 
   build-z80-libc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false # keep on building even if one target fails
       matrix:
-        target: [dragon-nx32, esp8266, multicomp09, rc2014-6502]
+        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, sbcv2, sc108]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +33,10 @@ jobs:
           esp8266)
           PKGS="gcc-xtensa-lx106 esptool"
           ;;
+          n8vem-mark4|sbcv2|sc108)
+          PKGS="sdcc"
+          echo "sub_target=kernel" >> $GITHUB_ENV
+          ;;
           rc2014-6502)
           PKGS="cc65"
           ;;
@@ -41,46 +45,7 @@ jobs:
         sudo apt-get install -y byacc automake ${PKGS}
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
-      run: make TARGET=${{ matrix.target }} -j`nproc`
-
-  build-sbcv2:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y sdcc
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make TARGET=sbcv2 kernel -j`nproc`
-
-  build-sc108:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y sdcc
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make TARGET=sc108 kernel -j`nproc`
-
-  build-n8vem-mark4:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y sdcc
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make TARGET=n8vem-mark4 kernel -j`nproc`
+      run: make TARGET=${{ matrix.target }} ${{ env.sub_target }} -j`nproc`
 
   build-rc2014-68008:
     runs-on: ubuntu-20.04

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,20 +25,20 @@ jobs:
     - uses: actions/checkout@v2
     - name: install build deps
       run: |
-        sudo add-apt-repository -n -y ppa:p-pisati/fuzix
-        sudo apt-get update -q
         case ${{ matrix.target }} in
           dragon-nx32|multicomp09)
-          sudo apt-get install -y lwtools gcc6809
+          sudo add-apt-repository -n -y ppa:p-pisati/fuzix
+          PKGS="lwtools gcc6809"
           ;;
           esp8266)
-          sudo apt-get install -y gcc-xtensa-lx106 esptool
+          PKGS="gcc-xtensa-lx106 esptool"
           ;;
           rc2014-6502)
-          sudo apt-get install -y cc65
+          PKGS="cc65"
           ;;
           esac
-        sudo apt-get install -y byacc automake
+        sudo apt-get update -q
+        sudo apt-get install -y byacc automake ${PKGS}
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
       run: make TARGET=${{ matrix.target }} -j`nproc`

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,13 +19,18 @@ jobs:
     strategy:
       fail-fast: false # keep on building even if one target fails
       matrix:
-        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, rc2014-68008, rpipico, sbcv2, sc108, tiny68k]
+        target: [dragon-nx32, esp8266, multicomp09, n8vem-mark4, rc2014-6502, rc2014-68008, rpipico, sbcv2, sc108, tiny68k, armm0-libc, z80-libc]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install build deps
       run: |
         case ${{ matrix.target }} in
+          armm0-libc)
+          PKGS="sdcc"
+          echo "target=USERCPU=armm0" >> $GITHUB_ENV
+          echo "sub_target=libs" >> $GITHUB_ENV
+          ;;
           dragon-nx32|multicomp09)
           sudo add-apt-repository -n -y ppa:p-pisati/fuzix
           PKGS="lwtools gcc6809"
@@ -55,35 +60,14 @@ jobs:
           echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           echo "sub_target=kernel" >> $GITHUB_ENV
           ;;
+          z80-libc)
+          PKGS="sdcc"
+          echo "target=USERCPU=z80" >> $GITHUB_ENV
+          echo "sub_target=libs" >> $GITHUB_ENV
+          ;;
           esac
         sudo apt-get update -q
         sudo apt-get install -y byacc automake ${PKGS}
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
       run: make ${{ env.cross_cc }} ${{ env.target }} ${{ env.sub_target }} -j`nproc`
-
-  build-z80-libc:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y sdcc
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make USERCPU=z80 libs -j`nproc`
-
-  build-armm0-libc:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y sdcc
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make USERCPU=armm0 libs -j`nproc`

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,24 +29,30 @@ jobs:
           dragon-nx32|multicomp09)
           sudo add-apt-repository -n -y ppa:p-pisati/fuzix
           PKGS="lwtools gcc6809"
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           ;;
           esp8266)
           PKGS="gcc-xtensa-lx106 esptool"
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           ;;
           n8vem-mark4|sbcv2|sc108)
           PKGS="sdcc"
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           echo "sub_target=kernel" >> $GITHUB_ENV
           ;;
           rc2014-6502)
           PKGS="cc65"
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           ;;
           rc2014-68008|tiny68k)
           wget -O - "${M68K_CROSS_URL}" | sudo tar zxvf - -C /usr/local
           echo "/usr/local/${M68K_CROSS_DIR}/m68k-linux/bin" >> $GITHUB_PATH
           echo "cross_cc=CROSS_COMPILE=m68k-linux-" >> $GITHUB_ENV
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           ;;
           rpipico)
           PKGS="cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib"
+          echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV
           echo "sub_target=kernel" >> $GITHUB_ENV
           ;;
           esac
@@ -54,7 +60,7 @@ jobs:
         sudo apt-get install -y byacc automake ${PKGS}
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
-      run: make ${{ env.cross_cc }} TARGET=${{ matrix.target }} ${{ env.sub_target }} -j`nproc`
+      run: make ${{ env.cross_cc }} ${{ env.target }} ${{ env.sub_target }} -j`nproc`
 
   build-z80-libc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Continuous integration
 
 on:
   push:
@@ -15,7 +15,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-dragon-nx32:
+  build:
+    strategy:
+      fail-fast: false # keep on building even if one target fails
+      matrix:
+        target: [dragon-nx32, esp8266, multicomp09, rc2014-6502]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -23,25 +27,21 @@ jobs:
       run: |
         sudo add-apt-repository -n -y ppa:p-pisati/fuzix
         sudo apt-get update -q
-        sudo apt-get install -y lwtools gcc6809
+        case ${{ matrix.target }} in
+          dragon-nx32|multicomp09)
+          sudo apt-get install -y lwtools gcc6809
+          ;;
+          esp8266)
+          sudo apt-get install -y gcc-xtensa-lx106 esptool
+          ;;
+          rc2014-6502)
+          sudo apt-get install -y cc65
+          ;;
+          esac
         sudo apt-get install -y byacc automake
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
-      run: make TARGET=dragon-nx32 -j`nproc`
-
-  build-multicomp09:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo add-apt-repository -n -y ppa:p-pisati/fuzix
-        sudo apt-get update -q
-        sudo apt-get install -y lwtools gcc6809
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make TARGET=multicomp09 -j`nproc`
+      run: make TARGET=${{ matrix.target }} -j`nproc`
 
   build-sbcv2:
     runs-on: ubuntu-20.04
@@ -81,19 +81,6 @@ jobs:
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
       run: make TARGET=n8vem-mark4 kernel -j`nproc`
-
-  build-rc2014-6502:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y cc65
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make
-      run: make TARGET=rc2014-6502 -j`nproc`
 
   build-rc2014-68008:
     runs-on: ubuntu-20.04
@@ -136,20 +123,6 @@ jobs:
     - name: make kernel
       run: make TARGET=rpipico kernel -j`nproc`
 
-  build-esp8266:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install build deps
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y gcc-xtensa-lx106 esptool
-        sudo apt-get install -y byacc automake
-        sudo update-alternatives --set yacc /usr/bin/byacc
-    - name: make libraries
-      run: |
-        make TARGET=esp8266 -j`nproc`
-
   build-z80-libc:
     runs-on: ubuntu-20.04
     steps:
@@ -175,5 +148,3 @@ jobs:
         sudo update-alternatives --set yacc /usr/bin/byacc
     - name: make
       run: make USERCPU=armm0 libs -j`nproc`
-
-


### PR DESCRIPTION
Stop cut&pasting pieces of code around, and switch to a build matrix - this should make the entire process easier to reuse and push forward.

And while here, give the file and action a more sensible name.