### PR TITLE
Fix some accumulated bitrot on the rpipico port.

### DIFF
--- a/Kernel/cpu-armm0/cpu.h
+++ b/Kernel/cpu-armm0/cpu.h
@@ -74,3 +74,6 @@ extern void copy_blocks(void *, void *, unsigned int);
 extern void swap_blocks(void *, void *, unsigned int);
 
 #define NORETURN __attribute__((__noreturn__))
+#undef __fastcall
+#define __fastcall /* nothing */
+

--- a/Kernel/include/elf.h
+++ b/Kernel/include/elf.h
@@ -483,6 +483,6 @@ struct elf_args {
 #define R_68K_GOT16O	11
 #define R_68K_GOT8O	12
 
-extern int platform_relocate_rel(Elf32_Rel* rel, uaddr_t section_base);
+extern int plt_relocate_rel(Elf32_Rel* rel, uaddr_t section_base);
 
 #endif /* _SYS_ELF_H_ */

--- a/Kernel/malloc.c
+++ b/Kernel/malloc.c
@@ -112,7 +112,7 @@ void *kmalloc(size_t size, uint8_t owner)
 	struct block *b;
 
 	used(owner);	/* For now */
-	size = ALIGNUP(size) + sizeof(struct block);
+	size = (size_t)ALIGNUP(size) + sizeof(struct block);
 	b = find_smallest(size);
 	if (!b)
 		return NULL;

--- a/Kernel/platform-rpipico/CMakeLists.txt
+++ b/Kernel/platform-rpipico/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(fuzix
 	tricks.S
 	core1.c
 	usbdescriptors.c
+	usermem.c
 	../dev/blkdev.c
 	../dev/mbr.c
 	../dev/devsd_discard.c
@@ -39,6 +40,7 @@ add_executable(fuzix
 	../lib/dhara/journal.c
 	../lib/dhara/map.c
 	../lib/hexdump.c
+	../blk512.c
 	../devio.c
 	../devsys.c
 	../filesys.c

--- a/Kernel/platform-rpipico/config.h
+++ b/Kernel/platform-rpipico/config.h
@@ -28,7 +28,6 @@
 #define CONFIG_PLATFORM_BRK
 
 #define CONFIG_32BIT
-#define CONFIG_USERMEM_DIRECT
 /* Serial TTY, no VT or font */
 #undef CONFIG_VT
 #undef CONFIG_FONT8X8

--- a/Kernel/platform-rpipico/tricks.S
+++ b/Kernel/platform-rpipico/tricks.S
@@ -204,5 +204,21 @@ dofork:
     mov r12, r5
     pop {r5, r6, r7, pc}
 
+.global _ugetc
+_ugetc:
+    b ugetc
+
+.global _uputc
+_uputc:
+    b uputc
+
+.global _uget
+_uget:
+    b uget
+
+.global _uput
+_uput:
+    b uput
+
 // vim: sw=4 ts=4 et:
 

--- a/Kernel/platform-rpipico/usermem.c
+++ b/Kernel/platform-rpipico/usermem.c
@@ -1,0 +1,61 @@
+#include <kernel.h>
+#include <kdata.h>
+#include <printf.h>
+
+
+int uget(const void* user, void* dest, usize_t count)
+{
+	memcpy(dest, user, count);
+	return 0;
+}
+
+int uput(const void* source, void* user, usize_t count)
+{
+	memcpy(user, source, count);
+	return 0;
+}
+
+int16_t ugetc(const void* user)
+{
+	return *(uint8_t*)user;
+}
+
+uint16_t ugetw(const void* user)
+{
+	uint16_t tmp;
+	uget(user, &tmp, 2);
+	return tmp;
+}
+
+uint32_t ugetl(void* user, int* err)
+{
+	uint32_t tmp;
+	uget(user, &tmp, 4);
+	err = 0;
+	return tmp;
+}
+
+int uputc(uint16_t value, void* user)
+{
+	*(uint8_t*)user = value;
+	return 0;
+}
+
+int uputw(uint16_t value, void* user)
+{
+	memcpy(user, &value, 2);
+	return 0;
+}
+
+int uputl(uint32_t value, void* user)
+{
+	memcpy(user, &value, 4);
+	return 0;
+}
+
+int uzero(void* user, usize_t count)
+{
+	memset(user, 0, count);
+	return 0;
+}
+

--- a/Kernel/syscall_exec.c
+++ b/Kernel/syscall_exec.c
@@ -36,7 +36,7 @@ bool rargs(uint8_t **userspace_argv, struct s_argblk * argbuf)
 		while (c);
 	}
 	argbuf->a_arglen = bufp - (uint8_t *)argbuf->a_buf;	/* Store total string size. */
-	argbuf->a_arglen = ALIGNUP(argbuf->a_arglen);
+	argbuf->a_arglen = (size_t)ALIGNUP(argbuf->a_arglen);
 	return false;		// success
 }
 

--- a/Kernel/syscall_execelf32.c
+++ b/Kernel/syscall_execelf32.c
@@ -40,8 +40,8 @@ char *argv[];
 char *envp[];
 ********************************************/
 #define name (uint8_t *)udata.u_argn
-#define argv (char **)udata.u_argn1
-#define envp (char **)udata.u_argn2
+#define argv (uint8_t **)udata.u_argn1
+#define envp (uint8_t **)udata.u_argn2
 
 arg_t _execve(void)
 {
@@ -326,8 +326,8 @@ arg_t _execve(void)
 	/* Write back the arguments and environment. */
 
 	int argc;
-	char** nargv = wargs(((char *) stacktop - sizeof(uaddr_t)), abuf, &argc);
-	char** nenvp = wargs((char *) (nargv), ebuf, NULL);
+	uint8_t** nargv = wargs(((char *) stacktop - sizeof(uaddr_t)), abuf, &argc);
+	uint8_t** nenvp = wargs((char *) (nargv), ebuf, NULL);
 
 	/* Fill in udata.u_name with program invocation name. */
 


### PR DESCRIPTION
There was a pile of small issues which were preventing the Pico port from building. The biggest one (apart from the new source files) is the change in configuration in the USERMEM macros. I couldn't find a standard setting which worked --- `CONFIG_USERMEM_DIRECT` now only works on systems with no memory alignment requirements --- so I thought it simplest just to do a platform-specific `usermem.c`.

This now successfully boots an old userland I had lying around. It does not boot a current userland. I'll investigate that and try and find out what's wrong in another PR.

It also fixes some warnings.