### PR TITLE
.github/workflows: ci: armm0-libc: install the correct toolchain

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         case ${{ matrix.target }} in
           armm0-libc)
-          PKGS="sdcc"
+          PKGS="cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib"
           echo "target=USERCPU=armm0" >> $GITHUB_ENV
           echo "sub_target=libs" >> $GITHUB_ENV
           ;;


### PR DESCRIPTION
Fix a cut&paste error, and install the correct arm toolchain instead.

Signed-off-by: Paolo Pisati <p.pisati@gmail.com>