### PR TITLE
Fix dc

### DIFF
--- a/Applications/V7/cmd/dc.c
+++ b/Applications/V7/cmd/dc.c
@@ -2039,7 +2039,7 @@ void more(struct blk *hptr)
 	if ((size = (hptr->last - hptr->beg) * 2) == 0)
 		size = 1;
 	nbytes += size / 2;
-	free(hptr->beg);
+
 	p = realloc(hptr->beg, (unsigned) size);
 	if (p == 0) {
 		hptr->beg =


### PR DESCRIPTION
`hptr->beg` is freed just before being reallocated which can lead to a segfault (double free later). I have only tested this with esp8266 and it currently fixes https://github.com/EtchedPixels/FUZIX/issues/928 (maybe also https://github.com/EtchedPixels/FUZIX/issues/856 but I can't test due to lack of hardware).