### PR TITLE
dk-tm4c129x: fixes in the ethernet driver

### DIFF
--- a/Applications/netd/fuzix-netd.pkg
+++ b/Applications/netd/fuzix-netd.pkg
@@ -30,4 +30,4 @@ f 0755 /usr/bin/netd-slip      netd-slip
 package  netd-eth
 if-file  netd-eth
 f 0755 /usr/bin/netd-eth  netd-eth
-n 060666 2048 /dev/eth
+n 020666 2048 /dev/eth


### PR DESCRIPTION
Three things were wrong:
- 'if' that was always true and was never needed blocked
  all of the outgoing traffic
- outgoing buffers were never freed
- /dev/eth was a block device while it should have been
  a character device

ICMP pings are now coming back from the device!