### PR TITLE
msx2: make disk image bootable

### DIFF
--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -40,22 +40,36 @@ $(DISCARD_DOBJS): %.rel: ../dev/%.c
 
 clean:
 	rm -f $(OBJS) *.lst *.asm *.sym *.rst *.lk  core *~
-	rm -f fuzix.ascii8.rom
+	rm -f fuzix.ascii8.rom fuzix.com boot.bin
 
 image:
 	dd if=../fuzix.bin of=fuzix.tmp bs=256 skip=1
 	dd if=../fuzix_disk.bin of=fuzix.com bs=256 skip=241
-	cp fuzix.com /tmp/com1
 	cat fuzix.tmp >> fuzix.com
-#	rm -f fuzix.tmp
 	dd if=../fuzix_boot.bin of=fuzix.ascii8.rom skip=1 bs=16384 conv=sync
 	dd if=../fuzix.bin of=fuzix.ascii8.rom seek=1 bs=16384 conv=sync
+	rm -f fuzix.tmp
+
+boot: boot.s
+	sdasz80 -o boot.s
+	sdldz80 -i boot.rel
+	# This makes us a binary from physical 0
+	makebin -p -s 49664 boot.ihx boot.tmp
+	# Chop off the leading 49152 bytes we don't want
+	dd if=boot.tmp of=boot.bin bs=512 count=1 skip=96 conv=sync
+	rm -f boot.ihx boot.tmp
 
 IMAGES = $(FUZIX_ROOT)/Images/$(TARGET)
 
-diskimage: image
+diskimage: image boot
 	# Make a blank disk image with partition
 	dd if=$(FUZIX_ROOT)/Standalone/filesystem-src/parttab.40M of=$(IMAGES)/disk.img bs=40017920 conv=sync
+	# Add the boot partition
+	env LANG=c echo -en '\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\xff\x07\x00\x00' | dd iflag=fullblock of=$(IMAGES)/disk.img bs=478 seek=1 conv=notrunc
+	# Add the bootb sector
+	dd if=boot.bin of=$(IMAGES)/disk.img bs=512 seek=1 conv=notrunc
+	# Add the kernel
+	dd if=fuzix.com of=$(IMAGES)/disk.img bs=512 seek=2 conv=notrunc
 	# Add the file system
 	dd if=$(IMAGES)/filesys.img of=$(IMAGES)/disk.img bs=512 seek=2048 conv=notrunc
 	cp fuzix.ascii8.rom $(IMAGES)

--- a/Kernel/platform-msx2/boot.s
+++ b/Kernel/platform-msx2/boot.s
@@ -1,0 +1,60 @@
+; FUZIX boot sector for MSX2 using MegaFlashROM_SCC+_SD
+;
+	.module	boot
+	.area	BOOT(ABS)
+	.org	0xc000
+
+	.macro	BDOS, func
+	ld	c, func
+	call	0xf37d
+	.endm
+
+	.macro	ENASLT, slotaddr, page
+	ld	a, (slotaddr)
+	ld	h, page
+	call	0x24
+	.endm
+
+	.db	0xeb, 0xfe, 0x90; MSDOS boot signature
+	.ascii	'FUZIX   '	; disk name
+	.dw	512		; sector size (in bytes)
+	.db	16		; cluster size (in sectors)
+	.dw	1		; unused sectors
+	.db	2		; FATs
+	.dw	1		; directory entries (avoid garbage)
+	.dw	2047		; disk size (in sectors)
+	.db	0xf0		; media id
+	.dw	3		; FAT size (in sectors)
+	.dw	0		; sectors per track
+	.dw	0		; sides
+	.dw	0		; hidden sectors
+	jr	boot		; MSXDOS2 boot signature
+        .ascii	'VOL_ID'
+        .db	0x00, 0x52, 0x34, 0xd6, 0xf8
+        .ascii	'NEXTOR 2.0 FAT12   '
+boot:	ret	nc
+	ld	(#call+1), de
+	ld	(hl), #entry
+	inc	hl
+	ld	(hl), #0xc0
+retry:	ld	sp, #0xf51f
+	ENASLT	#0xf342, #0x40	; RAM in slot 1
+	ld	de, #0x100
+	BDOS	#0x1a		; set disk transfer address
+	BDOS	#0x19		; get current drive
+	ld	l, a
+	ld	de, #1		; start of fuzix.com
+	ld	h, #95		; size of fuzix.com
+	BDOS	#0x2f		; absolute sector read
+	inc	a
+	jp	nz, 0x100
+	ENASLT	#0xfcc1, #0x40	; ROM in slot 1
+	jr	call
+entry:	.dw	call
+call:	call	0x0000
+	ld	a, c
+	and	#0xfe
+	sub	#2
+or:	or	#0
+	jp	z, 0x4022
+	jr	retry


### PR DESCRIPTION
MSX2 disk image is now bootable (hence no bootrom needed anymore) - that is if used with MegaFlash without romdisk, as I haven't found a key combination which disables booting from romdisk, except in the recovery mode (key up during boot) F3 which erases the romdisk (a bit drastic) ...

Would you consider publishing this MSX2 bootable diskimage on fuzix.org? 