### PR TITLE
Cleaned up I/O-ports. 512KiB RAM, no ROM.

### DIFF
--- a/Kernel/platform-pz1/devtty.c
+++ b/Kernel/platform-pz1/devtty.c
@@ -37,12 +37,12 @@ void kputchar(uint8_t c)
 ttyready_t tty_writeready(uint8_t minor)
 {
 	if (minor == 1) {
-		if ((port_serial0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
+		if ((port_serial_0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
 			return TTY_READY_NOW;
 		else
 			return TTY_READY_SOON;
 	} else {
-		if ((port_serial0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
+		if ((port_serial_0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
 			return TTY_READY_NOW;
 		else
 			return TTY_READY_SOON;
@@ -52,13 +52,13 @@ ttyready_t tty_writeready(uint8_t minor)
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	if (minor == 1) {
-		while ((port_serial0_flags & SERIAL_FLAGS_OUT_FULL) != 0);
+		while ((port_serial_0_flags & SERIAL_FLAGS_OUT_FULL) != 0);
 		// do nothing
-		port_serial0_out = c;
+		port_serial_0_out = c;
 	} else {
-		while ((port_serial1_flags & SERIAL_FLAGS_OUT_FULL) != 0);
+		while ((port_serial_1_flags & SERIAL_FLAGS_OUT_FULL) != 0);
 		// do nothing
-		port_serial1_out = c;
+		port_serial_1_out = c;
 	}
 
 
@@ -84,8 +84,8 @@ void tty_data_consumed(uint8_t minor)
 
 void tty_poll(void)
 {
-	while (port_serial0_flags & SERIAL_FLAGS_IN_AVAIL)
-		tty_inproc(1, port_serial0_in);
-	while (port_serial1_flags & SERIAL_FLAGS_IN_AVAIL)
-		tty_inproc(2, port_serial1_in);
+	while (port_serial_0_flags & SERIAL_FLAGS_IN_AVAIL)
+		tty_inproc(1, port_serial_0_in);
+	while (port_serial_1_flags & SERIAL_FLAGS_IN_AVAIL)
+		tty_inproc(2, port_serial_1_in);
 }

--- a/Kernel/platform-pz1/main.c
+++ b/Kernel/platform-pz1/main.c
@@ -27,10 +27,10 @@ void do_beep(void)
 void pagemap_init(void)
 {
     int i;
-    /* Add the user banks, taking care to land 36 as the last one as we
-       use that for init  (32-35 are the kernel) */
+    /* Add the user banks, taking care to land 4 as the last one as we
+       use that for init (0/1/2/3 are the kernel) */
     for (i = 6; i >= 0; i--)
-        pagemap_add(36 + i * 4);
+        pagemap_add(4 + i * 4);
 }
 
 void map_init(void)

--- a/Kernel/platform-pz1/ports.def
+++ b/Kernel/platform-pz1/ports.def
@@ -3,21 +3,14 @@ PORT_BANK_1             .set $FE01
 PORT_BANK_2             .set $FE02
 PORT_BANK_3             .set $FE03
 
-PORT_SERIAL_FLAGS       .set $FE10 ; bit 7: out buffer full, bit 6: in-data available
-PORT_SERIAL_IN          .set $FE11
-PORT_SERIAL_OUT         .set $FE12
-PORT_DEBUG_FLAGS        .set $FE18 ; bit 7: out buffer full, bit 6: in-data available
-PORT_DEBUG_IN           .set $FE19
-PORT_DEBUG_OUT          .set $FE1A
+PORT_SERIAL_0_FLAGS     .set $FE10 ; bit 7: out buffer full, bit 6: in-data available
+PORT_SERIAL_0_IN        .set $FE11
+PORT_SERIAL_0_OUT       .set $FE12
+PORT_SERIAL_1_FLAGS     .set $FE18 ; bit 7: out buffer full, bit 6: in-data available
+PORT_SERIAL_1_IN        .set $FE19
+PORT_SERIAL_1_OUT       .set $FE1A
 SERIAL_FLAGS_OUT_FULL   .set   128
 SERIAL_FLAGS_IN_AVAIL   .set    64
-
-PORT_COUNTER_50HZ       .set $FE40
-PORT_COUNTER_60HZ       .set $FE41
-PORT_CPU_COUNTER_0      .set $FE48
-PORT_CPU_COUNTER_1      .set $FE49
-PORT_CPU_COUNTER_2      .set $FE4A
-PORT_CPU_COUNTER_3      .set $FE4B
 
 PORT_FILE_SYSTEM_CMD    .set $FE60
 PORT_FILE_SYSTEM_PRM_0  .set $FE61

--- a/Kernel/platform-pz1/ports.h
+++ b/Kernel/platform-pz1/ports.h
@@ -1,11 +1,14 @@
-#define port_serial0_flags           (*(volatile uint8_t *)0xFE10)
-#define port_serial0_in              (*(volatile uint8_t *)0xFE11)
-#define port_serial0_out             (*(volatile uint8_t *)0xFE12)
+#define port_bank_0                 (*(volatile uint8_t *)0xFE00)
+#define port_bank_1                 (*(volatile uint8_t *)0xFE01)
+#define port_bank_2                 (*(volatile uint8_t *)0xFE02)
+#define port_bank_3                 (*(volatile uint8_t *)0xFE03)
 
-#define port_serial1_flags           (*(volatile uint8_t *)0xFE18)
-#define port_serial1_in              (*(volatile uint8_t *)0xFE19)
-#define port_serial1_out             (*(volatile uint8_t *)0xFE1A)
-
+#define port_serial_0_flags         (*(volatile uint8_t *)0xFE10)
+#define port_serial_0_in            (*(volatile uint8_t *)0xFE11)
+#define port_serial_0_out           (*(volatile uint8_t *)0xFE12)
+#define port_serial_1_flags         (*(volatile uint8_t *)0xFE18)
+#define port_serial_1_in            (*(volatile uint8_t *)0xFE19)
+#define port_serial_1_out           (*(volatile uint8_t *)0xFE1A)
 #define SERIAL_FLAGS_OUT_FULL       128
 #define SERIAL_FLAGS_IN_AVAIL       64
 
@@ -20,4 +23,8 @@
 #define FS_STATUS_NOK               1
 
 #define port_irq_timer_target       (*(volatile uint8_t *)0xFE80)
+#define port_irq_timer_count        (*(volatile uint8_t *)0xFE81)
 #define port_irq_timer_reset        (*(volatile uint8_t *)0xFE82)
+#define port_irq_timer_trig         (*(volatile uint8_t *)0xFE83)
+#define port_irq_timer_pause        (*(volatile uint8_t *)0xFE84)
+#define port_irq_timer_cont         (*(volatile uint8_t *)0xFE85)

--- a/Kernel/platform-pz1/pz1.s
+++ b/Kernel/platform-pz1/pz1.s
@@ -70,7 +70,7 @@ _plt_reboot:
 	    jmp _plt_reboot	; We don't restore the data/bss so can't
 				; restart
 
-	    lda #35
+	    lda #3
 	    sta PORT_BANK_3		; top 16K to ROM 0
 	    jmp ($FFFC)
 
@@ -99,10 +99,10 @@ irq_on:
 
 init_early:
 	    ; Hack for now - create a common copy for init. We should then
-	    ; recycle page 32 into a final process but that means awkward
+	    ; recycle page 0 into a final process but that means awkward
 	    ; handling - or does it - we wrap the bit ?? FIXME
 	    jsr _create_init_common
-	    lda #36
+	    lda #4
 	    sta PORT_BANK_0		; set low page to copy
             rts			; stack was copied so this is ok
 
@@ -201,7 +201,7 @@ map_process:
 	    bne map_process_2
 ;
 ;	Map in the kernel below the current common, all registers preserved
-;	the kernel lives in 32/33/34/35
+;	the kernel lives in 0/1/2/3
 ;	Later we'll be clever and stuff _DISCARD and the copy blocks there or
 ;	something (that would also let us put RODATA in
 ;	common area just to balance out memory usages).
@@ -211,7 +211,7 @@ map_kernel:
 	    txa
 	    pha
 				; Common is left untouched as is ZP and S
-	    ldx #$20		; Kernel RAM
+	    ldx #0		; Kernel RAM
 	    jsr map_bank_i
 	    pla
 	    tax
@@ -291,11 +291,11 @@ saved_map:  .byte 0
 outchar:
 	    pha
 outcharw:
-	    lda PORT_SERIAL_FLAGS
+	    lda PORT_SERIAL_0_FLAGS
             and #SERIAL_FLAGS_OUT_FULL
             bne outcharw
             pla
-            sta PORT_SERIAL_OUT
+            sta PORT_SERIAL_0_OUT
             rts
 
 ;

--- a/Kernel/platform-pz1/tricks.s
+++ b/Kernel/platform-pz1/tricks.s
@@ -336,9 +336,9 @@ copy1:
 	rts
 
 _create_init_common:
-	lda #32
+	lda #0
 	sta PORT_BANK_1		;	set the map for 0x4000
-	lda #36
+	lda #4
 	sta PORT_BANK_2		;	and 0x8000
 	jsr bank2bank
 	jmp map_kernel


### PR DESCRIPTION
These fixes and the latest addition to the pull request in RC2014 belong together to form the almost proper PZ1 emulation and real HW Fuzix environment.