### PR TITLE
68hc11: repair broken build

### DIFF
--- a/Kernel/dev/68hc11/sci.h
+++ b/Kernel/dev/68hc11/sci.h
@@ -1,0 +1,9 @@
+#ifndef _SCI_H
+#define _SCI_HJ
+
+extern void sci_tx_console(uint8_t c);
+extern uint8_t sci_tx_space();
+extern void sci_tx_queue(uint8_t c);
+extern int16_t sci_rx_get();
+
+#endif

--- a/Library/libs/fuzix68hc11/.gitignore
+++ b/Library/libs/fuzix68hc11/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Not sure how it buit before, but `sci.h` was missing. Also `fuzix68hc11` folder is required, otherwise `Library/tools/syscall_68hc11.c` breaks.