### PR TITLE
sc111: switch I/O base to 0xC0

### DIFF
--- a/Kernel/platform-sc111/config.h
+++ b/Kernel/platform-sc111/config.h
@@ -35,7 +35,7 @@
 #define NMOUNTS	 4	  /* Number of mounts at a time */
 
 /* Hardware parameters : internal hardware at 0x40-0x7F */
-#define Z180_IO_BASE       0x40
+#define Z180_IO_BASE       0xC0
 
 #define MAX_BLKDEV 2	    /* 2 IDE drives */
 

--- a/Kernel/platform-sc111/kernel.def
+++ b/Kernel/platform-sc111/kernel.def
@@ -8,7 +8,7 @@ OS_BANK                     .equ 0x00         ; value from include/kernel.h
 
 ; Memory layout
 FIRST_RAM_BANK              .equ 0x80         ; low 512K of physical memory is ROM/ECB window.
-Z180_IO_BASE                .equ 0x40
+Z180_IO_BASE                .equ 0xC0
 
 ; No standard clock speed for the Mark IV board, but this is a common choice.
 USE_FANCY_MONITOR           .equ 1            ; disabling this saves around approx 0.5KB


### PR DESCRIPTION
This primarily affects the SCM Fuzix loader, as it needs to know the current I/O base in order to work correctly. If there is a mismatch, Fuzix won't boot without any output on serial console.

With version 1.3.0 (2022-02-28), SCM switched from I/O base 0x40 to 0xC0. This change will make the SCM loader work on newer systems. Systems with SCM older than 1.3.0 will need this change reverted.

The RomWBW loader is not affected as RomWBW did always use I/O base 0xC0 on SC111 and the loader uses that knowledge to switch the I/O base if needed.
