### PR TITLE
Define msx2 segmentation rules (to fix hangs at boot and direct reads)

### DIFF
--- a/Kernel/platform-msx2/rules.mk
+++ b/Kernel/platform-msx2/rules.mk
@@ -1,0 +1,14 @@
+#
+export CROSS_CC_SEG1=--codeseg CODE2
+export CROSS_CC_SEG2=--codeseg CODE2
+export CROSS_CC_SEG3=--codeseg CODE
+export CROSS_CC_VIDEO=--codeseg VIDEO
+export CROSS_CC_FONT=--constseg FONT
+#
+export CROSS_CC_SYS1=--codeseg CODE
+export CROSS_CC_SYS2=--codeseg CODE
+export CROSS_CC_SYS3=--codeseg CODE2
+export CROSS_CC_SYS4=--codeseg CODE2
+export CROSS_CC_SYS5=--codeseg CODE
+export CROSS_CC_SEGDISC=--codeseg DISCARD
+


### PR DESCRIPTION
Hi Alan,

This is my first time contributing something on github!
I am an MSX retro-computing enthousiast and I have a fix for the MSX2 target ...

Your commit 83342ae244312ff662543fce74907aeb90de6e66 (msx2: sort out the memory maps and buffers) introduced direct read access to userspace and to support that feature it changed buffer locations, but also set the code segment for common code to CODE1 (iso COMMONMEM).  By itself this change crashed the MegaFlashROM SD card detection (as its code was spilling over into the bank that needs switching), but even when e.g. putting its code back in COMMONMEM then the inode code crashes for the same reason while performing direct reads.

So, after playing around a bit, I discovered that MSX1 has a rules.mk entry in its platform directory, defining the segmentation rules.  MSX2 did not have such a rules.mk.  After introducing it, based on the MSX1 one, but adapting its VIDEO and FONT segmentation to what is done in MSX2 (I hope), now everything is back to normal - well up to speed is probably a better expression, because the direct read shows off on the MSX TurboR in comparison with the last working commit b047efe617e419a07661a0aacf86571d27f019c9 (msx2: note work needed to fix the horrible I/O speed)!

Is this the way to go, and are the rules correct for MSX2?  I played around a bit with my build and had no crashes.  VI however seems to misbehave (often the screen shows stripes and when saving sometimes much more is saved than what was in the buffer), but I think that is a separate bug, in userland, not in the kernel?  (In general I noticed kernel keyboard handling is a bit off, having frequent doubles and missers on openmsx, something I want to look at; the doubles issue should be fixed by introducing delay after the first keystroke).  Anyway, that's all off topic for this pull request.  What do you say?

Kind regards,
Filip.