### PR TITLE
build: the toolchain can be installed anywhere, e.g. in the home directory

### DIFF
--- a/Tools/build-armm4
+++ b/Tools/build-armm4
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-X=`which /opt/gcc-arm-eabi/bin/arm-none-eabi-gcc`
+X=`which arm-none-eabi-gcc`
 if [ "$X" = "" ]; then
-	echo "gcc: /opt/gcc-arm-eabi/bin/arm-none-eabi-gcc is required"
+	echo "gcc: arm-none-eabi-gcc is required"
 	exit 1
 fi


### PR DESCRIPTION
As long as the cross-compiler is in the PATH, there should be no complaints.