### PR TITLE
sc126: fix wiznet polling

### DIFF
--- a/Kernel/platform-sc126/main.c
+++ b/Kernel/platform-sc126/main.c
@@ -81,7 +81,7 @@ void plt_interrupt(void)
 	switch (irqvector) {
 	case Z180_INT_TIMER0:
 		z180_timer_interrupt();
-#ifdef CONFIG_NET_W5X00		
+#ifdef CONFIG_NET_WIZNET
 		w5x00_poll();
 #endif		
 		return;


### PR DESCRIPTION
CONFIG_NET_W5X00 isn't defined and no data flow is possible without polling.

Fix this by checking if CONFIG_NET_WIZNET is defined instead like on other platforms.