### PR TITLE
Try rolling forward the change needed for stack-below-heap again.

### DIFF
--- a/Applications/V7/cmd/sh/blok.c
+++ b/Applications/V7/cmd/sh/blok.c
@@ -132,7 +132,7 @@ void sh_free(void *ap)
 {
 	BLKPTR p = ap;
 
-	if (p && p < bloktop) {
+	if (p && p >= (BLKPTR)end && p < bloktop) {
 	        /* Step back from data to header */
 	        p--;
 	        /* Clear the busy bit */


### PR DESCRIPTION
I'd like to try this again --- it's needed for any platform with stack-below-heap, such as the Pico. This is useful for making minimal process sizes work, which is needed on the Pico to let it run swapless. (I'm also looking at doing this on the ESP8266, but that's more difficult due to the exotic memory layout.)

I remember you saying that you reverted it due to this breaking some of the other platforms. I've tried this change on the Z80 (the trs80 platform) and it seemed fine there, so I'm wondering whether the problem was something else. Do you recall any specific platforms that were broken that I should try with?