### PR TITLE
sc111: fix PRT timer interrupt flag reset

### DIFF
--- a/Kernel/platform-sc111/main.c
+++ b/Kernel/platform-sc111/main.c
@@ -31,8 +31,8 @@ void z180_timer_interrupt(void)
     unsigned char a;
 
     /* we have to read both of these registers in order to reset the timer */
-    a = TIME_TMDR0L;
     a = TIME_TCR;
+    a = TIME_TMDR0L;
     timer_interrupt();
 }
 


### PR DESCRIPTION
To reset the timer interrupt, read TCR first and then TMDR0L. Otherwise, on Z8S180-K the timer interrupt triggers with double of the intended frequency.