### PR TITLE
Library/libs/crt0_6809_rel.s: fix stashing argv[] as __argv

### DIFF
--- a/Library/libs/crt0_6809_rel.s
+++ b/Library/libs/crt0_6809_rel.s
@@ -89,7 +89,7 @@ start2:
 		; pointers and data stuffed above stack by execve()
 		leax 4,s
 		stx _environ
-		leax 2,s
+		ldx 2,s
 		stx ___argv
 		puls x			; argc
 		ldy #_exit		; return vector


### PR DESCRIPTION
Showed up running "calendar".