### PR TITLE
sc111: clear ASCI error flags after reading input characters

### DIFF
--- a/Kernel/platform-sc111/devtty.c
+++ b/Kernel/platform-sc111/devtty.c
@@ -115,12 +115,16 @@ void tty_pollirq_asci0(void)
 {
     while(ASCI_STAT0 & 0x80)
         tty_inproc(1, ASCI_RDR0);
+    if (ASCI_STAT0 & 0x70)
+        ASCI_CNTLA0 &= ~0x08;
 }
 
 void tty_pollirq_asci1(void)
 {
     while(ASCI_STAT1 & 0x80)
         tty_inproc(2, ASCI_RDR1);
+    if (ASCI_STAT1 & 0x70)
+        ASCI_CNTLA1 &= ~0x08;
 }
 
 /* FIXME: we should have a proper tty buffer output queue really */


### PR DESCRIPTION
This fixes a bug seen on Z8S180-K. When using GTKterm to paste a few characters to the serial port, the Fuzix system became unusable. Input data was still being processed and echo'ed back, but the wait pointer of the shell process got cleared and the tty driver would not deliver input data anymore. On further debugging, it turned out that the ASCI interrupt would trigger continuously with OVRN set and RDRF cleared when this happened.

Clearing errors by writing to EFR before exiting from the interrupt handler fixes the problem. According to the Z8S180 errata, clearing error flags might be a good idea on other CPU variants as well to prevent ASCI from stopping input processing after overrun.