### PR TITLE
Links created for dosdir, doswrite and dosdel utils in filesystem image. Fix type mismatch compilation error on cu.c

### DIFF
--- a/Applications/util/cu.c
+++ b/Applications/util/cu.c
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
         uint_fast8_t is_esc = 0;
         uint_fast8_t is_nl = 1;
         uint_fast8_t w;
-        atexit(restore);
+        atexit((void *)&restore);
         if (escchar <= 0x1A)
         {
             escStr[0] = '^';

--- a/Applications/util/fuzix-util.pkg
+++ b/Applications/util/fuzix-util.pkg
@@ -73,6 +73,9 @@ f 0755 /bin/cut         cut
 f 0755 /bin/decomp16    decomp16
 f 0755 /bin/dirname     dirname
 f 0755 /bin/dosread     dosread
+l /bin/dosread /bin/dosdir
+l /bin/dosread /bin/doswrite
+l /bin/dosread /bin/dosdel
 f 0755 /bin/env         env
 f 0755 /bin/factor      factor
 f 0755 /bin/false       false

--- a/Kernel/dev/cpc/video.s
+++ b/Kernel/dev/cpc/video.s
@@ -336,12 +336,8 @@ reset_cursor_line:
         ld (de),a
 	
         VIDEO_UNMAP
-<<<<<<< HEAD
-        ret
-=======
 	ret
 
->>>>>>> 9e6066d9ba890c01777baba4e6bb5ef289d9b802
 	.if CPCVID_ONLY
 _do_beep:
 	.endif


### PR DESCRIPTION
About dos filesystem manipulation utilities, I tried dosdir with a FAT16 partition and got the error reserved != 1 error. @EtchedPixels do you know the right way to use this with a partition in the same disk as the root filesystem?