### PR TITLE
trs80m1: build and link fixes

### DIFF
--- a/Kernel/lowlevel-z80-banked.s
+++ b/Kernel/lowlevel-z80-banked.s
@@ -1366,7 +1366,7 @@ _sys_cpu:
 _sys_cpu_feat:
 	.db 0
 
-	.area _DISCARD
+	.area _DISCARD2
 
 _set_cpu_type:
 	ld h,#2		; Assume Z80

--- a/Kernel/platform-trs80m1/config.h
+++ b/Kernel/platform-trs80m1/config.h
@@ -27,8 +27,10 @@
 /* And our buffer pool is dynamically sized */
 #define CONFIG_DYNAMIC_BUFPOOL
 /* And networking */
+/*
 #define CONFIG_NET
 #define CONFIG_NET_NATIVE
+*/
 /* And IDE */
 #define MAX_BLKDEV	2
 #define CONFIG_IDE

--- a/Kernel/platform-trs80m1/fuzix.lnk
+++ b/Kernel/platform-trs80m1/fuzix.lnk
@@ -29,6 +29,7 @@ platform-trs80m1/devstringy.rel
 platform-trs80m1/stringy.rel
 platform-trs80m1/devices.rel
 platform-trs80m1/buffers.rel
+network.rel
 platform-trs80m1/net_native.rel
 devio.rel
 filesys.rel

--- a/Standalone/util.c
+++ b/Standalone/util.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500	/* For swab in unistd.h */
+#define _XOPEN_SOURCE 700	/* For swab in unistd.h, strdup in string.h */
 
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
A number of small fixes needed to get the trs80m1 kernel to build and run successfully in the xtrs emulator. 

Alas, networking had to be disabled for this to work.

Kernel/lowlevel-z80-banked.s: Move `_set_cpu_type` to `DISCARD2` segment.
Fixes: Linker was previously locating `_set_cpu_type` in TRS-80 ROM space (around 0x0243). This caused an infinite loop when called from `_fuzix_main`.

Kernel/platform-trs80m1/config.h: Disable `CONFIG_NET` and `CONFIG_NET_NATIVE`
Fixes: With both these options enabled, the `DISCARD2` segment was pushed past address 0xFFFF.

Kernel/platform-trs80m1/fuzix.lnk: Add `network.rel` to module list
Fixes: With `CONFIG_NET` and `CONFIG_NET_NATIVE` enabled, `network.rel` is needed to link the kernel. If someone wants to re-enable those settings, they'll need `network.rel` to complete the build.

Standalone/util.c: Bump `_XOPEN_SOURCE` to 700
Fixes: missing definition for `strdup()` when building on MacOS. 

Tested on MacOS and Ubuntu 20.04 LTS.