### PR TITLE
Fixed routine '_hd_xfer_out' in Kernel/platform/platform-trs80/trs80.s:

### DIFF
--- a/Kernel/platform/platform-trs80/trs80.s
+++ b/Kernel/platform/platform-trs80/trs80.s
@@ -197,6 +197,12 @@ _hd_xfer_out:
 	   call nz, map_proc_a
 	   ld bc, #0xC8			; 256 bytes to 0xC8
 	   otir
+xfer_out_wait:				; busy wait after OTIR
+	   ex (sp), hl
+	   ex (sp), hl
+	   in a,(0xCF)
+	   rlca
+	   jr c, xfer_out_wait
 	   call map_kernel
 	   ret
 


### PR DESCRIPTION
It hanged during boot on real hardware (Model 4P with FreHD) because a busy wait loop was missing after the OTIR instruction.

Compiled in Ubuntu 24.10 with sdcc280, Fuzix_BinTools (z80) and Fuzix_Compiler_Kit (z80).

Tested with trs80gp and on real hardware Model 4p with FreHD.
