### PR TITLE
Changed td_transfer() parameters from uint8_t uint_fast8_t

### DIFF
--- a/Kernel/dev/tinydisk.c
+++ b/Kernel/dev/tinydisk.c
@@ -20,7 +20,7 @@ uint8_t td_unit[CONFIG_TD_NUM];
 td_xfer td_op[CONFIG_TD_NUM];
 td_ioc td_iop[CONFIG_TD_NUM];
 
-static int td_transfer(uint8_t minor, bool is_read, uint8_t rawflag)
+static int td_transfer(uint_fast8_t minor, bool is_read, uint_fast8_t rawflag)
 {
 	uint8_t dev = minor >> 4;
 	register uint16_t ct = 0;


### PR DESCRIPTION
On the Z1013 platform which is compiled with fcc this fixes a signed/unsigned issue of the statement

    uint8_t dev = minor >> 4

fcc seems to get confused with 8/16 bit or signed unsigned which breaks the statement above. It's possibly a fcc issue.