### PR TITLE
coco3: use CONFIG_TD_MAX_PART enumerating CCPT partitions

### DIFF
--- a/Kernel/platform/platform-coco3/config.h
+++ b/Kernel/platform/platform-coco3/config.h
@@ -80,6 +80,9 @@ extern uint16_t swap_dev;
 #define CONFIG_TD_SD
 #define TD_SD_NUM	2
 #define CONFIG_TD_CUSTOMPART		/* Custom partition tables (CCPT) */
+/* CCPT supports 14 partitions, but more than 6 makes the buffers take too much
+ * space for the memory map as it stands.  Keep to the default of 4 for now. */
+#define CONFIG_TD_MAX_PART 4
 
 #define CONFIG_RTC		/* enable RTC code */
 #define CONFIG_RTC_INTERVAL 100	/* time in deciseconds to atually poll rtc */

--- a/Kernel/platform/platform-coco3/mbr.c
+++ b/Kernel/platform/platform-coco3/mbr.c
@@ -64,7 +64,7 @@ uint_fast8_t td_plt_setup(uint_fast8_t dev, uint32_t *lba, void *buf)
 			k++;
 			kprintf("hd%c%d ", dev + 'a', k);
 			/* TODO: swap on CCPT */
-			if (k == MAX_PART)
+			if (k == CONFIG_TD_MAX_PART)
 				break;
 		}
 	}


### PR DESCRIPTION
Needed since 4694e871b.  Not super useful right now though, as raising this number above 6 makes the buffers too large for the current map.  So keeping the default of 4.