### PR TITLE
Fix #887: Lack of bound check while loading elf32 segments

### DIFF
--- a/Kernel/syscall_execelf32.c
+++ b/Kernel/syscall_execelf32.c
@@ -211,6 +211,13 @@ arg_t _execve(void)
 			udata.u_base = (uint8_t*) base;
 			udata.u_sysio = false;
 
+			if (base < PROGLOAD || (base + ssize) > (PROGLOAD + lomem)){
+				#ifdef DEBUG
+				kprintf("failed: invalid ph->p_vaddr\n");
+				#endif
+				goto fatal;
+			}
+
 			#ifdef DEBUG
 				kprintf("loading %p bytes from %p to %p\n", ssize, udata.u_offset, udata.u_base);
 			#endif


### PR DESCRIPTION
This fix should prevent arbitrary write when loading elf32 segments. I previously reported it on #887.
