### PR TITLE
coco3 video: fix clear_lines, scroll_up, scroll_down

### DIFF
--- a/Kernel/platform/platform-coco3/videoll.s
+++ b/Kernel/platform/platform-coco3/videoll.s
@@ -279,7 +279,7 @@ _clear_lines:
 	beq	donea
 clt:
 	std	,u++
-	leax	-1,x
+	leax	-2,x
 	bne	clt
 donea:
 	ldd	#0x0102
@@ -326,7 +326,7 @@ scrupt:
 	std	,u++
 	ldd	,x++
 	std	,u++
-	leay	-4,y
+	leay	-8,y
 	bne	scrupt
 	ldd	#0x0102
 	std	$FFA9
@@ -359,7 +359,7 @@ scrdnt:
 	std	,--u
 	ldd	,--x
 	std	,--u
-	leay	-4,y
+	leay	-8,y
 	bne	scrdnt
 	ldd	#0x0102
 	std	$FFA9

--- a/Kernel/platform/platform-coco3/videoll.s
+++ b/Kernel/platform/platform-coco3/videoll.s
@@ -351,14 +351,14 @@ _scroll_down:
 	std	$FFA9
 
 scrdnt:
-	ldd	,--x
-	std	,--u
-	ldd	,--x
-	std	,--u
-	ldd	,--x
-	std	,--u
-	ldd	,--x
-	std	,--u
+	ldd	,--u
+	std	,--x
+	ldd	,--u
+	std	,--x
+	ldd	,--u
+	std	,--x
+	ldd	,--u
+	std	,--x
 	leay	-8,y
 	bne	scrdnt
 	ldd	#0x0102


### PR DESCRIPTION
Each interprets twidth as the number of 16-bit words (character, attribute) in a line, where actually it is the number of bytes.

You could see the effect by spawning getty in tty2, setting tty1 to mode 0 (80 column) and issuing a 'clear' command, or by letting it scroll. The operations would touch too much memory and affect tty2.