### PR TITLE
.github/workflows: ci: bump m68k-gcc to 13.10 and enable ci on every push/pull-req

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,6 @@
 name: Continuous integration
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 env:
   M68K_CROSS_URL: https://mirrors.edge.kernel.org/pub/tools/crosstool/files/bin/x86_64/13.1.0/x86_64-gcc-13.1.0-nolibc-m68k-linux.tar.gz

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 env:
-  M68K_CROSS_URL: https://mirrors.edge.kernel.org/pub/tools/crosstool/files/bin/x86_64/11.1.0/x86_64-gcc-11.1.0-nolibc-m68k-linux.tar.gz
-  M68K_CROSS_DIR: gcc-11.1.0-nolibc
+  M68K_CROSS_URL: https://mirrors.edge.kernel.org/pub/tools/crosstool/files/bin/x86_64/13.1.0/x86_64-gcc-13.1.0-nolibc-m68k-linux.tar.gz
+  M68K_CROSS_DIR: gcc-13.1.0-nolibc
 
 concurrency:
   group: environment-${{ github.head_ref }}


### PR DESCRIPTION
-Bump m68k-gcc to 13.10 (and fix rc2014-68008 and tiny68k build as a side effect)
-enable CI actions on every push/pull (thus letting people build test their code before preparing a pull-req)