### PR TITLE
sc111: fix undefined reference to ds1302_init

### DIFF
--- a/Kernel/platform-sc111/discard.c
+++ b/Kernel/platform-sc111/discard.c
@@ -39,9 +39,11 @@ void pagemap_init(void)
      * Page size is 4KB. */
     for(i = 0x90; i < (1024 >> 2); i += 0x10)
         pagemap_add(i);
+#ifdef CONFIG_RTC_DS1302
     ds1302_init();
     if (ds1302_present)
         kputs("DS1302 detected at 0xC0.\n");
+#endif
 }
 
 void map_init(void)


### PR DESCRIPTION
By default, CONFIG_RTC_DS1302 is not defined for SC111, resulting in undefined reference to ds1302_init.