### PR TITLE
MSX kbd improv

### DIFF
--- a/Kernel/dev/vdp1.s
+++ b/Kernel/dev/vdp1.s
@@ -518,8 +518,7 @@ clear_across:
 	    ld a,(_int_disabled)
 	    push af
 	    di
-	    ld a, (_scrollu_w)
-	    ld b,a
+	    ld b, #0x40
 	    call videopos
 	    ld a, c
 	    ld bc, (_vdpport)

--- a/Kernel/platform-msx1/devices.c
+++ b/Kernel/platform-msx1/devices.c
@@ -115,8 +115,9 @@ void device_init(void)
     kprintf("%s.\n", vdpname);
 
     /* Default key repeat values in 10ths of seconds */
-    keyrepeat.first = 2 * ticks_per_dsecond;
-    keyrepeat.continual = 1 * ticks_per_dsecond;
+    /* These are the keyrepeat values observed for MSX1, irrespective of VDP frequency */
+    keyrepeat.first = 39;
+    keyrepeat.continual = 3;
 
     sunrise_probe();
 }

--- a/Kernel/platform-msx1/devtty.c
+++ b/Kernel/platform-msx1/devtty.c
@@ -104,8 +104,8 @@ static uint8_t keyin[11];
 static uint8_t keybyte, keybit;
 static uint8_t newkey;
 static int keysdown = 0;
-static uint8_t shiftmask[11] = {
-	0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+static uint8_t modmask[11] = { /* check for SHIFT, CTRL, GRPH and CODE */
+	0, 0, 0, 0, 0, 0, 0x17, 0, 0, 0, 0
 };
 
 static void keyproc(void)
@@ -113,6 +113,8 @@ static void keyproc(void)
 	int i;
 	uint8_t key;
 
+	if ((keyin[6] ^ keymap[6]) & modmask[6])
+		kbd_timer = keyrepeat.first; /* modifier state change invalidates repeat timer */
 	for (i = 0; i < 11; i++) {
 		key = keyin[i] ^ keymap[i];
 		if (key) {
@@ -120,11 +122,11 @@ static void keyproc(void)
 			int m = 1;
 			for (n = 0; n < 8; n++) {
 				if ((key & m) && (keymap[i] & m)) {
-					if (!(shiftmask[i] & m))
+					if (!(modmask[i] & m))
 						keysdown--;
 				}
 				if ((key & m) && !(keymap[i] & m)) {
-					if (!(shiftmask[i] & m)) {
+					if (!(modmask[i] & m)) {
 						keysdown++;
 						newkey = 1;
 						keybyte = i;
@@ -164,6 +166,10 @@ static void keydecode(void)
 	} else
 		c = keyboard[keybyte][keybit];
 
+	/* Until we have true i8n we should make sure the Yen sign is interpreted as backslash */
+	if (c == KEY_YEN)
+		c = '\\';
+
 	if (keymap[6] & 2) {	/* control */
 		if (c > 31 && c < 127)
 			c &= 31;
@@ -196,13 +202,14 @@ void kbd_interrupt(void)
 	update_keyboard();
 	keyproc();
 
-	if (keysdown && keysdown < 3) {
+	/* accept any number of keys down, only retain last one pressed */
+	if (keysdown > 0) {
 		if (newkey) {
 			keydecode();
-			kbd_timer = keyrepeat.first * ticks_per_dsecond;
+			kbd_timer = keyrepeat.first;
 		} else if (! --kbd_timer) {
 			keydecode();
-			kbd_timer = keyrepeat.continual * ticks_per_dsecond;
+			kbd_timer = keyrepeat.continual;
 		}
 	}
 }

--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -1,5 +1,5 @@
 
-CSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c
+DSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c
 CSRCS += devfd.c devhd.c devlpr.c
 CSRCS += devices.c main.c devtty.c ../dev/rp5c01.c devrtc.c ../dev/v99xx.c vdp.c
 COMMON_CSRCS = devmegasd.c
@@ -12,7 +12,7 @@ CROSS_CCOPTS += -I../dev/
 
 COBJS = $(CSRCS:.c=.rel)
 AOBJS = $(ASRCS:.s=.rel)
-DOBJS = $(DSRCS:.c=.rel)
+DOBJS = $(patsubst ../dev/%.c,%.rel, $(DSRCS))
 COMMON_COBJS = $(COMMON_CSRCS:.c=.rel)
 DISCARD_COBJS = $(DISCARD_CSRCS:.c=.rel)
 DISCARD_DOBJS = $(patsubst ../dev/%.c,%.rel, $(DISCARD_DSRCS))

--- a/Kernel/platform-msx2/discard.c
+++ b/Kernel/platform-msx2/discard.c
@@ -53,8 +53,9 @@ void device_init(void)
     kputs("video.\n");
 
     /* Default key repeat values in 10ths of seconds */
-    keyrepeat.first = 2 * ticks_per_dsecond;
-    keyrepeat.continual = 1 * ticks_per_dsecond;
+    /* These are the 50/60 Hz keyrepeat values observed for MSX2 and above */
+    keyrepeat.first = ticks_per_dsecond == 6 ? 40 : 32;
+    keyrepeat.continual = 2;
 
     if (megasd_probe()) {
         /* probe for megaflash rom sd */


### PR DESCRIPTION
Note that the branch could be read as improvisation too ;-)

- It turned out that on MSX1 the tenth seconds where applied twice hence slowing down key repeat to molasses.  Fixed.
- Then took the repeat values from actual machines as a norm (which are not so linearly dependent on VDP frequency).
- The self-repeating ctrl-<sth> was due to only checking for SHIFT as modifier, changed that to SHIFT, CTRL, GRPH and CODE.
- Also, repetition stops not only on keys down change but also on modifier change.  Fixed.
- The big mystery of missing keys was due to me pressing the next key before letting go of the previous one.  Changed code to accept any number of keys down, yet only retain the last one pressed.  This is not the same as having multiple new keys down in one scan.  That will now give the highest scan numbered key as the so-called last pressed one.  This is consistent with actual MSX (though there they do input all pressed keys in repetition, which is a bit silly as they are of course in kbd matrix order and not in typed order, so no sense in trying to mimic this behavior).  But luckily for me, I am not that fast that my keystrokes end up in one scan! ;-)
- On JP keyboards we have an overlay where backslash is now the Yen sign.  Great, but until we have true i8n we should make sure that the function of that Yen key is the same as the backslash, as is the case in an actual MSX (e.g. path name separators are Yen signs).  So, in the key decode routine I now translate the Yen key to backslash, so that we can at least do something like echo -e "\0123" on the cli ...
- Finally there was an annoyance with recompilation for msx2 where the DSRCS where not properly handled with as consequence that some sources where recompiled each time even if they were not changed.  Fixed.
- Retro-actively fixed vdp1.s where there was left-over probably from copy/paste in clear_across.