### PR TITLE
localtim_r: delete duplicate includes

### DIFF
--- a/Library/libs/localtim_r.c
+++ b/Library/libs/localtim_r.c
@@ -1,9 +1,6 @@
 #include <time.h>
 #include <string.h>
 
-#include <time.h>
-#include <string.h>
-
 /* Slight duplication here so gmtime doesn't suck in tz and all the rest */
 #define SECS_PER_DAY	86400
 #define SECS_PER_HOUR	3600


### PR DESCRIPTION
The header files time.h and string.h are included twice.
