### PR TITLE
zx+3: make sure TERM is set to vt52 on ZX Spectrum +3

### DIFF
--- a/Kernel/platform-zx+3/fuzix-platform-zx+3.pkg
+++ b/Kernel/platform-zx+3/fuzix-platform-zx+3.pkg
@@ -1,0 +1,7 @@
+package platform-zx+3
+
+disable-pkg platform-zx+3
+
+l /etc/inittab /etc/inittab.orig
+r /etc/inittab
+f 0644 /etc/inittab userspace/inittab

--- a/Kernel/platform-zx+3/userspace/inittab
+++ b/Kernel/platform-zx+3/userspace/inittab
@@ -1,0 +1,14 @@
+# Inittab
+id:3:initdefault:
+# Start a shell first
+# si::sysinit:/bin/sh
+# Run level s - a shell
+is:s:respawn:/bin/sh
+# Start up
+rc::bootwait:/etc/rc
+# Terminals
+01:3:respawn:getty /dev/tty1 9600 vt52
+02:3:off:getty /dev/tty2
+03:3:off:getty /dev/tty3
+# Shutdown
+ht:6:wait:/etc/rc.halt

--- a/Standalone/filesystem-src/build-zx+3-filesystem
+++ b/Standalone/filesystem-src/build-zx+3-filesystem
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+endian=
+if [ "$1" = "-X" ]; then
+	shift
+	endian=-X
+fi
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "Syntax: $0 [ -X ] filename isize bsize"
+        echo ""
+        echo "For a 1.44MB floppy disk, use isize=64, bsize=2880"
+        echo "For a 32MB (or larger) hard disk, use isize=256, bsize=65535"
+        exit 1
+fi
+
+./build-filesystem-ng $endian -f $1 -g $2 $3 -p platform-zx+3


### PR DESCRIPTION
It became annoying I had to edit /etc/inittab on each fresh +3 image.
