### PR TITLE
PZ1: Blockdevice, names & formatting

### DIFF
--- a/Kernel/platform/platform-pz1/Makefile
+++ b/Kernel/platform/platform-pz1/Makefile
@@ -2,13 +2,19 @@
 CSRCS = devtty.c devhd.c
 CSRCS += main.c devices.c
 
+CDSRCS = ../../dev/tinydisk_discard.c
+
+DSRCS = ../../dev/tinydisk.c
+
 ASRCS = pz1.s crt0.s
 ASRCS += tricks.s commonmem.s
 
 COBJS = $(CSRCS:.c=$(BINEXT))
 AOBJS = $(ASRCS:.s=$(BINEXT))
+DOBJS = $(patsubst ../../dev/%.c,%.o, $(DSRCS))
+CDOBJS = $(CDSRCS:.c=$(BINEXT))
 
-OBJS  = $(COBJS) $(AOBJS)
+OBJS  = $(COBJS) $(AOBJS) $(DOBJS) $(CDOBJS)
 
 CROSS_CCOPTS += -I../../dev/
 
@@ -16,6 +22,12 @@ all:	$(OBJS)
 
 $(COBJS): %$(BINEXT): %.c
 	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEG1) $<
+
+$(CDOBJS): %$(BINEXT): %.c
+	$(CROSS_CC) $(CROSS_CCOPTS) $(CROSS_CC_SEGDISC) -c $<
+
+$(DOBJS): %$(BINEXT): ../../dev/%.c
+	$(CROSS_CC) $(CROSS_CCOPTS) $(HIGH) -c $<
 
 $(AOBJS): %$(BINEXT): %.s
 	$(CROSS_AS) $(ASOPTS) $< -o $*$(BINEXT)
@@ -27,18 +39,17 @@ image:
 	$(CROSS_LD) -o ../../fuzix.bin --mapfile ../../fuzix.map -C ld65.cfg crt0.o commonmem.o \
 	pz1.o ../../start.o ../../version.o ../../cpu-6502/lowlevel-6502.o \
 	tricks.o main.o ../../timer.o ../../kdata.o devices.o \
-	devhd.o ../../mm/memalloc_none.o \
+	devhd.o ../../mm/memalloc_none.o ../../dev/tinydisk.o ../../dev/tinydisk_discard.o \
 	../../devio.o ../../filesys.o ../../process.o ../../inode.o ../../syscall_fs.o \
 	../../syscall_proc.o ../../syscall_other.o ../../mm.o ../../mm/bankfixed.o \
 	../../tty.o ../../devsys.o ../../syscall_fs2.o ../../syscall_fs3.o \
 	../../syscall_exec16.o ../../syscall_exec.o ../../blk512.o \
 	../../usermem.o ../../cpu-6502/usermem_std-6502.o devtty.o
-	dd if=../../fuzix.bin of=fuzix.img bs=256 skip=4 
 
 IMAGES = $(FUZIX_ROOT)/Images/$(TARGET)
 
 diskimage: image
-	cp fuzix.img $(IMAGES)/fuzix.rom
+	cp ../../fuzix.bin $(IMAGES)/fuzix.rom
 	# Make a blank disk image with partition
 	dd if=$(FUZIX_ROOT)/Standalone/filesystem-src/parttab.40M of=$(IMAGES)/disk.img bs=40017920 conv=sync
 	# Add the file system

--- a/Kernel/platform/platform-pz1/README
+++ b/Kernel/platform/platform-pz1/README
@@ -1,10 +1,10 @@
-Initial support for the PZ1
+Support for the PZ1 platform
 
 Use a modern cc65 from https://github.com/cc65/cc65 (2.18 as shipped in
-many Linux distributions is just fine).
+many Linux distributions works well).
 
-Although the memory card can operate as 4 independent 16K pages for simplicity
-at this point we treat it as if it just provided 16K and 48K
+Although the memory can operate as 4 independent 16K pages, for simplicity
+at this point we treat it as if it just provided 16K and 48K.
 
 Interrupts deal wth the shared ZP by swapping the ZP back and forth with the
 interrupt copies (about 20 bytes involved)
@@ -28,11 +28,14 @@ User space:
 
 The memory banks are allocated as follows
 
-	32			RAM mapped initially at 0-16K
-	33			RAM mapped initially at 16-32K
-	34			RAM mapped initially at 32-48K
-	35			RAM mapped initially at 48K-64K
-	36-63			Handed out in fours for process maps
+	0			RAM mapped initially at 0-16K
+	1			RAM mapped initially at 16-32K
+	2			RAM mapped initially at 32-48K
+	3			RAM mapped initially at 48K-64K
+	4-31			Handed out in fours for process maps
+
+This port is based on the rcbus-6502 port, so share most of the same features
+and missing bits.
 
 The 6502 port has some interesting gotchas to be aware of and things that
 need addressing
@@ -77,9 +80,9 @@ Swap support
 Lots of features
 Virtual disk partitioning or multiple volumes
 
-Emulator:
-
+EmulatorKit usage:
 make diskimage
+./pz1 -r fuzix.rom -i disk.img
 
-./pz1 -r fuzix.img -i filesys.img
-
+fix for erase in console:
+stty erase '^?'

--- a/Kernel/platform/platform-pz1/config.h
+++ b/Kernel/platform/platform-pz1/config.h
@@ -12,44 +12,55 @@
 #define CONFIG_BANKS	1
 /* Permit large I/O requests to bypass cache and go direct to userspace */
 #define CONFIG_LARGE_IO_DIRECT(x)	(1)
-
-#define CONFIG_CALL_R2L		/* Runtime stacks arguments backwards */
+/* Runtime stacks arguments backwards */
+#define CONFIG_CALL_R2L
 
 /*
- *	1024K RAM (swap yet to do ) - not yet using it all
+ *	512K RAM (swap yet to do ) - not yet using it all
  *	Question: is common better top or bottom ?
  *	Top means we switch ZP and 6502 stacks, bottom means we don't but
  *	have to copy stuff/watching sharing
  */
 #define CONFIG_BANK_FIXED
-#define MAX_MAPS	7   /* 9 x 64K */
+#define MAX_MAPS	7	/* 9 x 64K */
 #define MAP_SIZE	0xDE00
 
-#define TICKSPERSEC 100	    /* Ticks per second */
+#define TICKSPERSEC	100	/* Ticks per second */
 
 /* We've not yet made the rest of the code - eg tricks match this ! */
-#define MAPBASE	    0x0000  /* We map from 0 */
-#define PROGBASE    0x2000  /* also data base */
-#define PROGLOAD    0x2000
-#define PROGTOP     0xFE00
+#define MAPBASE		0x0000	/* We map from 0 */
+#define PROGBASE	0x2000	/* also data base */
+#define PROGLOAD	0x2000
+#define PROGTOP		0xFE00
 
-/* FIXME: swap */
+/* TODO: swap */
+//#define SWAPDEV		1
+//#define SWAP_SIZE	127	/* 0xfe00 / 512 */
+//#define SWAPBASE	0x0000	/* We swap the lot in one, include the */
+//#define SWAPTOP		0xfe00	/* uarea so its a round number of sectors */
+//#define UDATA_BLOCKS	0	/* We swap the uarea in the data */
+//#define UDATA_SWAPSIZE	0
+//#define MAX_SWAPS	16
+//#define swap_map(x)	((uint8_t *)(x & 0x3fff ))
 
-#define BOOT_TTY 513        /* Set this to default device for stdio, stderr */
+#define BOOT_TTY	513	/* Set this to default device for stdio, stderr */
 
 /* We need a tidier way to do this from the loader */
-#define CMDLINE	NULL	  /* Location of root dev name */
+#define CMDLINE	NULL		/* Location of root dev name */
 
 /* Device parameters */
-#define NUM_DEV_TTY 2
-#define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */
-#define NBUFS    5        /* Number of block buffers */
+#define NUM_DEV_TTY	2
+#define TTYDEV		BOOT_TTY/* Device used by kernel for messages, panics */
+#define NBUFS		5	/* Number of block buffers */
+
+/* Block device define */
+#define CONFIG_TD_NUM	1
 
 #define plt_discard()
 #define plt_copyright()
 
-#define MAX_BLKDEV 1
-#define NMOUNTS	   1	      /* Number of mounts at a time */
-#define BOOTDEVICE 0x0000 /* Only one possible option */
+#define MAX_BLKDEV	1
+#define NMOUNTS		2	/* Number of mounts at a time */
+#define BOOTDEVICENAMES	"hda"
 
 #define CONFIG_SMALL

--- a/Kernel/platform/platform-pz1/devhd.c
+++ b/Kernel/platform/platform-pz1/devhd.c
@@ -7,77 +7,40 @@
 #include <printf.h>
 #include <devhd.h>
 #include <ports.h>
+#include <tinydisk.h>
 
 #define BLOCK_SIZE 512
-
-int hd_open(uint_fast8_t minor, uint16_t flag)
-{
-        used(flag);
-        if(minor != 0) {
-                udata.u_error = ENODEV;
-                return -1;
-        }
-        return 0;
-}
 
 /* Asm transfer routines in common space */
 extern uint8_t hd_data_in(uint8_t *ptr);
 extern uint8_t hd_data_out(uint8_t *ptr);
 
-uint8_t hd_mode;
-
-/* The main disk read/write loop */
-int hd_rw(uint_fast8_t minor, bool is_read, uint_fast8_t rawflag)
+int hd_xfer(uint8_t dev, bool is_read, uint32_t lba, uint8_t * dptr)
 {
-        uint8_t *dptr;
-        uint16_t n = 0;
-    
-        used(minor); 
-        used(flag);
+	if ((dev >> 4) != 0)
+		return 0;
 
-        if (rawflag == 1) { 
-                if (d_blkoff(BLKSHIFT))
-                        return -1;
-        }
-        /* No swap support yet. In the swap case we do I/O to or from the page
-           in swappage */
-        if (rawflag == 2)
-                return -1;
-    
-        // seek to wanted block
-        port_fs_prm0 = udata.u_block & 255;
-        port_fs_prm1 = udata.u_block >> 8;
-        port_fs_cmd = FS_CMD_SEEK;
+	/* seek to wanted block using 24-bit LBA */
+	io_disk_prm0 = (uint8_t)(lba & 255);
+	io_disk_prm1 = (uint8_t)(lba >> 8);
+	io_disk_prm2 = (uint8_t)(lba >> 16);
+	io_disk_cmd = DISK_CMD_SEEK;
+	if (io_disk_status != DISK_STATUS_OK)
+		return 0;
 
-        if (port_fs_status != FS_STATUS_OK)
-                return -1;
-    
-        dptr = udata.u_dptr;
-        hd_mode = rawflag;
-
-        // kprintf("I/O %u sector(s) from %u to address %u\n", udata.u_nblock, udata.u_block, udata.u_dptr);
-
-        while (udata.u_nblock--) {
-                if (is_read) {
-                        if (hd_data_in(dptr))
-                                break;
-                } else if (hd_data_out(dptr))
-                        break;
-                dptr += BLKSIZE;
-                n += BLKSIZE;
-        }
-        // kprintf("I/O completd %u\n", n);
-        return n;
+	/* transfer a block */
+	if (is_read) {
+		if (hd_data_in(dptr))
+			return 0; /* failure to read complete block */
+	} else {
+		if (hd_data_out(dptr))
+			return 0; /* failure to write complete block */
+	}
+	/* all is well! */
+	return 1;
 }
 
-int hd_read(uint8_t minor, uint8_t rawflag, uint8_t flag)
+void hd_init(void)
 {
-        used(flag);
-	return hd_rw(minor, true, rawflag);
-}
-
-int hd_write(uint8_t minor, uint8_t rawflag, uint8_t flag)
-{
-        used(flag);
-	return hd_rw(minor, false, rawflag);
+	td_register(0, hd_xfer, td_ioctl_none, 1);
 }

--- a/Kernel/platform/platform-pz1/devhd.h
+++ b/Kernel/platform/platform-pz1/devhd.h
@@ -2,9 +2,7 @@
 #define __DEVHD_DOT_H__
 
 /* public interface */
-int hd_read(uint_fast8_t minor, uint_fast8_t rawflag, uint_fast8_t flag);
-int hd_write(uint_fast8_t minor, uint_fast8_t rawflag, uint_fast8_t flag);
-int hd_open(uint_fast8_t minor, uint16_t flag);
+void hd_init(void);
 
 #endif /* __DEVHD_DOT_H__ */
 

--- a/Kernel/platform/platform-pz1/devices.c
+++ b/Kernel/platform/platform-pz1/devices.c
@@ -4,31 +4,31 @@
 #include <devsys.h>
 #include <tty.h>
 #include <devtty.h>
+#include <tinydisk.h>
 #include <devhd.h>
 
 struct devsw dev_tab[] =  /* The device driver switch table */
 {
-//     open         close       read       write       ioctl
+//	open		close		read		write		ioctl
 // -----------------------------------------------------------------
-    /* 0: /dev/hd - block device interface */
-    {  hd_open,     no_close,   hd_read,   hd_write,   no_ioctl},
-    /* 1: /dev/fd - Floppy disk block devices */
-    {  no_open,	    no_close,	no_rdwr,   no_rdwr,    no_ioctl},
-    /* 2: /dev/tty	TTY devices */
-    {  tty_open,    tty_close,  tty_read,  tty_write,  tty_ioctl},
-    /* 3: /dev/lpr	Printer devices */
-    {  no_open,     no_close,   no_rdwr,   no_rdwr,    no_ioctl},
-    /* 4: /dev/mem etc	System devices (one offs) */
-    {  no_open,     no_close,   sys_read,  sys_write,  sys_ioctl},
-    /* Pack to 7 with nxio if adding private devices and start at 8 */
+	/* 0: /dev/hd - block device interface */
+	{  td_open,	no_close,	td_read,	td_write,	td_ioctl},
+	/* 1: /dev/fd - Floppy disk block devices */
+	{  no_open,	no_close,	no_rdwr,	no_rdwr,	no_ioctl},
+	/* 2: /dev/tty	TTY devices */
+	{  tty_open,	tty_close,	tty_read,	tty_write,	tty_ioctl},
+	/* 3: /dev/lpr	Printer devices */
+	{  no_open,	no_close,	no_rdwr,	no_rdwr,	no_ioctl},
+	/* 4: /dev/mem etc	System devices (one offs) */
+	{  no_open,	no_close,	sys_read,	sys_write,	sys_ioctl},
+	/* Pack to 7 with nxio if adding private devices and start at 8 */
 };
 
 bool validdev(uint16_t dev)
 {
-    /* This is a bit uglier than needed but the right hand side is a constant this way */
-    if(dev > ((sizeof(dev_tab)/sizeof(struct devsw)) << 8) - 1)
-        return false;
-    else
-        return true;
+	/* This is a bit uglier than needed but the right hand side is a constant this way */
+	if(dev > ((sizeof(dev_tab)/sizeof(struct devsw)) << 8) - 1)
+		return false;
+	else
+		return true;
 }
-

--- a/Kernel/platform/platform-pz1/devtty.c
+++ b/Kernel/platform/platform-pz1/devtty.c
@@ -37,12 +37,12 @@ void kputchar(uint8_t c)
 ttyready_t tty_writeready(uint8_t minor)
 {
 	if (minor == 1) {
-		if ((port_serial_0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
+		if ((io_serial_0_flags & SERIAL_FLAGS_OUT_FULL) == 0)
 			return TTY_READY_NOW;
 		else
 			return TTY_READY_SOON;
 	} else {
-		if ((port_serial_1_flags & SERIAL_FLAGS_OUT_FULL) == 0)
+		if ((io_serial_1_flags & SERIAL_FLAGS_OUT_FULL) == 0)
 			return TTY_READY_NOW;
 		else
 			return TTY_READY_SOON;
@@ -52,13 +52,13 @@ ttyready_t tty_writeready(uint8_t minor)
 void tty_putc(uint8_t minor, unsigned char c)
 {
 	if (minor == 1) {
-		while ((port_serial_0_flags & SERIAL_FLAGS_OUT_FULL) != 0);
+		while ((io_serial_0_flags & SERIAL_FLAGS_OUT_FULL) != 0);
 		// do nothing
-		port_serial_0_out = c;
+		io_serial_0_out = c;
 	} else {
-		while ((port_serial_1_flags & SERIAL_FLAGS_OUT_FULL) != 0);
+		while ((io_serial_1_flags & SERIAL_FLAGS_OUT_FULL) != 0);
 		// do nothing
-		port_serial_1_out = c;
+		io_serial_1_out = c;
 	}
 
 
@@ -66,26 +66,31 @@ void tty_putc(uint8_t minor, unsigned char c)
 
 void tty_setup(uint8_t minor, uint8_t flag)
 {
+	used(minor);
+	used(flag);
 }
 
 void tty_sleeping(uint8_t minor)
 {
+	used(minor);
 }
 
 /* For the moment */
 int tty_carrier(uint8_t minor)
 {
+	used(minor);
 	return 1;
 }
 
 void tty_data_consumed(uint8_t minor)
 {
+	used(minor);
 }
 
 void tty_poll(void)
 {
-	while (port_serial_0_flags & SERIAL_FLAGS_IN_AVAIL)
-		tty_inproc(1, port_serial_0_in);
-	while (port_serial_1_flags & SERIAL_FLAGS_IN_AVAIL)
-		tty_inproc(2, port_serial_1_in);
+	while (io_serial_0_flags & SERIAL_FLAGS_IN_AVAIL)
+		tty_inproc(1, io_serial_0_in);
+	while (io_serial_1_flags & SERIAL_FLAGS_IN_AVAIL)
+		tty_inproc(2, io_serial_1_in);
 }

--- a/Kernel/platform/platform-pz1/main.c
+++ b/Kernel/platform/platform-pz1/main.c
@@ -2,18 +2,18 @@
 #include <timer.h>
 #include <kdata.h>
 #include <printf.h>
-//#include <blkdev.h>
 #include <devtty.h>
 #include <ports.h>
+#include <devhd.h>
 
 uint8_t kernel_flag = 1;
 uint16_t swap_dev = 0xFFFF;
 
 void plt_idle(void)
 {
-    irqflags_t flags = di();
-    tty_poll();
-    irqrestore(flags);
+	irqflags_t flags = di();
+	tty_poll();
+	irqrestore(flags);
 }
 
 void do_beep(void)
@@ -26,11 +26,11 @@ void do_beep(void)
 
 void pagemap_init(void)
 {
-    int i;
-    /* Add the user banks, taking care to land 4 as the last one as we
-       use that for init (0/1/2/3 are the kernel) */
-    for (i = 6; i >= 0; i--)
-        pagemap_add(4 + i * 4);
+	int i;
+	/* Add the user banks, taking care to land 4 as the last one as we
+	use that for init (0/1/2/3 are the kernel) */
+	for (i = 6; i >= 0; i--)
+		pagemap_add(4 + i * 4);
 }
 
 void map_init(void)
@@ -39,20 +39,22 @@ void map_init(void)
 
 uint8_t plt_param(char *p)
 {
-    return 0;
+	used(p);
+	return 0;
 }
 
 void device_init(void)
 {
 	//set 100Hz
-        //IRQ-timer counts 900 ticks per sec
-	port_irq_timer_target = 900 / TICKSPERSEC;
+	//IRQ-timer counts 900 ticks per sec
+	io_timer_target = 900 / TICKSPERSEC;
+	hd_init();
 }
 
 void plt_interrupt(void)
 {
 	tty_poll();
 	// writing any value will ack IRQ and restart timer
-	port_irq_timer_reset = 0;
+	io_timer_reset = 0;
 	timer_interrupt();
 }

--- a/Kernel/platform/platform-pz1/ports.def
+++ b/Kernel/platform/platform-pz1/ports.def
@@ -1,30 +1,32 @@
-PORT_BANK_0             .set $FE00
-PORT_BANK_1             .set $FE01
-PORT_BANK_2             .set $FE02
-PORT_BANK_3             .set $FE03
+IO_BANK_0		.set $FE00
+IO_BANK_1		.set $FE01
+IO_BANK_2		.set $FE02
+IO_BANK_3		.set $FE03
 
-PORT_SERIAL_0_FLAGS     .set $FE10 ; bit 7: out buffer full, bit 6: in-data available
-PORT_SERIAL_0_IN        .set $FE11
-PORT_SERIAL_0_OUT       .set $FE12
-PORT_SERIAL_1_FLAGS     .set $FE18 ; bit 7: out buffer full, bit 6: in-data available
-PORT_SERIAL_1_IN        .set $FE19
-PORT_SERIAL_1_OUT       .set $FE1A
-SERIAL_FLAGS_OUT_FULL   .set   128
-SERIAL_FLAGS_IN_AVAIL   .set    64
+IO_SERIAL_0_FLAGS	.set $FE10 ; bit 7: out buffer full, bit 6: in-data available
+IO_SERIAL_0_IN		.set $FE11
+IO_SERIAL_0_OUT		.set $FE12
+IO_SERIAL_1_FLAGS	.set $FE18 ; bit 7: out buffer full, bit 6: in-data available
+IO_SERIAL_1_IN		.set $FE19
+IO_SERIAL_1_OUT		.set $FE1A
+SERIAL_FLAGS_OUT_FULL	.set   128
+SERIAL_FLAGS_IN_AVAIL	.set    64
 
-PORT_FILE_SYSTEM_CMD    .set $FE60
-PORT_FILE_SYSTEM_PRM_0  .set $FE61
-PORT_FILE_SYSTEM_PRM_1  .set $FE62
-PORT_FILE_SYSTEM_DATA   .set $FE63
-PORT_FILE_SYSTEM_STATUS .set $FE64
-FS_CMD_SELECT           .set 0
-FS_CMD_SEEK             .set 1
-FS_STATUS_OK            .set 0
-FS_STATUS_NOK           .set 1
+IO_DISK_CMD		.set $FE60
+IO_DISK_PRM_0		.set $FE61
+IO_DISK_PRM_1		.set $FE62
+IO_DISK_PRM_2		.set $FE63
+IO_DISK_PRM_3		.set $FE64
+IO_DISK_DATA		.set $FE65
+IO_DISK_STATUS		.set $FE66
+DISK_CMD_SELECT		.set 0
+DISK_CMD_SEEK		.set 1
+DISK_STATUS_OK		.set 0
+DISK_STATUS_NOK		.set 1
 
-PORT_IRQ_TIMER_TARGET   .set $FE80
-PORT_IRQ_TIMER_COUNT    .set $FE81
-PORT_IRQ_TIMER_RESET    .set $FE82
-PORT_IRQ_TIMER_TRIG     .set $FE83
-PORT_IRQ_TIMER_PAUSE    .set $FE84
-PORT_IRQ_TIMER_CONT     .set $FE85
+IO_TIMER_TARGET		.set $FE80
+IO_TIMER_COUNT		.set $FE81
+IO_TIMER_RESET		.set $FE82
+IO_TIMER_TRIG		.set $FE83
+IO_TIMER_PAUSE		.set $FE84
+IO_TIMER_CONT		.set $FE85

--- a/Kernel/platform/platform-pz1/ports.h
+++ b/Kernel/platform/platform-pz1/ports.h
@@ -1,30 +1,32 @@
-#define port_bank_0                 (*(volatile uint8_t *)0xFE00)
-#define port_bank_1                 (*(volatile uint8_t *)0xFE01)
-#define port_bank_2                 (*(volatile uint8_t *)0xFE02)
-#define port_bank_3                 (*(volatile uint8_t *)0xFE03)
+#define io_bank_0		(*(volatile uint8_t *)0xFE00)
+#define io_bank_1		(*(volatile uint8_t *)0xFE01)
+#define io_bank_2		(*(volatile uint8_t *)0xFE02)
+#define io_bank_3		(*(volatile uint8_t *)0xFE03)
 
-#define port_serial_0_flags         (*(volatile uint8_t *)0xFE10)
-#define port_serial_0_in            (*(volatile uint8_t *)0xFE11)
-#define port_serial_0_out           (*(volatile uint8_t *)0xFE12)
-#define port_serial_1_flags         (*(volatile uint8_t *)0xFE18)
-#define port_serial_1_in            (*(volatile uint8_t *)0xFE19)
-#define port_serial_1_out           (*(volatile uint8_t *)0xFE1A)
-#define SERIAL_FLAGS_OUT_FULL       128
-#define SERIAL_FLAGS_IN_AVAIL       64
+#define io_serial_0_flags	(*(volatile uint8_t *)0xFE10)
+#define io_serial_0_in		(*(volatile uint8_t *)0xFE11)
+#define io_serial_0_out		(*(volatile uint8_t *)0xFE12)
+#define io_serial_1_flags	(*(volatile uint8_t *)0xFE18)
+#define io_serial_1_in		(*(volatile uint8_t *)0xFE19)
+#define io_serial_1_out		(*(volatile uint8_t *)0xFE1A)
+#define SERIAL_FLAGS_OUT_FULL	128
+#define SERIAL_FLAGS_IN_AVAIL	64
 
-#define port_fs_cmd                 (*(volatile uint8_t *)0xFE60)
-#define port_fs_prm0                (*(volatile uint8_t *)0xFE61)
-#define port_fs_prm1                (*(volatile uint8_t *)0xFE62)
-#define port_fs_data                (*(volatile uint8_t *)0xFE63)
-#define port_fs_status              (*(volatile uint8_t *)0xFE64)
-#define FS_CMD_SELECT               0
-#define FS_CMD_SEEK                 1
-#define FS_STATUS_OK                0
-#define FS_STATUS_NOK               1
+#define io_disk_cmd		(*(volatile uint8_t *)0xFE60)
+#define io_disk_prm0		(*(volatile uint8_t *)0xFE61)
+#define io_disk_prm1		(*(volatile uint8_t *)0xFE62)
+#define io_disk_prm2		(*(volatile uint8_t *)0xFE63)
+#define io_disk_prm3		(*(volatile uint8_t *)0xFE64)
+#define io_disk_data		(*(volatile uint8_t *)0xFE65)
+#define io_disk_status		(*(volatile uint8_t *)0xFE66)
+#define DISK_CMD_SELECT		0
+#define DISK_CMD_SEEK		1
+#define DISK_STATUS_OK		0
+#define DISK_STATUS_NOK		1
 
-#define port_irq_timer_target       (*(volatile uint8_t *)0xFE80)
-#define port_irq_timer_count        (*(volatile uint8_t *)0xFE81)
-#define port_irq_timer_reset        (*(volatile uint8_t *)0xFE82)
-#define port_irq_timer_trig         (*(volatile uint8_t *)0xFE83)
-#define port_irq_timer_pause        (*(volatile uint8_t *)0xFE84)
-#define port_irq_timer_cont         (*(volatile uint8_t *)0xFE85)
+#define io_timer_target		(*(volatile uint8_t *)0xFE80)
+#define io_timer_count		(*(volatile uint8_t *)0xFE81)
+#define io_timer_reset		(*(volatile uint8_t *)0xFE82)
+#define io_timer_trig		(*(volatile uint8_t *)0xFE83)
+#define io_timer_pause		(*(volatile uint8_t *)0xFE84)
+#define io_timer_cont		(*(volatile uint8_t *)0xFE85)

--- a/Kernel/platform/platform-pz1/tricks.s
+++ b/Kernel/platform/platform-pz1/tricks.s
@@ -84,7 +84,7 @@ _switchin:
 	ldy	#P_TAB__P_PAGE_OFFSET
 	lda	(ptr1),y
 ;	jsr	outcharhex
-	sta	PORT_BANK_0		; switches zero page, stack memory area
+	sta	IO_BANK_0		; switches zero page, stack memory area
 	; ------- No valid stack, new ZP ----- stack must not be used
 
 	; Set ptr1 back up (the old ptr1 was on the other ZP)
@@ -195,7 +195,7 @@ _dofork:
 	stx ptr1+1
 	ldy #P_TAB__P_PAGE_OFFSET
 	lda (ptr1),y
-	sta PORT_BANK_0			; switch to child and child stack
+	sta IO_BANK_0			; switch to child and child stack
 					; and zero page etc
 	; We are now in the kernel child context
 
@@ -240,10 +240,10 @@ _dofork:
 fork_copy:
 	ldy #P_TAB__P_PAGE_OFFSET
 	lda (ptr1),y		; child->p_pag[0]
-	sta PORT_BANK_2		; 8000
+	sta IO_BANK_2		; 8000
 	sta tmp1
 	lda _udata + U_DATA__U_PAGE
-	sta PORT_BANK_1		; 4000
+	sta IO_BANK_1		; 4000
 	sta tmp2
 
 	; Now use that window to copy 48K from 0000-BFFF
@@ -253,25 +253,25 @@ fork_copy:
 	inc tmp1
 	inc tmp2
 	lda tmp1
-	sta PORT_BANK_2
+	sta IO_BANK_2
 	lda tmp2
-	sta PORT_BANK_1
+	sta IO_BANK_1
 	jsr bank2bank		; second 16K
 
 	inc tmp1
 	inc tmp2
 	lda tmp1
-	sta PORT_BANK_2
+	sta IO_BANK_2
 	lda tmp2
-	sta PORT_BANK_1
+	sta IO_BANK_1
 	jsr bank2bank		; third 16K
 
 	inc tmp1
 	inc tmp2
 	lda tmp1
-	sta PORT_BANK_2
+	sta IO_BANK_2
 	lda tmp2
-	sta PORT_BANK_1
+	sta IO_BANK_1
 	jsr bank2bank		; final block
 
 	jmp map_kernel		; put the kernel mapping back as it should be
@@ -332,9 +332,9 @@ copy1:
 
 _create_init_common:
 	lda #0
-	sta PORT_BANK_1		;	set the map for 0x4000
+	sta IO_BANK_1		;	set the map for 0x4000
 	lda #4
-	sta PORT_BANK_2		;	and 0x8000
+	sta IO_BANK_2		;	and 0x8000
 	jsr bank2bank
 	jmp map_kernel
 ;

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@
 # zx+3:		ZX Spectrum +3
 # zxdiv:	ZX Spectrum 128K with DivIDE/DivMMC interface
 
-TARGET=sc720
+TARGET=pz1
 
 include version.mk
 


### PR DESCRIPTION
These are the latest changes for the PZ1 platform. There will be a corresponding EmulatorKit pull request.

24-bit LBA block-device implemented via tinydisk, swap still missing Renamed PORT_ to IO_, _IRQ_TIMER to _TIMER
Some formatting (tabs & spaces)
Makefile updates