### PR TITLE
coco3: fix RGB monitor detect

### DIFF
--- a/Kernel/platform/platform-coco3/coco3.s
+++ b/Kernel/platform/platform-coco3/coco3.s
@@ -146,6 +146,10 @@ init_hardware:
 	;; High speed poke
 	sta	0xffd9		; high speed poke
 	sta	0xffdf		; RAM mode
+	;; configure PIA1B to read monitor detect line
+	clr	$ff23
+	ldd	#$f037
+	std	$ff22
 	;; set system RAM size
 	jsr	_scanmem	; X = number of pages
 	tfr 	x,d

--- a/Kernel/platform/platform-coco3/devtty.c
+++ b/Kernel/platform/platform-coco3/devtty.c
@@ -530,7 +530,7 @@ void devtty_init()
 	/* set default keyboard delay/repeat rates */
 	keyrepeat.first = REPEAT_FIRST * (TICKSPERSEC / 10);
 	keyrepeat.continual = REPEAT_CONTINUAL * (TICKSPERSEC / 10);
-	is_rgb = *((volatile uint8_t *)0xFF22) & 8;
+	is_rgb = (*((volatile uint8_t *)0xFF22) & 8) == 0;
 	if (is_rgb)
 		apply_defmode(0);
 	else {


### PR DESCRIPTION
Need to set appropriate PIA DDR bit as input, then reverse the sense of the test.