### PR TITLE
Mods for RP2040 with alternative SD-Card pinning, and keeping kernel at build address for debugging

### DIFF
--- a/Kernel/platform-rpipico/CMakeLists.txt
+++ b/Kernel/platform-rpipico/CMakeLists.txt
@@ -5,8 +5,21 @@ include(pico_sdk_import.cmake)
 
 project(fuzix C CXX ASM)
 set(CMAKE_C_STANDARD 11)
+
+# Do not enable this, leave the build type to be Debug, and assume that the
+# conditional below is a placeholder: it is referred to in config.h and
+# devices.c. MarkMLl.
+
+# set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+
 set(CMAKE_BUILD_TYPE Debug)
-set(PICO_COPY_TO_RAM 1)
+
+# Needs fixing: HAS_ONBOARD_FLASH_DRIVE should be passed to Makefile. MarkMLl
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    set(PICO_COPY_TO_RAM 1)
+    set(HAS_ONBOARD_FLASH_DRIVE 1)
+endif()
 
 pico_sdk_init()
 

--- a/Kernel/platform-rpipico/config.h
+++ b/Kernel/platform-rpipico/config.h
@@ -19,8 +19,10 @@
 /* Enable single tasking */
 #define CONFIG_SWAP_ONLY
 #define CONFIG_SPLIT_UDATA
-/* Enable SD card code. */
+/* Enable SD card code (defaulting to MISO 12, CS 13, SCK 14, MOSI 15). */
 #define CONFIG_SD
+/* Alternative pin allocation for Cytron Maker Pi Pico (MISO 12, CS 15, SCK 10, MOSI 11). */
+#define CONFIG_SD_ALT
 #define SD_DRIVE_COUNT 1
 /* Enable dynamic swap. */
 #define CONFIG_PLATFORM_SWAPCTL
@@ -60,7 +62,17 @@ extern uint8_t progbase[USERMEM];
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL	  /* Location of root dev name */
 
-#define BOOTDEVICE 0x0000 /* hda */
+#ifdef HAS_ONBOARD_FLASH_DRIVE
+    #define BOOTDEVICE 0x0012 /* hdb2 */
+#else
+    #define BOOTDEVICE 0x0002 /* hda2 */
+#endif
+
+// THIS SETTING NEEDS TO BE PROPERLY INTEGRATED WITH THE CMAKE BUILDFILE ETC. MarkMLl
+
+#undef BOOTDEVICE
+#define BOOTDEVICE 0x0012
+
 #define SWAPDEV    (swap_dev) /* dynamic swap */
 
 /* Device parameters */

--- a/Kernel/platform-rpipico/devsdspi.c
+++ b/Kernel/platform-rpipico/devsdspi.c
@@ -14,12 +14,31 @@
 void sd_rawinit(void)
 {
 
+#ifndef CONFIG_SD_ALT
+
+// This is the standard pinning as per David Given's prototype.
+
     gpio_init_mask(0xf << 12);
-    gpio_set_function(12, GPIO_FUNC_SPI);
-    gpio_set_function(13, GPIO_FUNC_SIO);
-    gpio_set_function(14, GPIO_FUNC_SPI);
-    gpio_set_function(15, GPIO_FUNC_SPI);
-    gpio_set_dir(13, true);
+    gpio_set_function(12, GPIO_FUNC_SPI); // MISO
+    gpio_set_function(13, GPIO_FUNC_SIO); // CS
+    gpio_set_function(14, GPIO_FUNC_SPI); // SCK
+    gpio_set_function(15, GPIO_FUNC_SPI); // MOSI
+  #define SDCARD_CS_GP 13
+    gpio_set_dir(SDCARD_CS_GP, true);
+
+#else
+
+// Alternative pinning as per the Cytron Maker Pi Pico schematic from e.g.
+// https://www.electrokit.com/uploads/productfile/41018/MAKER-PI-PICO%20v1.2.0%20Schematic.pdf
+
+    gpio_init_mask(0x27 << 10);
+    gpio_set_function(10, GPIO_FUNC_SPI); // SCK
+    gpio_set_function(11, GPIO_FUNC_SPI); // MOSI
+    gpio_set_function(12, GPIO_FUNC_SPI); // MISO
+    gpio_set_function(15, GPIO_FUNC_SIO); // CS
+  #define SDCARD_CS_GP 15
+    gpio_set_dir(SDCARD_CS_GP, true);
+#endif
 
     spi_init(spi1, 250000);
     spi_set_format(spi1, 8, 0, 0, SPI_MSB_FIRST);
@@ -32,12 +51,12 @@ void sd_spi_clock(bool go_fast)
 
 void sd_spi_raise_cs(void)
 {
-    gpio_put(1<<13, true);
+    gpio_put(1<<SDCARD_CS_GP, true);
 }
 
 void sd_spi_lower_cs(void)
 {
-    gpio_put(1<<13, false);
+    gpio_put(1<<SDCARD_CS_GP, false);
 }
 
 void sd_spi_transmit_byte(uint_fast8_t b)

--- a/Kernel/start.c
+++ b/Kernel/start.c
@@ -354,8 +354,9 @@ void fuzix_main(void)
 			"Copyright (c) 1988-2002 by H.F.Bower, D.Braun, S.Nitschke, H.Peraza\n"
 			"Copyright (c) 1997-2001 by Arcady Schekochikhin, Adriano C. R. da Cunha\n"
 			"Copyright (c) 2013-2015 Will Sowerbutts <will@sowerbutts.com>\n"
-			"Copyright (c) 2014-2022 Alan Cox <alan@etchedpixels.co.uk>\nDevboot\n",
-			sysinfo.uname);
+			"Copyright (c) 2014-2021 Alan Cox <alan@etchedpixels.co.uk>\n"
+			"Built %s %s. Devboot\n",
+			sysinfo.uname, __DATE__, __TIME__);
 
 	set_cpu_type();
 	sysinfo.cpu[0] = sys_cpu_feat;


### PR DESCRIPTION
Please consider the attached as a tentative example. They are tested patches for an RP2040 running on a Cytron "Maker Pi Pico" board which use /dev/hdb2 on an externally-connected SD-Card as root, but they are not well integrated with the cmake build system more or less mandated by that platform.
