### PR TITLE
Pointer reassignment bug in floppy driver

### DIFF
--- a/Kernel/dev/devfd_hw-banked.s
+++ b/Kernel/dev/devfd_hw-banked.s
@@ -478,7 +478,8 @@ FdcNotDn:
 ;
 ; Enter : None
 ; Return: None
-; Uses  : HL.  Remaining Registers Preserved/Not Affected
+; Uses  : HL.
+;         AF, BC, DE, IY guaranteed to be preserved. Note external call.
 
 Motor:  PUSH    AF              ; Save Regs
         PUSH    BC
@@ -515,11 +516,13 @@ MtrSet: ; now B contains the relevant motor bit we need to be set in the FDC DOR
 ;	#2 The timers are set in 1/20ths but it's not clear everyone is
 ;	using 1/20ths for the IRQ call (See p112)
 ;
-MotoLp:	PUSH	DE
+MotoLp:	PUSH	IY
+	PUSH	DE
 	PUSH	AF
 	CALL	_plt_idle
 	POP	AF
 	POP	DE
+	POP	IY
 	LD      A,(mtm)         ;  ..otherwise, loop never times out!
         OR      A               ; Up to Speed?
         JR      NZ,MotoLp       ; ..loop if Not

--- a/Kernel/dev/devfd_hw.s
+++ b/Kernel/dev/devfd_hw.s
@@ -468,7 +468,8 @@ FdcNotDn:
 ;
 ; Enter : None
 ; Return: None
-; Uses  : HL.  Remaining Registers Preserved/Not Affected
+; Uses  : HL.
+;         AF, BC, DE, IY guaranteed to be preserved. Note external call.
 
 Motor:  PUSH    AF              ; Save Regs
         PUSH    BC
@@ -505,9 +506,11 @@ MtrSet: ; now B contains the relevant motor bit we need to be set in the FDC DOR
 ;	#2 The timers are set in 1/20ths but it's not clear everyone is
 ;	using 1/20ths for the IRQ call (See p112)
 ;
-MotoLp:	PUSH	DE
+MotoLp:	PUSH	IY
+	PUSH	DE
 	CALL	_plt_idle
 	POP	DE
+	POP	IY
 	LD      A,(mtm)         ;  ..otherwise, loop never times out!
         OR      A               ; Up to Speed?
         JR      NZ,MotoLp       ; ..loop if Not


### PR DESCRIPTION
When _devfd_init is called, GetPrm stores the drive table pointer in IY.
Eventually, Motor is called via Recal -> FdCmd -> Motor. All along it is assumed that IY is unchanged.
Within Motor, external function _plt_idle is called. For platform-rc2014, at least, the first thing that _plt_idle does is change IY to #_timer_source.
_devfd_init writes the value 1 to (IY) but coincidentally #_timer_source is often set to 1 so this bug does not cause crashes in most systems.