### PR TITLE
coco3: fix populating table of LBAs from CCPT table

### DIFF
--- a/Kernel/platform/platform-coco3/mbr.c
+++ b/Kernel/platform/platform-coco3/mbr.c
@@ -60,7 +60,7 @@ uint_fast8_t td_plt_setup(uint_fast8_t dev, uint32_t *lba, void *buf)
 				tstart >>= 1;
 			else
 				tstart <<= (br->secz - 1);
-			*lba++ = tstart;
+			*++lba = tstart;
 			k++;
 			kprintf("hd%c%d ", dev + 'a', k);
 			/* TODO: swap on CCPT */


### PR DESCRIPTION
Post- instead of pre- increment populating this table meant HDA1 referred to the 2nd partition, etc.

Brings the logic in coco3-specific td_plt_setup() in line with the usual approach in tinydisk_setup().