### PR TITLE
devtty: fix backspace echo not working properly with ASCI

### DIFF
--- a/Kernel/platform-dyno/devtty.c
+++ b/Kernel/platform-dyno/devtty.c
@@ -132,9 +132,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
     switch(minor){
         case 1:
+            while(!(ASCI_STAT0 & 2));
             ASCI_TDR0 = c;
             break;
         case 2:
+            while(!(ASCI_STAT1 & 2));
             ASCI_TDR1 = c;
             break;
     }

--- a/Kernel/platform-rc2014/devtty.c
+++ b/Kernel/platform-rc2014/devtty.c
@@ -731,12 +731,14 @@ ttyready_t asci_writeready1(uint_fast8_t minor)
 static void asci_putc0(uint_fast8_t minor, uint_fast8_t c)
 {
 	used(minor);
+	while(!(ASCI_STAT0 & 2));
 	ASCI_TDR0 = c;
 }
 
 static void asci_putc1(uint_fast8_t minor, uint_fast8_t c)
 {
 	used(minor);
+	while(!(ASCI_STAT1 & 2));
 	ASCI_TDR1 = c;
 }
 

--- a/Kernel/platform-rcbus-z180/devtty.c
+++ b/Kernel/platform-rcbus-z180/devtty.c
@@ -134,9 +134,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
 	switch (minor) {
 	case 1:
+		while(!(ASCI_STAT0 & 2));
 		ASCI_TDR0 = c;
 		break;
 	case 2:
+		while(!(ASCI_STAT1 & 2));
 		ASCI_TDR1 = c;
 		break;
 	}

--- a/Kernel/platform-riz180/devtty.c
+++ b/Kernel/platform-riz180/devtty.c
@@ -178,9 +178,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
 	switch (minor) {
 	case 1:
+		while(!(ASCI_STAT0 & 2));
 		ASCI_TDR0 = c;
 		break;
 	case 2:
+		while(!(ASCI_STAT1 & 2));
 		ASCI_TDR1 = c;
 		break;
 	}

--- a/Kernel/platform-sc111/devtty.c
+++ b/Kernel/platform-sc111/devtty.c
@@ -132,9 +132,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
     switch(minor){
         case 1:
+            while(!(ASCI_STAT0 & 2));
             ASCI_TDR0 = c;
             break;
         case 2:
+            while(!(ASCI_STAT1 & 2));
             ASCI_TDR1 = c;
             break;
     }

--- a/Kernel/platform-scrumpel/devtty.c
+++ b/Kernel/platform-scrumpel/devtty.c
@@ -135,9 +135,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
     switch(minor){
         case 1:
+            while(!(ASCI_STAT0 & 2));
             ASCI_TDR0 = c;
             break;
         case 2:
+            while(!(ASCI_STAT1 & 2));
             ASCI_TDR1 = c;
             break;
     }

--- a/Kernel/platform-z180itx/devtty.c
+++ b/Kernel/platform-z180itx/devtty.c
@@ -134,9 +134,11 @@ void tty_putc(uint_fast8_t minor, uint_fast8_t c)
 {
 	switch (minor) {
 	case 1:
+		while(!(ASCI_STAT0 & 2));
 		ASCI_TDR0 = c;
 		break;
 	case 2:
+		while(!(ASCI_STAT1 & 2));
 		ASCI_TDR1 = c;
 		break;
 	}


### PR DESCRIPTION
When backspace is read from the serial line, tty_inproc() will echo this back as "\b \b". This happens in interrupt context, so tty_putc_maywait() will not call tty_writeready(). On SC111, the space character got dropped because ASCI was still transmitting the first \b character. So only "\b\b" was transmitted on the serial port.

This was revealed by commit a56be113 ("sc111: now we have boot parameters don't hardware turbo mode"), which moved the DCNTL setup into a boot option, keeping DCNTL at the RomWBW/SCM default of 0 memory wait states on SC111. A minimum of 2 memory wait states is required on my SC111 to slow the CPU down to give ASCI enough time to transmit subsequent characters sent via tty_putc().

The check for TDRE in ASCI_STAT before writing to ASCI_TDR is present on several platforms already. Adding the check to all platforms that don't have it yet.