### PR TITLE
Fixed function 'probe_gfx' in Kernel/platform/platform-trs80/discard.c, not working because of write-only registers.

### DIFF
--- a/Kernel/platform/platform-trs80/discard.c
+++ b/Kernel/platform/platform-trs80/discard.c
@@ -18,7 +18,7 @@ __sfr __at 0x8E gfx_xor;
 
    The control port differs as follows
    Tandy
-   0: set to tun graphics on, clear for alpha
+   0: set to turn graphics on, clear for alpha
    1: set to turn on wait states (no flicker on update)
 
    Micrografyx
@@ -35,25 +35,35 @@ static uint_fast8_t probe_gfx(void)
 {
  kputs("Probing gfx\n");
  gfx_x = 1;
- if (gfx_x != 1)
+ gfx_y = 1;
+ gfx_ctrl = 0xA0;	/* Graphics off, inc X on read/write */
+ gfx_data = 0x55;
+ gfx_data = 0xAA;
+ gfx_x = 1;
+ if (gfx_data != 0x55) { 
+  kputs("none\n") ; 
   return 0;
- gfx_ctrl = 0x10;	/* Graphics off, inc X on read */
- gfx_data;
- if (gfx_x != 0x11)
+ }
+ if (gfx_data != 0xAA) { 
+  kputs("none\n") ; 
   return 0;
+ }
  /* We have either a TRS80 or a clone card present */
- gfx_xpan = 0xAA;
- if (gfx_xpan != 0xAA)
+ gfx_x = 0x7F;
+ gfx_y = 0xFF;
+ gfx_ctrl = 0xF0; 		/* No inc of X or Y */
+ gfx_data = 0xA5;
+ if (gfx_data != 0xA5) { 	/* this may need to be forced for Grafyx clone */
+  kputs("uLabs Grafyx (original)\n") ; 	
   return 2;
- gfx_xpan = 0;
+ }
+ kputs("Tandy (assumed) or Grafyx clone (unhandled)\n") ; 
  return 1;
 }
 
 void device_init(void)
 {
- kputs("Probing gfx\n");
   gfxtype = probe_gfx();
-  kputs("Done\n");
   vtbuf_init();
 #ifdef CONFIG_RTC
   /* Time of day clock */


### PR DESCRIPTION
Fixed function `probe_gfx()` in `Kernel/platform/platform-trs80/discard.c`:
- the registers `gfx_x`, `gfx_y` and `gfx_xor` are write-only; we can't get the value back;
- can differentiate between Tandy and Grafyx (original) by trying to write a byte outside the visible range: the Tandy (and the Grafyx clone by IanMav) can do it, but not the original uLabs Grafyx board;
- currently can't differentiate between the Tandy and the Grafyx clone: the Grafyx clone can't XOR the text and the hi-res graphics using the `gfx_xor` register (existing only on the Tandy board).

Compiled in Ubuntu 24.10 with sdcc280, Fuzix_BinTools (z80) and Fuzix_Compiler_Kit (z80).

Tested with trs80gp and on real hardware Model 4p with FreHD and a Grafyx clone from IanMav.