### PR TITLE
network: several changes that finally made it possible to connect to remote hosts

### DIFF
--- a/Applications/netd/Makefile.armm4
+++ b/Applications/netd/Makefile.armm4
@@ -1,6 +1,6 @@
 ROOT = ../..
 include $(ROOT)/Applications/rules.armm4
-CFLAGS += -DNETD_LITTLE_ENDIAN
+CFLAGS += -DNETD_LITTLE_ENDIAN -DNETD_RINGBUF_IN_MEMORY
 
 SRCS  = netd.c eth.c slip.c uip.c uiplib.c timer.c clock-arch.c uip_arp.c telnet.c
 SRCS += echoping.c dig.c gethostbyname.c httpd.c coconic.c ping.c ntpdate.c

--- a/Applications/netd/netd.c
+++ b/Applications/netd/netd.c
@@ -430,7 +430,7 @@ void netd_udp_appcall(void)
 		char *ptr = uip_appdata;
 		uint32_t base = ne.socket * RINGSIZ * 2;
 
-		if ( (s->rend + 1)&(NSOCKBUF-1) == s->rstart )
+		if ( ((s->rend + 1)&(NSOCKBUF-1)) == s->rstart )
 			return; /* full - drop it */
 		s->rsize[s->rend] = len;
 		memcpy( &ne.info, s->rsize, sizeof(uint16_t) * NSOCKBUF );
@@ -495,7 +495,7 @@ void netd_raw_appcall(void)
 		char *ptr = uip_appdata;
 		uint32_t base = ne.socket * RINGSIZ * 2;
 
-		if ( (s->rend + 1)&(NSOCKBUF-1) == s->rstart )
+		if ( ((s->rend + 1)&(NSOCKBUF-1)) == s->rstart )
 			return; /* full - drop it */
 		s->rsize[s->rend] = len;
 		memcpy( &ne.info, s->rsize, sizeof(uint16_t) * NSOCKBUF );
@@ -660,7 +660,7 @@ int dokernel( void )
 			int last;
 			m->tstart = sm.sd.tbuf;
 			m->tend = sm.sd.tnext;
-			last = m->tend-1 & NSOCKBUF-1;
+			last = (m->tend-1) & (NSOCKBUF-1);
 			/* tsize is for udp only, but copy it anyway */
 			m->tsize[last] = sm.sd.tlen[last];
 		}

--- a/Applications/netd/netd.c
+++ b/Applications/netd/netd.c
@@ -23,7 +23,7 @@ todo:
 * refactor  RAW with UDP code as they are very similar
 
 */
-#define TRACE
+#undef TRACE
 
 
 #include <stdio.h>
@@ -574,7 +574,9 @@ int dokernel( void )
 #endif
 		m = & map[sm.sd.lcn];
 		c = m->conn - uip_conns;
-		printf("Connection %d\n", c);
+#ifdef TRACE
+		   fprintf(stderr, "Connection %d\n", c);
+#endif
 
 		if ( sm.sd.event & NEV_STATE ){
 			ne.socket = sm.s.s_num;

--- a/Applications/netd/netd.c
+++ b/Applications/netd/netd.c
@@ -649,6 +649,7 @@ int dokernel( void )
 					}
 					m->conn = ( struct uip_conn *)conptr; /* fixme: needed? */
 					conptr->appstate = sm.sd.lcn;
+					conptr->proto = sm.s.s_protocol;
 					/* refactor: same as tcp action from connect event */
 					ne.data = SS_CONNECTED;
 					ksend(NE_NEWSTATE);

--- a/Applications/rules.armm4
+++ b/Applications/rules.armm4
@@ -5,6 +5,7 @@ AR = arm-none-eabi-ar
 STRIP = arm-none-eabi-strip
 LINKER = arm-none-eabi-ld
 CFLAGS = -mcpu=cortex-m4 -mtune=cortex-m4 -march=armv7e-m+nofp -mthumb -fpie -DPIE -ffunction-sections -fdata-sections -fno-strict-aliasing -fno-builtin -Wall -g -Os -isystem $(ROOT)/Library/include -isystem $(ROOT)/Library/include/armm4
+CFLAGS += -DNSOCKET=4
 
 LINKER_OPT = -L$(ROOT)/Library/libs -lc$(PLATFORM) -pie -static -no-dynamic-linker -z max-page-size=4
 LIBGCCDIR = $(dir $(shell $(CC) $(CFLAGS) -print-libgcc-file-name))

--- a/Kernel/cpu-armm4/rules.mk
+++ b/Kernel/cpu-armm4/rules.mk
@@ -1,6 +1,6 @@
 export CROSS_LD=arm-none-eabi-ld
 export CROSS_CC=arm-none-eabi-gcc
-export CROSS_CCOPTS=-g -c -Os -fno-strict-aliasing -fno-builtin -Wall -mcpu=cortex-m4 -mtune=cortex-m4 -march=armv7e-m+nofp -mthumb -I$(ROOT_DIR)/cpu-armm4 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include -I$(FUZIX_ROOT)/Library/include/armm4
+export CROSS_CCOPTS=-g -c -Os -fno-strict-aliasing -fno-builtin -Wall -mcpu=cortex-m4 -mtune=cortex-m4 -march=armv7e-m+nofp -mthumb -I$(ROOT_DIR)/cpu-armm4 -I$(ROOT_DIR)/platform-$(TARGET) -I$(ROOT_DIR)/include -I$(FUZIX_ROOT)/Library/include/armm4 -DNSOCKET=4
 export CROSS_AS=$(CROSS_CC)
 export CROSS_CC_SEG1=
 export CROSS_CC_SEG2=

--- a/Kernel/dev/net/net_native.c
+++ b/Kernel/dev/net/net_native.c
@@ -44,9 +44,9 @@ struct socktype {
 };
 
 static struct socktype socktype[] = {
-	{ AF_INET, SOCK_STREAM, IPPROTO_TCP, SOCKTYPE_TCP },
-	{ AF_INET, SOCK_DGRAM,  IPPROTO_UDP, SOCKTYPE_UDP },
-	{ AF_INET, SOCK_DGRAM,  IPPROTO_UDP, SOCKTYPE_RAW },
+	{ AF_INET, SOCK_STREAM, IPPROTO_TCP,  SOCKTYPE_TCP },
+	{ AF_INET, SOCK_DGRAM,  IPPROTO_UDP,  SOCKTYPE_UDP },
+	{ AF_INET, SOCK_RAW,    IPPROTO_ICMP, SOCKTYPE_RAW },
 	{ 0U, 0U, 0U, 0U }
 };
 
@@ -602,6 +602,7 @@ int netproto_find_local(struct ksockaddr *ka)
  */
 int netproto_autobind(struct socket *s)
 {
+	memcpy(&s->dst_addr, &udata.u_net.addrbuf, sizeof(struct ksockaddr));
 	return netn_synchronous_event(s, SS_BOUND);
 }
 
@@ -614,6 +615,7 @@ int netproto_autobind(struct socket *s)
  */
 int netproto_bind(struct socket *s)
 {
+	memcpy(&s->dst_addr, &udata.u_net.addrbuf, sizeof(struct ksockaddr));
 	return netn_synchronous_event(s, SS_BOUND);
 }
 

--- a/Kernel/include/net_native.h
+++ b/Kernel/include/net_native.h
@@ -68,12 +68,13 @@ struct netevent {
 	} info;
 };
 
-#define NET_INIT	0x4401
-#define NET_MAC		0x4402
-#define NET_MTU		0x4403
-#define NET_IPADDR	0x4404
-#define NET_MASK	0x4405
-#define NET_GATEWAY	0x4406
+#define NET_INIT_BFD	0x4401
+#define NET_INIT_BMEM	0x4402
+#define NET_MAC		0x4403
+#define NET_MTU		0x4404
+#define NET_IPADDR	0x4405
+#define NET_MASK	0x4406
+#define NET_GATEWAY	0x4407
 
 int netdev_write(uint8_t flag);
 int netdev_read(uint8_t flag);

--- a/Kernel/syscall_net.c
+++ b/Kernel/syscall_net.c
@@ -136,7 +136,7 @@ arg_t _netcall(void)
 {
 	uint8_t flags = 0;
 	uint8_t cn;
-	arg_t *ap = udata.u_net.args;
+	arg_t *ap;
 	uint8_t op;
 	usize_t s;
 	int n;
@@ -148,6 +148,7 @@ arg_t _netcall(void)
 		return -1;
 	}
 	uget(argptr, udata.u_net.args, sizeof(udata.u_net.args));
+	ap = udata.u_net.args;
 
 	cn = *ap++;
 	op = ncall_tab[cn];

--- a/Library/include/sys/net_native.h
+++ b/Library/include/sys/net_native.h
@@ -68,12 +68,13 @@ struct netevent {
 	} info;
 };
 
-#define NET_INIT	0x4401
-#define NET_MAC		0x4402
-#define NET_MTU		0x4403
-#define NET_IPADDR	0x4404
-#define NET_MASK	0x4405
-#define NET_GATEWAY	0x4406
+#define NET_INIT_BFD	0x4401
+#define NET_INIT_BMEM	0x4402
+#define NET_MAC		0x4403
+#define NET_MTU		0x4404
+#define NET_IPADDR	0x4405
+#define NET_MASK	0x4406
+#define NET_GATEWAY	0x4407
 
 int netdev_write(void);
 int netdev_read(uint8_t flag);


### PR DESCRIPTION
As connect() was never terminating, I looked at it and found several problems. Now connections are established and data can be transferred. Also emitting ICMP packets is fixed now so the remote hosts can be finally pinged.

A huge benefit from implementing in-memory ringbuf: netd-eth can now be started on read-only filesystems. The number of available sockets had to be halved though. Normally, 64k buffer would have to be allocated. Turned out, malloc() crashed for allocations larger than 4k, and a binary with a buffer larger than 32k in data segment cannot be loaded (it says it's too big to load).

Some issues are still remaining, for example:
1. httpd - listen() does not seem to work
2. ping `req=` shows suspicious values
3. telnet prints some trash after connecting to remote hosts; yet it works properly after that.
