### PR TITLE
wiznet w5x00 - further UDP fixes

### DIFF
--- a/Kernel/network.c
+++ b/Kernel/network.c
@@ -102,7 +102,7 @@ int net_syscall(void)
 			return 0;
 		if (s->s_state < SS_BOUND)
 			break;
-		/* This will put the address into u_net.n_addr for us */
+		/* This will put the address into u_net.addrbuf for us */
 		r = netproto_read(s);
 		udata.u_retval = udata.u_done;
 		return r;

--- a/Kernel/syscall_net.c
+++ b/Kernel/syscall_net.c
@@ -230,7 +230,7 @@ arg_t _netcall(void)
 				/* Copy the buffer, oe less if truncated by size */
 				if (s > udata.u_net.addrlen)
 					s = udata.u_net.addrlen;
-				if (uput(&udata.u_net.addrbuf, (void *) *ap, s) != s) {
+				if (uput(&udata.u_net.addrbuf, (void *) *ap, s) < 0) {
 					udata.u_error = EFAULT;
 					return -1;
 				}


### PR DESCRIPTION
With these changes dig and echoping "work" on a w5500.

Still more fixes required, as echoping will work twice, on the 3rd invocation it seems to never return from the `_netcall-> run_sockfunc -> psleep_flags -> psleep` call when doing the recvfrom. Still working on understanding why this is.