### PR TITLE
CI: Add PPA for updated esptool package for esp32

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,6 +35,7 @@ jobs:
           echo "flags=CI_TESTING=1" >> $GITHUB_ENV
           ;;
           esp32)
+          sudo add-apt-repository -n -y ppa:tormodvolden/esp
           PKGS="esptool"
           (cd ~ && git clone -b v5.0.2 --depth 1 --recursive https://github.com/espressif/esp-idf.git)
           (cd ~/esp-idf && ./install.sh esp32)


### PR DESCRIPTION
esptool after v3.0 broke support for ELF files without segments. I have filed an upstream PR at https://github.com/espressif/esptool/pull/1118 EDIT: Fixed upstream in https://github.com/espressif/esptool/commit/d27ce37a9cc62bc7f71dbd2241f7df4b57a98fbb (after v5.0.2, should show up in 4.10 and 5.1)

I made a esptool package in a PPA with this fix applied to the current version in Ubuntu 24.04 so that it can be pulled in for esp32 in the CI build.