### PR TITLE
armm0: support gcc installation that is not in /opt

### DIFF
--- a/Tools/build-armm0
+++ b/Tools/build-armm0
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-X=`which /opt/gcc-arm-eabi/bin/arm-none-eabi-gcc`
+X=`which arm-none-eabi-gcc /opt/gcc-arm-eabi/bin/arm-none-eabi-gcc 2>/dev/null | head -n1`
 if [ "$X" = "" ]; then
-	echo "gcc: /opt/gcc-arm-eabi/bin/arm-none-eabi-gcc is required"
-	exit 1
+    echo "gcc: arm-none-eabi-gcc is required"
+    exit 1
 fi


### PR DESCRIPTION
I was testing clean build from scratch `make TARGET=rpipico`.
Because I don't run debian (I think) I needed to fix up script that locates gcc. I believe it should still be backwards compatible.