### PR TITLE
dw: Add crt0 so the dw apps link properly

### DIFF
--- a/Applications/dw/Makefile.common
+++ b/Applications/dw/Makefile.common
@@ -11,7 +11,7 @@ $(OBJS): %.o : %.c
 	$(CC) -c $(CFLAGS) $(COPT) $<
 
 $(APPS): %: %.o
-	$(LINKER) $^ -o $@ $(LINKER_OPT) $(LINKER_TAIL)
+	$(LINKER) $(CRT0) $^ -o $@ $(LINKER_OPT) $(LINKER_TAIL)
 
 size.report: $(APPS)
 	ls -l $^ > $@


### PR DESCRIPTION
Was doing a `platform-coco3` build from scratch and hit the following issue with `Applications/dw`:  

```
make[2]: Entering directory '/home/n6il/src/FUZIX/Applications/dw'
m6809-unknown-gcc -c -I/home/n6il/src/FUZIX/Library/include -I/home/n6il/src/FUZIX/Library/include/6809 -Os dwterm.c
/home/n6il/src/FUZIX/Library/link/ld6809 dwterm.o -o dwterm  -L/home/n6il/src/FUZIX/Library/libs -lc6809 -L/usr/lib/gcc/m6809-unknown/4.6.4/ -lgcc
...
+ m6809-unknown-ld dwterm.o -L/home/n6il/src/FUZIX/Library/libs -lc6809 -L/usr/lib/gcc/m6809-unknown/4.6.4/ -lgcc --oformat=raw -o dwterm.b1 --script=/home/n6il/src/FUZIX/Library/link/m6809.link -Map=dwterm.map
+ m6809-unknown-ld dwterm.o -L/home/n6il/src/FUZIX/Library/libs -lc6809 -L/usr/lib/gcc/m6809-unknown/4.6.4/ -lgcc --oformat=raw -o dwterm.b2 --script=/home/n6il/src/FUZIX/Library/link/m6809.link2
+ /home/n6il/src/FUZIX/Library/tools/relocbin6809 dwterm.b1 dwterm.b2 dwterm
Bad relocation at 10 (00:06:34 v 00:01:34)
base2 - bufb = 10 base-buf = 10
Makefile.common:14: recipe for target 'dwterm' failed
```

This simple change fixes the build issue.  This is probably not the only way to resolve the issue.  There is probably something wrong elsewhere in another part of the build system that caused crt0 to not be included in the linker commands when it actually should be.