### PR TITLE
dk-tm4c129x: fix linker error

### DIFF
--- a/Kernel/platform-dk-tm4c129x/Makefile
+++ b/Kernel/platform-dk-tm4c129x/Makefile
@@ -65,5 +65,5 @@ image:
 	../tty.o ../devsys.o ../usermem.o ../syscall_fs2.o \
 	../syscall_fs3.o ../syscall_exec.o ../syscall_exec32.o \
 	../syscall_level2.o ../level2.o ../select.o ../blk512.o \
-	../usermem_std-armm4.o ../vt.o ../malloc.o armrelocate.o \
+	../usermem_std-armm4.o ../vt.o ../malloc.o \
 	../font8x8.o >../fuzix.map


### PR DESCRIPTION
`LOBJ` are listed in `OBJS`, so there is no need to list `armrelocate.o` separately as it results in linker error:

```
Kernel/platform-dk-tm4c129x/../lib/armrelocate.c:10: multiple definition of `plt_relocate'; armrelocate.o:Kernel/platform-dk-tm4c129x/../lib/armrelocate.c:10: first defined here
```