### PR TITLE
arm: fix huge instability in reading the process data from userspace

### DIFF
--- a/Library/include/proc.h
+++ b/Library/include/proc.h
@@ -37,9 +37,9 @@ struct p_tab {
     void *      p_wait;         /* Address of thing waited for */
     uint16_t    p_page;         /* Page mapping data */
     uint16_t    p_page2;        /* It's really four bytes for the platform */
-#if defined(__m68k__)
+#if defined(__m68k__) || defined(__arm__)
     void *	p_udata;
-#endif    
+#endif
     uint16_t    p_priority;     /* Process priority */
     struct __sigbits p_sig[2];
     uint16_t    p_waitno;       /* wait #; for finding longest waiting proc */


### PR DESCRIPTION
With this patch it is finally possible to see the process
name on the arm-based devices.
