### PR TITLE
Cleanup of ch375_probe() and ch375_rpoll()

### DIFF
--- a/Kernel/dev/ch375.c
+++ b/Kernel/dev/ch375.c
@@ -24,11 +24,30 @@
 #include <printf.h>
 #include "ch375.h"
 
+#define CH375_CMD_GET_IC_VER            0x01
+#define CH375_CMD_CHECK_EXIST           0x06
+#define CH375_CMD_SET_USB_MODE          0x15
+#define CH375_CMD_GET_STATUS            0x22
+#define CH376_CMD_RD_USB_DATA           0x27
+#define CH375_CMD_RD_USB_DATA           0x28
+#define CH375_CMD_WR_USB_DATA7          0x2B
+#define CH376_CMD_WR_HOST_DATA          0x2C
+#define CH375_CMD_DISK_INIT             0x51
+#define CH375_CMD_DISK_READ             0x54
+#define CH375_CMD_DISK_RD_GO            0x55
+#define CH375_CMD_DISK_WRITE            0x56
+#define CH375_CMD_DISK_WR_GO            0x57
+
+#define CH375_USB_INT_SUCCESS           0x14
+#define CH375_USB_INT_CONNECT           0x15
+#define CH375_USB_INT_DISK_READ         0x1D
+#define CH375_USB_INT_DISK_WRITE        0x1E
+
 #ifdef CONFIG_CH375
 
 static uint8_t ch_ver;
-static uint8_t ch_rd = 0x28;
-static uint8_t ch_wd = 0x2B;
+static uint8_t ch_rd = CH375_CMD_RD_USB_DATA;
+static uint8_t ch_wd = CH375_CMD_WR_USB_DATA7;
 static uint8_t ch_dev = 0xFF;
 
 /* Some guesswork here on how the get status polling is meant to work */
@@ -36,15 +55,13 @@ static uint8_t ch375_rpoll(void)
 {
     uint16_t count = 0x8000;
     uint8_t r;
-    nap20();
-    while(--count && ((ch375_rstatus() & 0x80) == 0x80));
+    while(--count && ((ch375_rstatus() & 0x80) != 0));
     if (count == 0) {
         kprintf("ch375: timeout.\n");
         return 0xFF;
     }
     /* Get interrupt status, and clear interrupt */
-    ch375_wcmd(0x22);
-    nap20();
+    ch375_wcmd(CH375_CMD_GET_STATUS);
     r = ch375_rdata();
 /*    kprintf("ch375_rpoll %2x", r); */;
     return r;
@@ -78,9 +95,9 @@ static int ch375_xfer(uint_fast8_t dev, bool is_read, uint32_t lba, uint8_t *dpt
     uint_fast8_t r;
 
     if (is_read)
-        ch375_wcmd(0x54);
+        ch375_wcmd(CH375_CMD_DISK_READ);
     else
-        ch375_wcmd(0x56);
+        ch375_wcmd(CH375_CMD_DISK_WRITE);
     ch375_wdata(lba);
     ch375_wdata(lba >> 8);
     ch375_wdata(lba >> 16);
@@ -89,7 +106,7 @@ static int ch375_xfer(uint_fast8_t dev, bool is_read, uint32_t lba, uint8_t *dpt
     for (n = 0; n < 8; n++) {
         r = ch375_rpoll();
         if (is_read) {
-            if (r != 0x1D)
+            if (r != CH375_USB_INT_DISK_READ)
                 return 0;
             ch375_wcmd(ch_rd);
             r = ch375_rdata();	/* Throw byte count away - always 64 */
@@ -98,19 +115,19 @@ static int ch375_xfer(uint_fast8_t dev, bool is_read, uint32_t lba, uint8_t *dpt
                 return 0;
             }
             ch375_rblock(dptr);
-            ch375_wcmd(0x55);
+            ch375_wcmd(CH375_CMD_DISK_RD_GO);
         } else {
             if (r != 0x1E)
                 return 0;
             ch375_wcmd(ch_wd);
             ch375_wdata(0x40);	/* Send write count */
             ch375_wblock(dptr);
-            ch375_wcmd(0x57);
+            ch375_wcmd(CH375_CMD_DISK_WR_GO);
         }
         dptr += 0x40;
     }
     r = ch375_rpoll();
-    if (r != 0x14) {
+    if (r != CH375_USB_INT_SUCCESS) {
         kprintf("ch375: error %d\n", r);
         return 0;
     }
@@ -123,42 +140,45 @@ uint_fast8_t ch375_probe(void)
     uint_fast8_t n;
     uint_fast8_t r;
 
-    ch375_cmd2(0x06, 0x55);
+    ch375_cmd2(CH375_CMD_CHECK_EXIST, 0x55);
     r = ch375_rdata();
     if (r != 0xAA) {
 /*        kprintf("ch375: response %2x not AA\n", r); */
         return 0;
     }
-    ch375_wcmd(0x01);	/* Version */
+
+    ch375_wcmd(CH375_CMD_GET_IC_VER);	/* Version */
     ch_ver = ch375_rdata();
     kprintf("ch375: version %2x\n", ch_ver);
     if (ch_ver == 0xFF)
         return 0;
-    /* Reset the bus */
-    ch375_cmd2(0x15, 0x07);
-    nap20();	/* 20 us */
-    ch375_cmd2(0x15, 0x06);
     /* 376 - update commands to use */
     if ((ch_ver & 0xC0) == 0x40) {
-        ch_rd = 0x27;
-        ch_wd = 0x2C;
+        ch_rd = CH376_CMD_RD_USB_DATA;
+        ch_wd = CH376_CMD_WR_HOST_DATA;
         chip = 6;
     }
     kprintf("ch37%d: firmware version %d\n", chip, ch_ver & 0x3F);
+
+    /* Enable USB host mode, reset USB bus */
+    ch375_cmd2(CH375_CMD_SET_USB_MODE, 0x07);
+    nap20();	/* 20 us */
+    /* Enable USB host mode, automatically generating SOF */
+    ch375_cmd2(CH375_CMD_SET_USB_MODE, 0x06);
     nap20();
-    /* Can take a few goes */
-    for (n = 0; n < 24; n++) {
-        unsigned i;
-        ch375_wcmd(0x51);
-        /* FIXME: proper delay would be good! */
-        for (i = 0; i < 10000; i++);
-        r = ch375_rpoll();
-        if (r == 0x14)
-            break;
-        nap20();
-    }
-    if (r != 0x14)
+    /* After setting USB mode 0x06 an interrupt is generated when
+     * an USB storage device is present */
+    r = ch375_rpoll();
+    if (r != CH375_USB_INT_CONNECT) {
         return 0;
+    }
+
+    /* Initialize USB storage device */
+    ch375_wcmd(CH375_CMD_DISK_INIT);
+    r = ch375_rpoll();
+    if (r != CH375_USB_INT_SUCCESS)
+        return 0;
+
     /* And done */
     ch_dev = td_register(0, ch375_xfer, td_ioctl_none, 1);
     return 1;


### PR DESCRIPTION
Setting USB mode 0x06 causes an interrupt when an USB storage device is present. This interrupt request needs to be handled before initializing the USB device. This solves the initialization issues where multiple tries where necessary.

In addition, some defines where added to improve the readability of the code.

Modifications where tested on a RC2014 platform with CH376. Definitely needs to be verified with CH375.