### PR TITLE
Patched `ps` that reports used memory for Pi Pico

### DIFF
--- a/Kernel/platform/platform-rpipico/.gitignore
+++ b/Kernel/platform/platform-rpipico/.gitignore
@@ -1,0 +1,7 @@
+utils/progbase.h
+utils/ps
+utils/ps.c
+utils/*.o
+filesystem.*
+uf2conv
+

--- a/Kernel/platform/platform-rpipico/Makefile
+++ b/Kernel/platform/platform-rpipico/Makefile
@@ -31,6 +31,7 @@ clean:
 	$(MAKE) -C ../../../Applications/cave -f Makefile.armm0 clean
 	$(MAKE) -C ../../../Applications/cursesgames -f Makefile.armm0 clean
 	$(MAKE) -C ../../../Standalone clean
+	$(MAKE) -C utils clean
 
 world: build/fuzix.elf
 	$(MAKE) -C ../../../Library/libs -f Makefile.armm0
@@ -42,6 +43,7 @@ world: build/fuzix.elf
 	$(MAKE) -C ../../../Applications/cave -f Makefile.armm0
 	$(MAKE) -C ../../../Applications/cursesgames -f Makefile.armm0
 	$(MAKE) -C ../../../Standalone
+	$(MAKE) -C utils
 
 uf2conv: tools/uf2conv.c
 	cc -O -g -o $@ $<

--- a/Kernel/platform/platform-rpipico/update-flash.sh
+++ b/Kernel/platform/platform-rpipico/update-flash.sh
@@ -167,9 +167,11 @@ bget ../../../Applications/util/tail
 bget ../../../Applications/util/touch
 bget ../../../Applications/util/tr
 bget ../../../Applications/util/true
+bget ../../../Applications/util/telinit
 bget ../../../Applications/util/umount
 bget ../../../Applications/util/uniq
 bget ../../../Applications/util/uptime
+bget ../../../Applications/util/uname
 bget ../../../Applications/util/uud
 bget ../../../Applications/util/uue
 bget ../../../Applications/util/wc
@@ -253,9 +255,11 @@ chmod 0755 tail
 chmod 0755 touch
 chmod 0755 tr
 chmod 0755 true
+chmod 0755 telinit
 chmod 0755 umount
 chmod 0755 uniq
 chmod 0755 uptime
+chmod 0755 uname
 chmod 0755 uud
 chmod 0755 uue
 chmod 0755 wc

--- a/Kernel/platform/platform-rpipico/update-flash.sh
+++ b/Kernel/platform/platform-rpipico/update-flash.sh
@@ -145,7 +145,7 @@ bget ../../../Applications/util/pagesize
 bget ../../../Applications/util/passwd
 bget ../../../Applications/util/printenv
 bget ../../../Applications/util/prtroot
-bget ../../../Applications/util/ps
+bget utils/ps
 bget ../../../Applications/util/pwd
 bget ../../../Applications/util/reboot
 bget ../../../Applications/util/remount

--- a/Kernel/platform/platform-rpipico/utils/Makefile
+++ b/Kernel/platform/platform-rpipico/utils/Makefile
@@ -1,0 +1,33 @@
+ROOT=../../../..
+FUZIX_ROOT=$(ROOT)
+USERCPU=armm0
+VERBOSE=1
+include $(FUZIX_ROOT)/Target/rules.$(USERCPU)
+
+UTILS = ps.c
+UTILSO = $(UTILS:.c=.o)
+UTILSBIN = $(UTILS:.c=)
+
+.PHONY: all clean
+
+all: $(UTILSBIN)
+
+clean:
+	rm -f *.o
+	rm -f $(UTILSBIN)
+	rm -f progbase.h
+	rm -f ps.c
+
+$(UTILSBIN): %: %.o
+	$(LINKER) $(CRT0) $^ -o $@ $(LINKER_OPT) $(LINKER_TAIL)
+
+ps.c: ps-rpipico.patch
+	cp ../../../../Applications/util/ps.c .
+	patch ps.c < ps-rpipico.patch
+
+%.o: %.c progbase.h
+	$(CC) $(CFLAGS) $(CCOPTS) -c $<
+
+progbase.h: ../build/fuzix.elf
+	nm ../build/fuzix.elf | grep progbase | awk '{print "#define PROGBASE 0x" $$1}' > progbase.h
+

--- a/Kernel/platform/platform-rpipico/utils/ps-rpipico.patch
+++ b/Kernel/platform/platform-rpipico/utils/ps-rpipico.patch
@@ -1,0 +1,33 @@
+--- ../../../../Applications/util/ps.c	2024-02-12 16:06:26.445511000 -0700
++++ ps.c	2024-03-31 10:58:57.708871714 -0600
+@@ -35,6 +35,7 @@
+ #include <pwd.h>
+ #include <fcntl.h>
+ #include <time.h>
++#include "progbase.h"
+ 
+ #define TTY_MAJOR	2		/* Be nice if we didn't have to
+ 					   just know this */
+@@ -66,6 +67,9 @@
+ #define OF_TIME		8192		/* Cumulative execution time */
+ #define OF_CMD		16384		/* Command line */
+ 
++#define BLOCKSIZE 4096
++#define alignup(v,a) (uint8_t*)((intptr_t)((v) + (a)-1) & ~((a)-1))
++
+ static const char *month = "JanFebMarAprMayJunJulAugSepOctNovDec";
+ 
+ static char mapstat(char s)
+@@ -348,7 +352,11 @@
+ 	if (outflags & OF_ADDR)
+ 		fputs("    - ", stdout);
+ 	if (outflags & OF_SZ)
+-		fputs("    - ", stdout);
++	{
++		long size = pp->p_top - PROGBASE;
++		size = (long)alignup(size, BLOCKSIZE) / 1024;
++		printf("%5d ", size);
++	}
+ 	if (outflags & OF_WCHAN) {
+ 		if (pp->p_status > 2)
+ 			printf(" %4x ", (unsigned int)pp->p_wait);


### PR DESCRIPTION
For pico every program is located at `PROGBASE`, so substracting it from `p_top` and rounding up to the ram block size (4k) will result in the correct value of memory allocated for process.