### PR TITLE
msx2: integrate Sunrise IDE

### DIFF
--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -50,7 +50,11 @@
        mknod /dev/hdb15 60660 31
 */
 
+#ifdef BLKDEV_INIT
 static blkdev_t blkdev_table[MAX_BLKDEV]={{0,},};
+#else
+static blkdev_t blkdev_table[MAX_BLKDEV];
+#endif
 struct blkparam blk_op;
 
 int blkdev_open(uint_fast8_t minor, uint16_t flags)

--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -50,7 +50,7 @@
        mknod /dev/hdb15 60660 31
 */
 
-static blkdev_t blkdev_table[MAX_BLKDEV];
+static blkdev_t blkdev_table[MAX_BLKDEV]={{0,},};
 struct blkparam blk_op;
 
 int blkdev_open(uint_fast8_t minor, uint16_t flags)

--- a/Kernel/dev/blkdev.c
+++ b/Kernel/dev/blkdev.c
@@ -50,11 +50,7 @@
        mknod /dev/hdb15 60660 31
 */
 
-#ifdef BLKDEV_INIT
-static blkdev_t blkdev_table[MAX_BLKDEV]={{0,},};
-#else
 static blkdev_t blkdev_table[MAX_BLKDEV];
-#endif
 struct blkparam blk_op;
 
 int blkdev_open(uint_fast8_t minor, uint16_t flags)

--- a/Kernel/dev/devsd.h
+++ b/Kernel/dev/devsd.h
@@ -59,7 +59,7 @@ extern uint_fast8_t sd_drive; /* current card/drive number */
 void sd_spi_release(void);
 int sd_send_command(uint_fast8_t cmd, uint32_t arg);
 uint_fast8_t sd_spi_wait(bool want_ff);
-void sd_init_drive(void);
+void sd_init_drive(uint8_t drive);
 int sd_spi_init(void);
 uint_fast8_t devsd_transfer_sector(void);
 

--- a/Kernel/dev/devsd_discard.c
+++ b/Kernel/dev/devsd_discard.c
@@ -31,19 +31,17 @@
 void devsd_init(void)
 {
     uint8_t i;
-    for(i = 0; i < SD_DRIVE_COUNT; i++) {
-        sd_drive = i;
-        sd_init_drive();
-    }
-//    sd_drive = SD_DRIVE_NONE;
+    for(i = 0; i < SD_DRIVE_COUNT; i++)
+        sd_init_drive(i);
 }
 
-void sd_init_drive(void)
+void sd_init_drive(uint8_t drive)
 {
     blkdev_t *blk;
     unsigned char csd[16], n;
     uint_fast8_t card_type;
 
+    sd_drive = drive;
     kprintf("SD drive %d: ", sd_drive);
     card_type = sd_spi_init();
 

--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -31,7 +31,7 @@ $(COMMON_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) --codeseg CODE1 -c $<
 
 $(DOBJS): %.rel: ../dev/%.c
-	$(CROSS_CC) $(CROSS_CCOPTS) --dataseg COMMONMEM -c $<
+	$(CROSS_CC) $(CROSS_CCOPTS) -DBLKDEV_INIT --dataseg COMMONMEM -c $<
 
 $(DISCARD_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<

--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -2,11 +2,12 @@
 DSRCS = ../dev/devsd.c ../dev/mbr.c ../dev/blkdev.c
 CSRCS += devfd.c devhd.c devlpr.c
 CSRCS += devices.c main.c devtty.c ../dev/rp5c01.c devrtc.c ../dev/v99xx.c vdp.c
-COMMON_CSRCS = devmegasd.c
+COMMON_CSRCS = devmegasd.c devide_sunrise.c
 DISCARD_CSRCS = discard.c
 DISCARD_DSRCS = ../dev/devsd_discard.c
 ASRCS = msx2.s crt0.s
 ASRCS += tricks.s commonmem.s bootrom.s diskboot.s
+ASRCS += sunrise.s
 
 CROSS_CCOPTS += -I../dev/
 
@@ -30,7 +31,7 @@ $(COMMON_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) --codeseg CODE1 -c $<
 
 $(DOBJS): %.rel: ../dev/%.c
-	$(CROSS_CC) $(CROSS_CCOPTS) -c $<
+	$(CROSS_CC) $(CROSS_CCOPTS) --dataseg COMMONMEM -c $<
 
 $(DISCARD_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
@@ -66,7 +67,7 @@ diskimage: image boot
 	dd if=$(FUZIX_ROOT)/Standalone/filesystem-src/parttab.40M of=$(IMAGES)/disk.img bs=40017920 conv=sync
 	# Add the boot partition
 	env LANG=c echo -en '\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\xff\x07\x00\x00' | dd iflag=fullblock of=$(IMAGES)/disk.img bs=478 seek=1 conv=notrunc
-	# Add the bootb sector
+	# Add the boot sector
 	dd if=boot.bin of=$(IMAGES)/disk.img bs=512 seek=1 conv=notrunc
 	# Add the kernel
 	dd if=fuzix.com of=$(IMAGES)/disk.img bs=512 seek=2 conv=notrunc

--- a/Kernel/platform-msx2/Makefile
+++ b/Kernel/platform-msx2/Makefile
@@ -31,7 +31,7 @@ $(COMMON_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) --codeseg CODE1 -c $<
 
 $(DOBJS): %.rel: ../dev/%.c
-	$(CROSS_CC) $(CROSS_CCOPTS) -DBLKDEV_INIT --dataseg COMMONMEM -c $<
+	$(CROSS_CC) $(CROSS_CCOPTS) -c $<
 
 $(DISCARD_COBJS): %.rel: %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<

--- a/Kernel/platform-msx2/boot.s
+++ b/Kernel/platform-msx2/boot.s
@@ -33,28 +33,19 @@
         .db	0x00, 0x52, 0x34, 0xd6, 0xf8
         .ascii	'NEXTOR 2.0 FAT12   '
 boot:	ret	nc
-	ld	(#call+1), de
-	ld	(hl), #entry
-	inc	hl
-	ld	(hl), #0xc0
-retry:	ld	sp, #0xf51f
+	ld	hl,#load
+	ld	de,#0xc100
+	ld	bc,#end-#load
+	ldir
+	jp	0xc100
+load:	ld	sp, #0xf51f
 	ENASLT	#0xf342, #0x40	; RAM in slot 1
 	ld	de, #0x100
 	BDOS	#0x1a		; set disk transfer address
 	BDOS	#0x19		; get current drive
 	ld	l, a
 	ld	de, #1		; start of fuzix.com
-	ld	h, #95		; size of fuzix.com
+	ld	h, #96		; size of fuzix.com
 	BDOS	#0x2f		; absolute sector read
-	inc	a
-	jp	nz, 0x100
-	ENASLT	#0xfcc1, #0x40	; ROM in slot 1
-	jr	call
-entry:	.dw	call
-call:	call	0x0000
-	ld	a, c
-	and	#0xfe
-	sub	#2
-or:	or	#0
-	jp	z, 0x4022
-	jr	retry
+	jp	0x100
+end:

--- a/Kernel/platform-msx2/config.h
+++ b/Kernel/platform-msx2/config.h
@@ -56,7 +56,7 @@
 
 #define BOOTDEVICENAMES	"hd#,fd"
 
-#define MAX_BLKDEV 1      /* Single SD drive */
+#define MAX_BLKDEV 1      /* Single SD or IDE drive */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL	10
 //#define CONFIG_RTC_RP5C01_NVRAM

--- a/Kernel/platform-msx2/config.h
+++ b/Kernel/platform-msx2/config.h
@@ -52,11 +52,11 @@
 #define NMOUNTS	 4	  /* Number of mounts at a time */
 
 #define CONFIG_SD
-#define SD_DRIVE_COUNT 1
+#define SD_DRIVE_COUNT 2
 
 #define BOOTDEVICENAMES	"hd#,fd"
 
-#define MAX_BLKDEV 2      /* 1 IDE and 1 SD drive */
+#define MAX_BLKDEV 4      /* 2 IDE and 2 SD drives */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL	10
 //#define CONFIG_RTC_RP5C01_NVRAM

--- a/Kernel/platform-msx2/config.h
+++ b/Kernel/platform-msx2/config.h
@@ -56,7 +56,7 @@
 
 #define BOOTDEVICENAMES	"hd#,fd"
 
-#define MAX_BLKDEV 1      /* Single SD or IDE drive */
+#define MAX_BLKDEV 2      /* 1 IDE and 1 SD drive */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL	10
 //#define CONFIG_RTC_RP5C01_NVRAM

--- a/Kernel/platform-msx2/devide_sunrise.c
+++ b/Kernel/platform-msx2/devide_sunrise.c
@@ -1,0 +1,158 @@
+#include <kernel.h>
+#include <kdata.h>
+#include <printf.h>
+#include <timer.h>
+#include <blkdev.h>
+#include <devide_sunrise.h>
+#include <msx2.h>
+
+extern uint16_t ide_error;
+extern uint16_t ide_base;
+extern uint8_t ide_slot;
+uint8_t *devide_buf;
+
+static void delay(void)
+{
+    timer_t timeout;
+
+    timeout = set_timer_ms(25);
+
+    while(!timer_expired(timeout))
+       plt_idle();
+}
+
+/* We assume that memory at 0xc000-0xc1fe is not allocated
+ * to solve the issue of page crossing below.
+ * A sector is read, and any surplus is copied to the next page.
+ * A sector is written after any surplus is copied from the next page.
+ */
+static uint8_t sunrise_transfer_sector(void)
+{
+    uint8_t drive = (blk_op.blkdev->driver_data & IDE_DRIVE_NR_MASK);
+    uint8_t mask = drive ? 0xF0 : 0xE0;
+    uint8_t *page, page_offset, *addr = blk_op.addr;
+    uint16_t status;
+
+    if (!blk_op.is_read)
+        blk_op.blkdev->driver_data |= FLAG_CACHE_DIRTY;
+
+    irqflags_t irq = di();
+    if (blk_op.is_user) {
+        blk_op.is_user = 0;
+        blk_op.addr = ((uint16_t) addr) % 0x4000 + 0x8000;
+        page_offset = (((uint16_t)addr) / 0x4000);
+        page = &udata.u_page;
+        int len = ((uint16_t)blk_op.addr) + BLKSIZE - 0xc000;
+        if (len > 0 && !blk_op.is_read) {
+            RAM_PAGE2 = *(page + page_offset + 1);
+            memcpy((uint8_t *)0xc000, (uint8_t *)0x8000, len);
+        }
+        RAM_PAGE2 = *(page + page_offset);
+        status = do_ide_xfer(mask);
+        if (len > 0 && blk_op.is_read) {
+            RAM_PAGE2 = *(page + page_offset + 1);
+            memcpy((uint8_t *)0x8000, (uint8_t *)0xc000, len);
+        }
+        RAM_PAGE2 = 1;
+        blk_op.addr = addr;
+        blk_op.is_user = 1;
+    } else {
+        status = do_ide_xfer(mask);
+    }
+    irqrestore(irq);
+
+    if (status != 0) {
+        if (ide_error == 0xFF)
+            kprintf("ide%d: timeout.\n", drive);
+        else
+            kprintf("ide%d: status %x\n", drive, ide_error);
+        return 0;
+    }
+    return 1;
+}
+
+static int sunrise_flush_cache(void)
+{
+    uint8_t drive;
+
+    drive = blk_op.blkdev->driver_data & IDE_DRIVE_NR_MASK;
+    /* check drive has a cache and was written to since the last flush */
+    if((blk_op.blkdev->driver_data & (FLAG_WRITE_CACHE | FLAG_CACHE_DIRTY))
+		                 != (FLAG_WRITE_CACHE | FLAG_CACHE_DIRTY))
+        return 0;
+
+    if (do_ide_flush_cache(drive ? 0xF0 : 0xE0)) {
+        udata.u_error = EIO;
+        return -1;
+    }
+    return 0;
+}
+
+static void sunrise_init_drive(uint8_t drive)
+{
+    uint8_t mask = drive ? 0xF0 : 0xE0;
+    blkdev_t *blk;
+
+    kprintf("IDE drive %d: ", drive);
+    devide_buf = tmpbuf();
+    if (do_ide_init_drive(mask) == NULL)
+        goto failout;
+    if (!(devide_buf[99] & 0x02)) {
+        kputs("LBA unsupported.\n");
+        goto failout;
+    }
+    blk = blkdev_alloc();
+    if (!blk)
+        goto failout;
+    blk->transfer = sunrise_transfer_sector;
+    blk->flush = sunrise_flush_cache;
+    blk->driver_data = drive;
+
+    if( !(((uint16_t*)devide_buf)[82] == 0x0000 && ((uint16_t*)devide_buf)[83] == 0x0000) ||
+         (((uint16_t*)devide_buf)[82] == 0xFFFF && ((uint16_t*)devide_buf)[83] == 0xFFFF) ){
+	/* command set notification is supported */
+	if(devide_buf[164] & 0x20){
+	    /* write cache is supported */
+            blk->driver_data |= FLAG_WRITE_CACHE;
+	}
+    }
+
+    /* read out the drive's sector count */
+    blk->drive_lba_count = le32_to_cpu(*((uint32_t*)&devide_buf[120]));
+
+    /* done with our temporary memory */
+    tmpfree(devide_buf);
+    blkdev_scan(blk, SWAPSCAN);
+    return;
+failout:
+    kputs("\n");
+    tmpfree(devide_buf);
+}
+
+/* byte sequence at 0x4098 to identify Sunrise IDE ROM */
+static const char sunrise_id[] = "\x40\x7e\x32\x04\x41\xf1\xe1\xc9";
+
+void sunrise_probe(void)
+{
+    uint8_t i;
+
+    ide_base = 0x7E00;
+
+    for (ide_slot = 1; ide_slot < 3; ide_slot++) {
+        mapslot_bank1(ide_slot);
+        if (memcmp(0x4098, sunrise_id, 8) == 0)
+            break;
+    }
+    mapslot_bank1(slotram);
+    if (ide_slot == 3)
+        return;
+
+    kprintf("Sunrise IDE found in slot %d\n", ide_slot);
+
+    do_ide_begin_reset();
+    delay();
+    do_ide_end_reset();
+    delay();
+    for (i = 0; i < IDE_DRIVE_COUNT; i++)
+        sunrise_init_drive(i);
+}

--- a/Kernel/platform-msx2/devide_sunrise.h
+++ b/Kernel/platform-msx2/devide_sunrise.h
@@ -1,0 +1,14 @@
+extern uint8_t *do_ide_init_drive(uint8_t drive) __z88dk_fastcall;
+extern void do_ide_begin_reset(void) __z88dk_fastcall;
+extern void do_ide_end_reset(void) __z88dk_fastcall;
+extern uint8_t do_ide_flush_cache(uint8_t drive) __z88dk_fastcall;
+extern unsigned do_ide_xfer(uint16_t drive) __z88dk_fastcall;
+
+extern void sunrise_probe(void);
+
+#define IDE_DRIVE_COUNT		2
+
+#define FLAG_WRITE_CACHE	0x80
+#define FLAG_CACHE_DIRTY	0x40
+
+#define IDE_DRIVE_NR_MASK	0x03

--- a/Kernel/platform-msx2/devmegasd.c
+++ b/Kernel/platform-msx2/devmegasd.c
@@ -57,6 +57,7 @@ int megasd_probe(void)
             goto found;
     }
     mapslot_bank1(slotram);
+    irqrestore(irq);
     return 0;
 
 found:

--- a/Kernel/platform-msx2/discard.c
+++ b/Kernel/platform-msx2/discard.c
@@ -1,6 +1,7 @@
 #include <kernel.h>
 #include <kdata.h>
 #include <devsd.h>
+#include <devide_sunrise.h>
 #include <printf.h>
 #include <vt.h>
 #include <tty.h>
@@ -57,6 +58,7 @@ void device_init(void)
     keyrepeat.first = ticks_per_dsecond == 6 ? 40 : 32;
     keyrepeat.continual = 2;
 
+    sunrise_probe();
     if (megasd_probe()) {
         /* probe for megaflash rom sd */
         devsd_init();

--- a/Kernel/platform-msx2/fuzix.lnk
+++ b/Kernel/platform-msx2/fuzix.lnk
@@ -44,6 +44,8 @@ platform-msx2/blkdev.rel
 platform-msx2/devsd.rel
 platform-msx2/devsd_discard.rel
 platform-msx2/devmegasd.rel
+platform-msx2/devide_sunrise.rel
+platform-msx2/sunrise.rel
 platform-msx2/mbr.rel
 platform-msx2/devrtc.rel
 platform-msx2/rp5c01.rel

--- a/Kernel/platform-msx2/msx2.s
+++ b/Kernel/platform-msx2/msx2.s
@@ -27,6 +27,7 @@
             .globl _bufpool
 	    .globl _int_disabled
             .globl _udata
+            .globl ___sdcc_enter_ix
 
 	    ; video driver
 	    .globl _vtinit
@@ -48,12 +49,17 @@
             .globl outstring
             .globl outstringhex
 
-
+	    ; machine bits
 	    .globl _slotrom
 	    .globl _slotram
 	    .globl _vdpport
 	    .globl _infobits
 	    .globl _machine_type
+
+            ; IDE driver
+	    .globl _ide_slot
+	    .globl _ide_error
+	    .globl _ide_base
 
 	    ;
 	    ; vdp - we must initialize this bit early for the vt
@@ -168,6 +174,21 @@ _program_vectors:
             ld (0x0066), a  ; Set vector for NMI
             ld hl, #nmi_handler
             ld (0x0067), hl
+
+            ; RST peepholes support
+            ld hl,#___sdcc_enter_ix
+            ld (0x08),a
+            ld (0x09),hl
+            ld hl,#___spixret
+            ld (0x10),a
+            ld (0x11),hl
+            ld hl,#___ixret
+            ld (0x18),a
+            ld (0x19),hl
+            ld hl,#___ldhlhl
+            ld (0x20),a
+            ld (0x21),hl
+
 	    jr map_kernel
 
 ;
@@ -249,6 +270,34 @@ map_save_kernel:
 	    pop hl
 	    ret
 
+		.area _CODE
+
+;
+;       Stub helpers for code compactness.
+;
+;   Note that sdcc_enter_ix is in the standard compiler support already
+;
+;   The first two use an rst as a jump. In the reload sp case we don't
+;   have to care. In the pop ix case for the function end we need to
+;   drop the spare frame first, but we know that af contents don't
+;   matter
+;
+
+___spixret:
+            ld      sp,ix
+            pop     ix
+            ret
+___ixret:
+            pop     af
+            pop     ix
+            ret
+___ldhlhl:
+            ld      a,(hl)
+            inc     hl
+            ld      h,(hl)
+            ld      l,a
+            ret
+
 ;
 ;	Slot mapping functions.
 ;
@@ -260,7 +309,6 @@ map_save_kernel:
 ;   can be in bank1 or 2 because those are the ones usually used to
 ;   map the io ports.
 ;
-		.area _CODE
 
 _mapslot_bank1:
 		ld hl,#0x4000
@@ -371,6 +419,12 @@ _slotrom:
 	    .db 0
 _slotram:
 	    .db 0
+_ide_slot:
+	    .db 0
+_ide_error:
+	    .dw 0
+_ide_base:
+	    .dw 0
 _vdpport:
 	    .dw 0
 _infobits:

--- a/Kernel/platform-msx2/msx2.s
+++ b/Kernel/platform-msx2/msx2.s
@@ -60,6 +60,9 @@
 	    .globl _ide_slot
 	    .globl _ide_error
 	    .globl _ide_base
+	    .globl _ide_addr
+	    .globl _ide_lba
+	    .globl _ide_is_read
 
 	    ;
 	    ; vdp - we must initialize this bit early for the vt
@@ -425,6 +428,13 @@ _ide_error:
 	    .dw 0
 _ide_base:
 	    .dw 0
+_ide_addr:
+	    .dw 0
+_ide_lba:
+	    .dw 0
+	    .dw 0
+_ide_is_read:
+	    .db 0
 _vdpport:
 	    .dw 0
 _infobits:

--- a/Kernel/platform-msx2/rules.mk
+++ b/Kernel/platform-msx2/rules.mk
@@ -11,3 +11,5 @@ export CROSS_CC_SYS3=--codeseg CODE2
 export CROSS_CC_SYS4=--codeseg CODE2
 export CROSS_CC_SYS5=--codeseg CODE2
 export CROSS_CC_SEGDISC=--codeseg DISCARD --constseg DISCARD
+#
+CROSS_CCOPTS += --peep-file $(FUZIX_ROOT)/Kernel/cpu-z80/rst.peep

--- a/Kernel/platform-msx2/sunrise.s
+++ b/Kernel/platform-msx2/sunrise.s
@@ -10,12 +10,14 @@
 
 	.globl _ide_error
 	.globl _ide_base
+	.globl _ide_addr
+	.globl _ide_lba
+	.globl _ide_is_read
 
 	.globl _mapslot_bank1
 	.globl _slotram
 	.globl _ide_slot
 
-	.globl _blk_op
 	.globl _ticks
 	.globl _devide_buf
 
@@ -191,7 +193,7 @@ _do_ide_xfer:
 	ld ix,(_ide_base)
 	call map_sunrise_k
 	ld e,l
-	ld hl, (_blk_op + BLK_OP_LBA + 2)
+	ld hl, (_ide_lba + 2)
 	ld a,h
 	and #0x0F			; Merge drive and bits 24-27
 	or e
@@ -202,11 +204,11 @@ _do_ide_xfer:
 	pop hl
 	jr nz, xfer_timeout
 	ld IDE_REG_LBA_2(ix),l
-	ld hl, (_blk_op + BLK_OP_LBA)
+	ld hl, (_ide_lba)
 	ld IDE_REG_LBA_1(ix),h
 	ld IDE_REG_LBA_0(ix),l
 	ld IDE_REG_SEC_COUNT(ix),#1
-	ld a,(_blk_op + BLK_OP_ISREAD)
+	ld a,(_ide_is_read)
 	or a
 	jr z, send_cmd
 	ld IDE_REG_COMMAND(ix),#IDE_CMD_READ_SECTOR
@@ -241,7 +243,7 @@ xfer_timeout:
 ;	deal with it here
 ;
 devide_xfer_r:
-	ld de,(_blk_op + BLK_OP_ADDR)
+	ld de,(_ide_addr)
 	; We don't have to worry about swap being special for this port
 	; Our caller also is responsible for working out when to bounce
 xfer_do:
@@ -252,7 +254,7 @@ xfer_do:
 	ret
 
 devide_xfer_w:
-	ld hl,(_blk_op + BLK_OP_ADDR)
+	ld hl,(_ide_addr)
 	; We don't have to worry about swap being special for this port
 	; Our caller also is responsible for working out when to bounce
 	ld de,#0x7C00

--- a/Kernel/platform-msx2/sunrise.s
+++ b/Kernel/platform-msx2/sunrise.s
@@ -1,0 +1,270 @@
+;
+;	Sunrise style IDE
+;
+
+	.globl _do_ide_init_drive
+	.globl _do_ide_begin_reset
+	.globl _do_ide_end_reset
+	.globl _do_ide_flush_cache
+	.globl _do_ide_xfer
+
+	.globl _ide_error
+	.globl _ide_base
+
+	.globl _mapslot_bank1
+	.globl _slotram
+	.globl _ide_slot
+
+	.globl _blk_op
+	.globl _ticks
+	.globl _devide_buf
+
+
+	.globl _int_disabled
+
+	.module sunrise
+
+IDE_REG_ERROR		.equ	1
+IDE_REG_FEATURES 	.equ	1
+IDE_REG_SEC_COUNT	.equ	2
+IDE_REG_LBA_0		.equ	3
+IDE_REG_LBA_1		.equ	4
+IDE_REG_LBA_2		.equ	5
+IDE_REG_LBA_3		.equ	6
+IDE_REG_DEVHEAD		.equ	6
+IDE_REG_COMMAND		.equ	7
+IDE_REG_STATUS		.equ	7
+
+; For Sunrise at least
+IDE_REG_CONTROL		.equ	14
+
+
+IDE_ERROR		.equ	0
+IDE_BUSY		.equ	7
+
+IDE_STATUS_READY	.equ	0x40
+IDE_STATUS_DATAREQUEST	.equ	0x08
+
+IDE_CMD_READ_SECTOR	.equ	0x20
+IDE_CMD_WRITE_SECTOR	.equ	0x30
+IDE_CMD_FLUSH_CACHE	.equ	0xE7
+IDE_CMD_IDENTIFY	.equ	0xEC
+
+BLK_OP_ADDR		.equ	0
+BLK_OP_ISUSER		.equ	2
+BLK_OP_LBA		.equ	6
+BLK_OP_ISREAD		.equ	12
+
+
+	.area _CODE1
+
+devide_wait_ready:
+	xor a
+	ld (_ide_error),a
+	ld a,#IDE_STATUS_READY
+devide_wait:
+	push de
+	push hl
+	ld c,a
+	ld de,(_ticks)
+wait_nbusy:
+	ld hl,(_ticks)
+	or a
+	sbc hl,de
+	bit 2,h			; We spin fast enough this is a safe test
+	jr nz, wait_timeout
+	ld a,IDE_REG_STATUS(ix)
+	bit IDE_BUSY,a
+	jr nz, wait_nbusy
+	; Check for an error
+	bit IDE_ERROR,a
+	jr z, noerror
+	; Keep NZ set
+	ld (_ide_error),a
+	ld a,IDE_REG_ERROR(ix)
+	ld (_ide_error + 1),a
+	jr waitout
+noerror:
+	; Now see if it's a good status
+	and c
+	cp c
+	jr nz, wait_nbusy
+	; We have !busy, !error and the value we wanted - done
+waitout:
+	pop hl
+	pop de
+	ret		; Z = good
+wait_timeout:
+	ld a,#255		; NZ is set already
+	ld (_ide_error),a	; save the value
+	; NZ set already
+	jr waitout
+
+;
+;	Flip I/O maps
+;
+map_sunrise_k:
+	push af
+	push hl
+	ld a,(#_ide_slot)
+	di
+	call _mapslot_bank1
+	jr keepdi
+map_sunrise_u:
+	push af
+	push hl
+	ld a,(#_slotram)
+	di
+	call _mapslot_bank1
+	ld a,(_int_disabled)
+	or a
+	jr nz, keepdi
+	ei
+keepdi:
+	pop hl
+	pop af
+	ret
+;
+;	Caller passes  L = disk, (devide_buf) = a tmpbuf in common space
+;
+_do_ide_init_drive:
+	push ix
+	ld ix,(_ide_base)
+	call map_sunrise_k
+	ld IDE_REG_DEVHEAD(ix),l
+	ld hl,#0
+	call devide_wait_ready
+	jr nz, timeout
+	ld IDE_REG_COMMAND(ix),#IDE_CMD_IDENTIFY
+	ld a,#IDE_STATUS_DATAREQUEST
+	call devide_wait
+	jr nz, timeout
+	call devide_rx_buf
+	; returns the tmpbuf to the caller to free
+timeout:
+	ld a,#'R'
+	call map_sunrise_u
+	pop ix
+	ret
+
+_do_ide_begin_reset:
+	push ix
+	ld ix,(_ide_base)
+	call map_sunrise_k
+	ld a,#0x01
+	ld (0x4104),a
+	ld IDE_REG_DEVHEAD(ix),#0xE0
+	ld IDE_REG_CONTROL(ix),#0x06	; start reset (bit 2)
+	call map_sunrise_u
+	pop ix
+	ret
+
+_do_ide_end_reset:
+	push ix
+	ld ix,(_ide_base)
+	call map_sunrise_k
+	ld IDE_REG_CONTROL(ix),#0x02
+	call map_sunrise_u
+	pop ix
+	ret
+
+_do_ide_flush_cache:
+	push ix
+	ld ix,(_ide_base)
+	call map_sunrise_k
+	ld IDE_REG_LBA_3(ix),l
+	ld hl,#0
+	call devide_wait_ready
+	jr nz, flush_bad
+	ld IDE_REG_COMMAND(ix),#IDE_CMD_FLUSH_CACHE
+	call devide_wait_ready
+	jr z,flush_good
+flush_bad:
+	dec hl		; to -1
+flush_good:
+	call map_sunrise_u
+	pop ix
+	ret
+
+_do_ide_xfer:
+	push ix
+	ld ix,(_ide_base)
+	call map_sunrise_k
+	ld e,l
+	ld hl, (_blk_op + BLK_OP_LBA + 2)
+	ld a,h
+	and #0x0F			; Merge drive and bits 24-27
+	or e
+	ld IDE_REG_LBA_3(ix),a
+	push hl
+	ld hl,#0
+	call devide_wait_ready
+	pop hl
+	jr nz, xfer_timeout
+	ld IDE_REG_LBA_2(ix),l
+	ld hl, (_blk_op + BLK_OP_LBA)
+	ld IDE_REG_LBA_1(ix),h
+	ld IDE_REG_LBA_0(ix),l
+	ld IDE_REG_SEC_COUNT(ix),#1
+	ld a,(_blk_op + BLK_OP_ISREAD)
+	or a
+	jr z, send_cmd
+	ld IDE_REG_COMMAND(ix),#IDE_CMD_READ_SECTOR
+	ld a,#IDE_STATUS_DATAREQUEST
+	call devide_wait
+	jr nz, xfer_timeout
+	call devide_xfer_r
+	ld hl,#0
+	call map_sunrise_u
+	pop ix
+	ret
+send_cmd:
+	ld IDE_REG_COMMAND(ix),#IDE_CMD_WRITE_SECTOR
+	ld a,#IDE_STATUS_DATAREQUEST
+	call devide_wait
+	jr nz, xfer_timeout
+	call devide_xfer_w
+	call devide_wait_ready
+	jr nz, xfer_timeout
+	ld hl,#0
+	call map_sunrise_u
+	pop ix
+	ret
+xfer_timeout:
+	ld hl,#0xffff
+	call map_sunrise_u
+	pop ix
+	ret
+
+;
+;	For now deal with Sunrise style. If we find any others we can
+;	deal with it here
+;
+devide_xfer_r:
+	ld de,(_blk_op + BLK_OP_ADDR)
+	; We don't have to worry about swap being special for this port
+	; Our caller also is responsible for working out when to bounce
+xfer_do:
+	; FIXME: for non Sunrise we may need to change this and the xfer_w
+	ld hl,#0x7C00
+	ld bc,#0x0200
+	ldir
+	ret
+
+devide_xfer_w:
+	ld hl,(_blk_op + BLK_OP_ADDR)
+	; We don't have to worry about swap being special for this port
+	; Our caller also is responsible for working out when to bounce
+	ld de,#0x7C00
+	ld bc,#0x0200
+	ldir
+	ret
+
+devide_rx_buf:
+	ld hl,(_devide_buf)
+	push hl
+	ex de,hl
+	call xfer_do
+	pop hl
+	ret
+


### PR DESCRIPTION
MSX2 now can also boot from Sunrise IDE (with or without ROM).  There is only room for one blkdev, so either SD or IDE.  However we can still include MegaSD for the integrated MegaRAM mapper, as the IDE drive is first probed.  I had to move the data of Kernel/dev/blkdev.c to COMMONMEM in MSX2 (hence the initializer).  It should not impact other platforms (verified MSX1).  I also had to enable RST peephole optimization, to arrive within a some 60 bytes of the 48K boundary.