### PR TITLE
Fixing library p_tab to match kernel p_tab

### DIFF
--- a/Library/include/proc.h
+++ b/Library/include/proc.h
@@ -59,28 +59,23 @@ struct p_tab {
 #ifdef __XTENSA_CALL0_ABI__
     unsigned int p_texttop;	/* Copy of u_texttop */
 #endif
-};
-
-/* Followed by this structure if profiling supported */
-struct p_prof {
+#ifdef CONFIG_LEVEL_2
+    uint16_t	p_session;
+#endif
+#ifdef CONFIG_PROFIL
     uint8_t     p_profscale;
     void *      p_profbuf;
     uint16_t    p_profsize;
     uint16_t    p_profoff;
+#endif
+    void *p_timerq;
 };
 
-/* Then this one if level 2 */
-struct p_level_2 {
-    uint16_t	p_session;
-};
 
 /* The offsets of the prof structure are not guaranteed to be as per this
    structure. Use this only for sizing */
 struct p_tab_buffer {
     struct p_tab	p_tab;
-    struct p_level_2	_l2;
-    struct p_prof	_prof;
-    void *p_timerq;
 };
 
 #endif /* __PROC_H */


### PR DESCRIPTION
Fixes #1069 

Okay, this turned out nastier than I thought. It is caused specifically by the `ps.c:475`

    ppid_slot[i] = ptab[i].p_tab.p_pptr - ptab[0].p_tab.p_pptr;

So as it turns out it was broken before and after `struct p_tab` change, it just was breaking differently. `Library/struct p_tab` actually has different size than `Kernel/struct p_tab`. Because `Kernel/p_tab` is larger, subtraction does not result in a value divisible by `Library/p_tab`, which I believe is UB.

    before psize change
    # ps -la                                                                               
    ppid_slot[0] = 0. Address difference 0x00000000. Misallignment: 0 Ptab size: 0x0058    
    ppid_slot[1] = 0. Address difference 0x00000000. Misallignment: 0 Ptab size: 0x0058    
    ppid_slot[2] = 1. Address difference 0x0000005c. Misallignment: 4 Ptab size: 0x0058    
    
    after psize change
    # ps -la   
    ppid_slot[0] = 0. Address difference 0x00000000. Misallignment: 0 Ptab size: 0x005c    
    ppid_slot[1] = 0. Address difference 0x00000000. Misallignment: 0 Ptab size: 0x005c    
    ppid_slot[2] = 14248. Address difference 0x00000060. Misallignment: 4 Ptab size: 0x005c

What actually breaks is line 341 where we try to get the process in the slot 14248... 

    printf("%5d ", ptab[ppid_slot[i]].p_tab.p_pid);