### PR TITLE
Fix clock divider and print actual clock frequency on SC111

### DIFF
--- a/Kernel/platform-sc111/discard.c
+++ b/Kernel/platform-sc111/discard.c
@@ -20,9 +20,13 @@ void init_hardware_c(void)
     Z180_DCNTL |= 0xF0;		/* Force slow as possible, then mod back */
     Z180_DCNTL &= 0xBF;		/* 2 wait memory, 4 on I/O */
     Z180_RCR &= 0x7F;		/* No DRAM, kill refresh */
-    Z180_CCR &= 0x7F;		/* Clock divider off */
+    Z180_CCR |= 0x80;		/* Clock divider off */
+    Z180_CMR &= 0x7F;		/* Clock doubler off */
+    if (Z180_CMR & 0x80)
+        kputs("no clock doubler, 18.4MHz.\n");
+    else
+        kputs("turbo engaged, 36.8MHz.\n");
     Z180_CMR |= 0x80;		/* Clock doubler on */
-    kputs("turbo engaged, 36.8MHz.\n");
 }
 
 void pagemap_init(void)


### PR DESCRIPTION
CCR bit 8 needs to be set to switch the clock divider off according to the documentation. Verified by measuring PHI output frequency.

Z8S180-K has no clock doubler and CMR bit 8 is always 1. With that, try to detect missing clock doubler and print the clock frequency accordingly.

Before adding this fix, the clock speed was reduced to 9.2 MHz on my REV K Z180 and the serial port did run with 57600 bit/s instead of 115200. On a Z180 REV N with clock doubler, there may be a similar effect after adding this patch, it may speed up to 230400 bit/s. Just something to keep in mind when there's garbage on the serial port. I don't have a REV N to test with.