### PR TITLE
tinyide: fix IDE device detection on boot

### DIFF
--- a/Kernel/dev/tinyide_discard.c
+++ b/Kernel/dev/tinyide_discard.c
@@ -72,6 +72,8 @@ static void ide_identify(int dev, uint8_t *buf)
 		ide_write(cmd, 0xEF);
 	}
 #endif
+	if (ide_wait_nbusy() == -1)
+		return;
 	if (ide_wait_drdy() == -1)
 		return;
 	ide_write(cmd, 0xEC);	/* Identify */


### PR DESCRIPTION
In my case (SC111 with SC145 and CF), the device signals DRDY before BSY is 0, which leads to a timeout and failed disk detection. So wait for BSY to be 0 in addition to DRDY before submitting the identify command.