### PR TITLE
Permit fburn for esp8266

### DIFF
--- a/Kernel/platform/platform-esp8266/Makefile
+++ b/Kernel/platform/platform-esp8266/Makefile
@@ -72,7 +72,7 @@ image.elf: kernel.ld addresses.ld $(KOBJS)
 	$(CROSS_CC) -T kernel.ld -T addresses.ld -flto -mlongcalls -nostdlib -o image.elf \
 		$(KOBJS)
 	
-filesystem.img::
+filesystem.img:
 	./update-flash.sh
 
 filesystem.ftl: filesystem.img
@@ -81,6 +81,8 @@ filesystem.ftl: filesystem.img
 
 filesystem.elf: filesystem.ftl
 	xtensa-lx106-elf-objcopy -I binary -O elf32-xtensa-le --change-section-vma .data=0x40220000 filesystem.ftl filesystem.elf
+	xtensa-lx106-elf-ld -Tdata 0x40220000 -o filesystem2.elf filesystem.elf
+	mv filesystem2.elf filesystem.elf
 
 fburn: filesystem.elf
 	esptool elf2image filesystem.elf

--- a/Kernel/platform/platform-esp8266/README.md
+++ b/Kernel/platform/platform-esp8266/README.md
@@ -19,8 +19,18 @@ for further file storage and swap.
 
 ## Building
 
+The kernel needs to know the boot device, therefore, depending on your setup,
+you will need to run one of the following. If your root device is the flash:
 ```
-make TARGET=esp866 kernel diskimage
+make TARGET=esp866 DEFAULT_BOOT=hda kernel
+```
+If your root device in the SD card:
+```
+make TARGET=esp866 DEFAULT_BOOT=hdb1 kernel diskimage
+```
+Then you can build the application and the filesystem:
+```
+make TARGET=esp866 diskimage
 ```
 
 You need the `xtensa-lx106-elf` gcc toolchain --- install the
@@ -63,13 +73,13 @@ Remember to also connect the SD card's GND to any ESP8266 GND pin and Vcc to
 
 The console is UART0, and runs at 115200 baud.
 
-Doing `make -C Kernel/platform-esp8266 burn` will flash the kernel onto the device
-connected on `/dev/ttyUSB0` with this command:
+Doing `make -C Kernel/platform/platform-esp8266 burn` will flash the kernel
+onto the device connected on `/dev/ttyUSB0` with this command:
 
     `esptool --port /dev/ttyUSB0 write_flash 0x00000 image.elf-0x00000.bin 0x10000 image.elf-0x10000.bin -ff 80m -fm dio'
 
-Doing `make -C Kernel/platform-esp8266 fburn` will flash the filesystem onto
-the device in the same manner.
+Doing `make -C Kernel/platform/platform-esp8266 fburn` will flash the
+filesystem onto the device in the same manner.
 
 ## Swap
 

--- a/Kernel/platform/platform-esp8266/README.md
+++ b/Kernel/platform/platform-esp8266/README.md
@@ -20,17 +20,11 @@ for further file storage and swap.
 ## Building
 
 The kernel needs to know the boot device, therefore, depending on your setup,
-you will need to run one of the following. If your root device is the flash:
+you will need to run one of the following. If your root device is the flash,
+you must edit Kernel/platform/platform-esp8266/config.h.
+Otherwise, if your root device is the SD card, the default is fine for you.
 ```
-make TARGET=esp866 DEFAULT_BOOT=hda kernel
-```
-If your root device in the SD card:
-```
-make TARGET=esp866 DEFAULT_BOOT=hdb1 kernel
-```
-Then you can build the application and the filesystem:
-```
-make TARGET=esp866 diskimage
+make TARGET=esp866 kernel diskimage
 ```
 
 You need the `xtensa-lx106-elf` gcc toolchain --- install the

--- a/Kernel/platform/platform-esp8266/README.md
+++ b/Kernel/platform/platform-esp8266/README.md
@@ -26,7 +26,7 @@ make TARGET=esp866 DEFAULT_BOOT=hda kernel
 ```
 If your root device in the SD card:
 ```
-make TARGET=esp866 DEFAULT_BOOT=hdb1 kernel diskimage
+make TARGET=esp866 DEFAULT_BOOT=hdb1 kernel
 ```
 Then you can build the application and the filesystem:
 ```

--- a/Kernel/platform/platform-esp8266/config.h
+++ b/Kernel/platform/platform-esp8266/config.h
@@ -92,12 +92,11 @@ extern uint8_t _code_top[];
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL	  /* Location of root dev name */
 
-#if DEFAULT_BOOT==hda
 #define BOOTDEVICE 0x0000 /* hda */
-#elif DEFAULT_BOOT==hdb1
+//#define BOOTDEVICE 0x0011 /* hdb1 */
+#ifndef BOOTDEVICE
 #define BOOTDEVICE 0x0011 /* hdb1 */
-#else
-#error "You must call make with either DEFAULT_BOOT=hda or DEFAULT_BOOT=hdb1"
+#warning "Default boot device is hdb1, if you want to change that you can edit Kernel/platform/platform-esp8266/config.h"
 #endif
 
 #define SWAPDEV    (swap_dev) /* wherever */

--- a/Kernel/platform/platform-esp8266/config.h
+++ b/Kernel/platform/platform-esp8266/config.h
@@ -92,7 +92,14 @@ extern uint8_t _code_top[];
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL	  /* Location of root dev name */
 
+#if DEFAULT_BOOT==hda
+#define BOOTDEVICE 0x0000 /* hda */
+#elif DEFAULT_BOOT==hdb1
 #define BOOTDEVICE 0x0011 /* hdb1 */
+#else
+#error "You must call make with either DEFAULT_BOOT=hda or DEFAULT_BOOT=hdb1"
+#endif
+
 #define SWAPDEV    (swap_dev) /* wherever */
 
 #define CONFIG_DYNAMIC_SWAP

--- a/Kernel/platform/platform-esp8266/config.h
+++ b/Kernel/platform/platform-esp8266/config.h
@@ -92,7 +92,7 @@ extern uint8_t _code_top[];
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	NULL	  /* Location of root dev name */
 
-#define BOOTDEVICE 0x0000 /* hda */
+//#define BOOTDEVICE 0x0000 /* hda */
 //#define BOOTDEVICE 0x0011 /* hdb1 */
 #ifndef BOOTDEVICE
 #define BOOTDEVICE 0x0011 /* hdb1 */

--- a/Kernel/platform/platform-esp8266/update-flash.sh
+++ b/Kernel/platform/platform-esp8266/update-flash.sh
@@ -91,7 +91,7 @@ cd /bin
 bget ../../../Applications/util/banner
 bget ../../../Applications/util/basename
 bget ../../../Applications/util/bd
-bget ../../../Applications/util/blkdiscard
+# bget ../../../Applications/util/blkdiscard
 bget ../../../Applications/util/cal
 bget ../../../Applications/util/cat
 bget ../../../Applications/util/chgrp
@@ -175,7 +175,7 @@ bget ../../../Applications/util/yes
 chmod 0755 banner
 chmod 0755 basename
 chmod 0755 bd
-chmod 0755 blkdiscard
+# chmod 0755 blkdiscard
 chmod 0755 cal
 chmod 0755 cat
 chmod 0755 chgrp

--- a/Kernel/platform/platform-esp8266/update-flash.sh
+++ b/Kernel/platform/platform-esp8266/update-flash.sh
@@ -91,7 +91,7 @@ cd /bin
 bget ../../../Applications/util/banner
 bget ../../../Applications/util/basename
 bget ../../../Applications/util/bd
-# bget ../../../Applications/util/blkdiscard
+bget ../../../Applications/util/blkdiscard
 bget ../../../Applications/util/cal
 bget ../../../Applications/util/cat
 bget ../../../Applications/util/chgrp
@@ -175,7 +175,7 @@ bget ../../../Applications/util/yes
 chmod 0755 banner
 chmod 0755 basename
 chmod 0755 bd
-# chmod 0755 blkdiscard
+chmod 0755 blkdiscard
 chmod 0755 cal
 chmod 0755 cat
 chmod 0755 chgrp


### PR DESCRIPTION
Dear @ermiah, @EtchedPixels,
This PR want to continue the work #1090 and now make fburn should works fine (it needs an additional call to ld to generate the segment headers, maybe there is a clever way to add them).
As I don't use anymore the SD card reader for the root filesystem, and as now fburn works fine, I've booted correctly without the panic in #1091. @ermiah would you mind to try to boot on the flash drive? (it requires to recompile the kernel ~~with a new option~~ after an updating config.h)
Best.