### PR TITLE
devtty: ASCI odd parity flag is bit 4, not value 4

### DIFF
--- a/Kernel/platform-n8/devtty.c
+++ b/Kernel/platform-n8/devtty.c
@@ -96,7 +96,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
 	if (cflag & PARENB) {
 		cntla |= 2;
 		if (cflag & PARODD)
-			cntlb |= 4;
+			cntlb |= 0x10;
 	}
 	if ((cflag & CSIZE) == CS8)
 		cntla |= 4;

--- a/Kernel/platform-rc2014/devtty.c
+++ b/Kernel/platform-rc2014/devtty.c
@@ -779,7 +779,7 @@ static void asci_setup(uint_fast8_t minor)
     if (cflag & PARENB) {
         cntla |= 2;
         if (cflag & PARODD)
-            cntlb |= 4;
+            cntlb |= 0x10;
     }
     if ((cflag & CSIZE) == CS8)
         cntla |= 4;

--- a/Kernel/platform-rhyophyre/devtty.c
+++ b/Kernel/platform-rhyophyre/devtty.c
@@ -62,7 +62,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
 	if (cflag & PARENB) {
 		cntla |= 2;
 		if (cflag & PARODD)
-			cntlb |= 4;
+			cntlb |= 0x10;
 	}
 	if ((cflag & CSIZE) == CS8)
 		cntla |= 4;

--- a/Kernel/platform-sc111/devtty.c
+++ b/Kernel/platform-sc111/devtty.c
@@ -59,7 +59,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
     if (cflag & PARENB) {
         cntla |= 2;
         if (cflag & PARODD)
-            cntlb |= 4;
+            cntlb |= 0x10;
     }
     if ((cflag & CSIZE) == CS8)
         cntla |= 4;

--- a/Kernel/platform-sc126/devtty.c
+++ b/Kernel/platform-sc126/devtty.c
@@ -61,7 +61,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
 	if (cflag & PARENB) {
 		cntla |= 2;
 		if (cflag & PARODD)
-			cntlb |= 4;
+			cntlb |= 0x10;
 	}
 	if ((cflag & CSIZE) == CS8)
 		cntla |= 4;

--- a/Kernel/platform-scrumpel/devtty.c
+++ b/Kernel/platform-scrumpel/devtty.c
@@ -61,7 +61,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
     if (cflag & PARENB) {
         cntla |= 2;
         if (cflag & PARODD)
-            cntlb |= 4;
+            cntlb |= 0x10;
     }
     if ((cflag & CSIZE) == CS8)
         cntla |= 4;

--- a/Kernel/platform-z180itx/devtty.c
+++ b/Kernel/platform-z180itx/devtty.c
@@ -61,7 +61,7 @@ void tty_setup(uint_fast8_t minor, uint_fast8_t flags)
 	if (cflag & PARENB) {
 		cntla |= 2;
 		if (cflag & PARODD)
-			cntlb |= 4;
+			cntlb |= 0x10;
 	}
 	if ((cflag & CSIZE) == CS8)
 		cntla |= 4;


### PR DESCRIPTION
Bit 2 is one of the speed select bits instead of parity.

I could only test this on SC111, but some other platforms look sufficiently similar, so applying the fix there as well.