### PR TITLE
tinydisk: allow access to MAX_PARTth partition

### DIFF
--- a/Kernel/dev/tinydisk.c
+++ b/Kernel/dev/tinydisk.c
@@ -47,7 +47,7 @@ static int td_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
 
 	lba = udata.u_block;
 	if (minor) {
-		if (minor < MAX_PART && td_lba[dev][minor])
+		if (minor <= MAX_PART && td_lba[dev][minor])
 			lba += td_lba[dev][minor];
 		else
 			goto fail;


### PR DESCRIPTION
Space in td_lba[][] is reserved for MAX_PART+1 partitions (index 0 being whole disk), so access to [MAX_PART] is allowed (and without it you can't access hda5).

Edit: May be that dropping MAX_PART to 4 is also the "right thing" here - I just noticed it wasn't allowing hda5 which was enumerated in the CCPT hook because MAX_PART is 5.