### PR TITLE
CPC6128 and ZX+3 fixes

### DIFF
--- a/Kernel/dev/cpc/albireo.c
+++ b/Kernel/dev/cpc/albireo.c
@@ -41,7 +41,7 @@ not_swapin:
 doread:
             ld bc,#0x7f10
             out (c),c
-            ld c,#0x53
+            ld c,#0x4a  ;yellow
             out (c),c
             ld bc, #CH376_REG_DATA                    ; setup port number
                                                     ; and count
@@ -110,13 +110,13 @@ doread:
             inc b
             ini
             inc b
-            push bc
-            ld bc,#0x7f10
-            out (c),c
-            ld c,#0x4c
-            out (c),c
+            ;push bc
+            ;ld bc,#0x7f10
+            ;out (c),c
+            ;ld c,#0x4c
+            ;out (c),c
                       ; transfer second 32 bytes
-            pop bc
+            ;pop bc
             ini
             inc b
             ini
@@ -226,7 +226,7 @@ dowrite:
 
             ld bc,#0x7f10
             out (c),c
-            ld c,#0x55
+            ld c,#0x4e  ;orange
             out (c),c
             ld bc, #CH376_REG_DATA                    ; setup port number
                                                     ; and count
@@ -295,12 +295,12 @@ dowrite:
             outi
             inc b
             outi
-            push bc
-            ld bc,#0x7f10
-            out (c),c
-            ld c,#0x4e
-            out (c),c                                   
-            pop bc
+            ;push bc
+            ;ld bc,#0x7f10
+            ;out (c),c
+            ;ld c,#0x55
+            ;out (c),c                                   
+            ;pop bc
             inc b
             outi
             inc b

--- a/Kernel/dev/cpc/video.s
+++ b/Kernel/dev/cpc/video.s
@@ -1,16 +1,16 @@
 ;
-;        zx128 vt primitives
+;        amstrad cpc vt primitives
 ;
         ; exported symbols
-        .globl zx_plot_char
-        .globl zx_scroll_down
-        .globl zx_scroll_up
-        .globl zx_cursor_on
-        .globl zx_cursor_off
-	.globl zx_cursor_disable
-        .globl zx_clear_lines
-        .globl zx_clear_across
-        .globl zx_do_beep
+        .globl cpc_plot_char
+        .globl cpc_scroll_down
+        .globl cpc_scroll_up
+        .globl cpc_cursor_on
+        .globl cpc_cursor_off
+	.globl cpc_cursor_disable
+        .globl cpc_clear_lines
+        .globl cpc_clear_across
+        .globl cpc_do_beep
 	.globl _fontdata_8x8
 	.globl _curattr
 	.globl _vtattr
@@ -66,10 +66,10 @@ scr_next_line:                    ;{{Addr=$0c1f Code Calls/jump count: 10 Data u
         set 6,d
         ret                 
 
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _plot_char:
 	.endif
-zx_plot_char:
+cpc_plot_char:
         pop hl
         pop de              ; D = x E = y
         pop bc
@@ -159,10 +159,10 @@ last_ul:
 	ld a,#0xff
 	jr plot_attr
 
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _clear_lines:
 	.endif
-zx_clear_lines:
+cpc_clear_lines:
         pop hl
         pop de              ; E = line, D = count
         push de
@@ -191,10 +191,10 @@ nextline:
         ret
 
 
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _clear_across:
 	.endif
-zx_clear_across:
+cpc_clear_across:
         pop hl
         pop de              ; DE = coords 
         pop bc              ; C = count
@@ -271,10 +271,10 @@ set_hardware_scroll:
         add hl,hl
         ld (scroll_offset),hl   ;prepare scroll_offset for videopos
         ret
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _scroll_up:
 	.endif
-zx_scroll_up:
+cpc_scroll_up:
         ld hl, (CRTC_offset)
         ld bc, #32           ; one crtc character are two bytes
         add hl,bc
@@ -284,10 +284,10 @@ zx_scroll_up:
         ld (CRTC_offset),hl
         jr set_hardware_scroll
  
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _scroll_down:
 	.endif
-zx_scroll_down:
+cpc_scroll_down:
         ld hl, (CRTC_offset)
         ld bc, #32           ; one crtc character are two bytes
         or a
@@ -299,10 +299,10 @@ zx_scroll_down:
         jr set_hardware_scroll
         ret
 
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _cursor_on:
 	.endif
-zx_cursor_on:
+cpc_cursor_on:
         pop hl
         pop de
         push de
@@ -319,12 +319,12 @@ set_cursor_line:
 
 	VIDEO_UNMAP
         ret
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _cursor_disable:
 _cursor_off:
 	.endif
-zx_cursor_disable:
-zx_cursor_off:
+cpc_cursor_disable:
+cpc_cursor_off:
         ld de, (cursorpos)
         call videopos
 
@@ -337,10 +337,10 @@ reset_cursor_line:
 	
         VIDEO_UNMAP
 
-	.if ZXVID_ONLY
+	.if CPCVID_ONLY
 _do_beep:
 	.endif
-zx_do_beep:
+cpc_do_beep:
         ld e,#4
         ld d,#38        ;channel C 110Hz
         call write_ay_reg

--- a/Kernel/platform/platform-cpc6128/README
+++ b/Kernel/platform/platform-cpc6128/README
@@ -8,7 +8,7 @@ The CPC6128 supported memory maps:
  -MAP-	     C0     C1     C2     C3     C4     C5     C6     C7
  0000-3FFF   RAM_0  RAM_0  RAM_4  RAM_0  RAM_0  RAM_0  RAM_0  RAM_0
  4000-7FFF   RAM_1  RAM_1  RAM_5  RAM_3  RAM_4  RAM_5  RAM_6  RAM_7
- 8000-BFFF   RAM_2  RAM_2  RAM_6  RAM_2  RAM_2  RAM_2  RAM_2  RAM_2DATA
+ 8000-BFFF   RAM_2  RAM_2  RAM_6  RAM_2  RAM_2  RAM_2  RAM_2  RAM_2
  C000-FFFF   RAM_3  RAM_7  RAM_7  RAM_7  RAM_3  RAM_3  RAM_3  RAM_3
 
 This port is based on the zx+3 port, following Alan Cox's suggestion to take advantage of the fact that memory maps C1, C2 and C3 correspond to the maps used in the zx+3 port.

--- a/Kernel/platform/platform-cpc6128/cpc6128.s
+++ b/Kernel/platform/platform-cpc6128/cpc6128.s
@@ -1,7 +1,7 @@
 ;
 ;    Spectrum +3 support
 
-        .module plus3
+        .module cpc6128
 
         ; exported symbols
         .globl init_early
@@ -94,12 +94,10 @@ _plt_monitor:
 
 _plt_reboot:
 	di
-	halt ;we are debugging why we end here
-	ld bc, #0x7fc0
+	;halt ;we are debugging why we end here
+	ld bc, #0x7f89 ;this would set the firmware ready for boot into firmware with (out (c),c ; rst0)
 	out (c), c
-	ld bc, #0x7fa9 ;this would set the firmware ready for boot into firmware with (out (c),c ; rst0)
-	out (c), c
-        rst 0		; back into our booter
+	    rst 0		; back into our booter
 
 plt_interrupt_all:
         ret

--- a/Kernel/platform/platform-cpc6128/cpcvideo.s
+++ b/Kernel/platform/platform-cpc6128/cpcvideo.s
@@ -1,8 +1,8 @@
 ;
-;        zx128 vt primitives
+;        cpc vt primitives
 ;
 
-        .module zxvideo
+        .module cpcvideo
 
         ; exported symbols
         .globl _plot_char
@@ -23,7 +23,7 @@
 
 	; Build the video library as the only driver
 
-ZXVID_ONLY	.equ	1
+CPCVID_ONLY	.equ	1
 SCREENBASE	.equ 0x40
 
 .macro VIDEO_MAP

--- a/Kernel/platform/platform-zx+3/plt_ide.h
+++ b/Kernel/platform/platform-zx+3/plt_ide.h
@@ -1,0 +1,13 @@
+__sfr __at 0xA3 data;
+__sfr __at 0xA7 error;
+__sfr __at 0xA8 count;
+__sfr __at 0xAF sec;
+__sfr __at 0xB3 cyll;
+__sfr __at 0xB7 cylh;
+__sfr __at 0xBB devh;
+__sfr __at 0xBF cmd;
+__sfr __at 0xBF status;
+
+#define IDE_REG_DATA	0x00A3
+
+#define IDE_NONSTANDARD_XFER


### PR DESCRIPTION
CPC6128: _plt_reboot bug fix, albireo transfer speed optimization and renaming of things inherited from zx+3 port.
ZX+3: put plt_ide.h in platform folder as build fails without it.