### PR TITLE
Fixed potential out-of-bounds array access in Kernel/platform/platform-trs80/devhd.c

### DIFF
--- a/Kernel/platform/platform-trs80/devhd.c
+++ b/Kernel/platform/platform-trs80/devhd.c
@@ -167,7 +167,7 @@ int hd_open(uint8_t minor, uint16_t flag)
 {
 	uint8_t dev = minor >> 4;
 	flag;
-	if (dev > MAX_HD || parts[dev].g.head == 0 ||
+	if (dev >= MAX_HD || parts[dev].g.head == 0 ||
 		(minor && parts[dev].cyl[(minor-1)&0x0F] == 0xFFFF)) {
 		udata.u_error = ENODEV;
 		return -1;


### PR DESCRIPTION
In `if (dev > MAX_HD || parts[dev].g.head == 0 || ... )`: the `dev` variable can't be higher than the maximum subscript of the array `parts[]`. If `dev == MAX_HD` (= 4) then `parts[dev]` is accessed out of bounds (= 0..3).

Changed to `if (dev >= MAX_HD || parts[dev].g.head == 0 || ... )`.


Compiled in Ubuntu 24.10 with sdcc280, Fuzix_BinTools (z80) and Fuzix_Compiler_Kit (z80).

Tested with trs80gp and on real hardware Model 4p with FreHD.