### PR TITLE
Get CI running again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false # keep on building even if one target fails
       matrix:
         target: [appleiie, dragon-mooh, dragon-nx32, esp32, esp8266, multicomp09, rbc-mark4, rcbus-6502, rcbus-68008, rpipico, sc108, tiny68k, armm0-libc]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: install build deps
@@ -29,7 +29,6 @@ jobs:
           echo "sub_target=libs" >> $GITHUB_ENV
           ;;
           dragon-mooh|dragon-nx32|multicomp09)
-          sudo add-apt-repository -n -y ppa:p-pisati/fuzix
           sudo add-apt-repository -n -y ppa:tormodvolden/m6809
           PKGS="lwtools gcc6809 xroar"
           echo "target=TARGET=${{ matrix.target }}" >> $GITHUB_ENV

--- a/Build/tests/test-dragon-mooh
+++ b/Build/tests/test-dragon-mooh
@@ -34,6 +34,7 @@ xroar \
     -timeout-motoroff 10 \
     -default-machine dragon32 -romlist d32=$BASROM \
     -cart mooh -cart-rom $CARTROM -load-hd0 $IMAGE \
+    -cart-opt mooh-crt9128-stderr \
     2>&1 | tee $LOGFILE
 echo "XRoar done $(date)"
 

--- a/Build/tests/test-dragon-mooh
+++ b/Build/tests/test-dragon-mooh
@@ -29,6 +29,7 @@ echo "Starting XRoar $(date)"
 xroar \
     -no-ratelimit \
     -ui $UI \
+    -ao null \
     -timeout 60 \
     -timeout-motoroff 10 \
     -default-machine dragon32 -romlist d32=$BASROM \

--- a/Kernel/platform/platform-dragon-nx32/userspace/rc.ci_testing
+++ b/Kernel/platform/platform-dragon-nx32/userspace/rc.ci_testing
@@ -8,7 +8,9 @@ prtroot >/etc/mtab
 #fsck -a
 #mount -a
 >/var/run/utmp
-echo "Starting various tests from rc"
-echo '[dc is working] P' | dc ; echo
-echo "Testing done!"
+echo "Starting various tests from /etc/rc:"
+echo '[dc is working OK] P' | dc ; echo
+echo "shell pipeline" | head | tail | sed 's/$/ OK/' | cat
+echo ': test1 ." fforth is working OK" CR ; test1' | fforth
+echo "Testing done! Cycling motor relay..."
 echo "HEX 3c ff21 C! 34 ff21 C!" | fforth


### PR DESCRIPTION
Move CI to Ubuntu 24.04 images so we should be good for some time.

Unfortunately while we had no CI working, the esp32 build started to fail  and the dragon-mooh run test doesn't boot up properly any longer, but the rest seems fine.