### PR TITLE
netd: fix /dev/eth colliding with later introduced /dev/rd0

### DIFF
--- a/Applications/netd/fuzix-netd.pkg
+++ b/Applications/netd/fuzix-netd.pkg
@@ -30,4 +30,4 @@ f 0755 /usr/bin/netd-slip      netd-slip
 package  netd-eth
 if-file  netd-eth
 f 0755 /usr/bin/netd-eth  netd-eth
-n 020666 2048 /dev/eth
+n 020666 2304 /dev/eth

--- a/Kernel/platform/platform-tm4c129x/devices.c
+++ b/Kernel/platform/platform-tm4c129x/devices.c
@@ -24,11 +24,12 @@ struct devsw dev_tab[] =  /* The device driver switch table */
   /* 4: /dev/mem etc - System devices (one offs) */
   {  no_open,       no_close,   sys_read,       sys_write,      sys_ioctl },
 #ifdef CONFIG_NET
-  /* Pack to 7 with nxio if adding private devices and start at 8 */
+  /* Pack to 8 with nxio if adding private devices and start at 9 */
   {  nxio_open,     no_close,   no_rdwr,        no_rdwr,        no_ioctl },
   {  nxio_open,     no_close,   no_rdwr,        no_rdwr,        no_ioctl },
   {  nxio_open,     no_close,   no_rdwr,        no_rdwr,        no_ioctl },
-  /* 8: /dev/eth ethernet device raw access */
+  {  nxio_open,     no_close,   no_rdwr,        no_rdwr,        no_ioctl },
+  /* 9: /dev/eth ethernet device raw access */
   {  eth_open,      eth_close,  eth_read,       eth_write,      eth_ioctl },
 #endif
 };


### PR DESCRIPTION
I've found it when looking into the `/dev` tree on dk-tm4c129x
